### PR TITLE
Replay

### DIFF
--- a/crates/seismic/node/tests/integration.rs
+++ b/crates/seismic/node/tests/integration.rs
@@ -157,26 +157,9 @@ async fn test_seismic_reth_rpc() {
     assert!(response["result"] == itx.tx_hashes[1]);
 
     // Replay transaction, need to add right here, must be done before tx is mined.
-    let replay_resp = replay_transaction(&client, RETH_RPC_URL, &itx.tx_hashes[0]).await.expect("Replay failed");
-    println!("eth_call Response REPLAY ATTACK: {:?}", replay_resp);
+    let replay_resp = replay_transaction(&client, RETH_RPC_URL, &itx.tx_hashes[1]).await.expect("Replay failed");
+    // Setters doesn't return the new number, but if it did we'd get the secret.
     assert!(replay_resp["result"] == "0x");
-
-    let get_transaction_hash = json!({
-        "jsonrpc": "2.0",
-        "method": "eth_getTransactionByHash",
-        "params": [itx.tx_hashes[0]],
-        "id": 1
-    });
-
-    let response: Value = client
-        .post(RETH_RPC_URL)
-        .json(&get_transaction_hash)
-        .send()
-        .await
-        .expect("Failed to get code")
-        .json()
-        .await
-        .expect("Failed to parse code");
     thread::sleep(Duration::from_secs(1));
 
     // Step 4: Get the transaction receipt


### PR DESCRIPTION
There is a flaw in our current construction where I can get any secrets (assuming the smart contract will return the variable) by simply replaying a transaction before it is mined.

While doing this POC, I noticed that the txpool endpoint seemed to be down, so I just obtained pending transactions using `eth_getTransactionByHash`. Furthermore, in real life, to be as fast as possible, one would simply subscribe to some tx_pool websocket.

In general, todos seem to be two:
- make sure API is bullet-proof, even when looked at holistically.
- check out tx_pool endpoint. 