### PR TITLE
Use enclave server in `seismic_getTeePublicKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10439,10 +10439,12 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-enclave",
  "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-network-api",
+ "reth-node-core",
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
@@ -10459,6 +10461,7 @@ dependencies = [
  "secp256k1",
  "seismic-enclave 0.1.0 (git+https://github.com/SeismicSystems/enclave.git?rev=0600d0a)",
  "seismic-node",
+ "thiserror 2.0.11",
  "tokio",
 ]
 

--- a/bin/seismic-reth/src/main.rs
+++ b/bin/seismic-reth/src/main.rs
@@ -22,6 +22,10 @@ fn main() {
 
     if let Err(err) = Cli::<SeismicChainSpecParser, NoArgs>::parse().run(|builder, _| async move {
         let engine_tree_config = TreeConfig::default();
+
+        // building seismic api
+        let seismic_api = SeismicApi::new(builder.config());
+
         let node = builder
             .with_types_and_provider::<EthereumNode, BlockchainProvider2<_>>()
             .with_components(EthereumNode::components())
@@ -45,7 +49,6 @@ fn main() {
                 )?;
 
                 // add seismic_ namespace
-                let seismic_api = SeismicApi::new(&ctx.config);
                 ctx.modules.merge_configured(seismic_api.into_rpc())?;
                 info!(target: "reth::cli", "seismic api configured");
                 Ok(())

--- a/bin/seismic-reth/src/main.rs
+++ b/bin/seismic-reth/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
                 )?;
 
                 // add seismic_ namespace
-                let seismic_api = SeismicApi::new();
+                let seismic_api = SeismicApi::new(&ctx.config);
                 ctx.modules.merge_configured(seismic_api.into_rpc())?;
                 info!(target: "reth::cli", "seismic api configured");
                 Ok(())

--- a/crates/seismic/rpc-api/Cargo.toml
+++ b/crates/seismic/rpc-api/Cargo.toml
@@ -15,6 +15,11 @@ workspace = true
 reth-tracing.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-eth-api.workspace = true
+reth-node-core.workspace = true
+reth-rpc-server-types.workspace = true
+reth-enclave.workspace = true
+
+seismic-enclave.workspace = true
 
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
@@ -22,8 +27,8 @@ alloy-dyn-abi.workspace = true
 
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 secp256k1.workspace = true
-seismic-enclave.workspace = true
 tokio = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 alloy-rpc-types-engine.workspace = true
@@ -44,7 +49,6 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-rpc.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-rpc-layer.workspace = true
-reth-rpc-server-types.workspace = true
 reth-primitives.workspace = true
 
 seismic-node.workspace = true

--- a/crates/seismic/rpc-api/src/error.rs
+++ b/crates/seismic/rpc-api/src/error.rs
@@ -17,6 +17,7 @@ impl From<SeismicApiError> for jsonrpsee::types::error::ErrorObject<'static> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::error::SeismicApiError;
 

--- a/crates/seismic/rpc-api/src/error.rs
+++ b/crates/seismic/rpc-api/src/error.rs
@@ -1,0 +1,29 @@
+use reth_rpc_server_types::result::internal_rpc_err;
+
+#[derive(Debug, thiserror::Error)]
+
+/// Seismic API error
+pub enum SeismicApiError {
+    /// Enclave error
+    #[error("enclave error: {0}")]
+    EnclaveError(String),
+}
+
+impl From<SeismicApiError> for jsonrpsee::types::error::ErrorObject<'static> {
+    fn from(error: SeismicApiError) -> Self {
+        match error {
+            SeismicApiError::EnclaveError(e) => internal_rpc_err(format!("enclave error: {e}")),
+        }
+    }
+}
+
+mod tests {
+    use crate::error::SeismicApiError;
+
+    #[test]
+    fn enclave_error_message() {
+        let err: jsonrpsee::types::error::ErrorObject<'static> =
+            SeismicApiError::EnclaveError("test".to_string()).into();
+        assert_eq!(err.message(), "enclave error: test");
+    }
+}

--- a/crates/seismic/rpc-api/src/lib.rs
+++ b/crates/seismic/rpc-api/src/lib.rs
@@ -1,5 +1,7 @@
 //! This crate provides the seismic rpc api implementation.
 
+/// Error types for the seismic rpc api
+pub mod error;
 /// The seismic rpc api implementation
 pub mod rpc;
 /// Utils for testing the seismic rpc api


### PR DESCRIPTION
1. Contact the enclave server when retrieving network public key 
2. Added error handling for seismicapi