### PR TITLE
docs: update MSRV link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When updating this, also update:
 - .github/workflows/lint.yml
 -->
 
-The Minimum Supported Rust Version (MSRV) of this project is [1.82.0](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html).
+The Minimum Supported Rust Version (MSRV) of this project is [1.82.0](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html).
 
 See the book for detailed instructions on how to [build from source](https://paradigmxyz.github.io/reth/installation/source.html).
 


### PR DESCRIPTION
Hi! I noticed that the link to the Rust 1.82.0 release blog in the `README.md` file is outdated. The current link points to a non-existent page (`https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html`), which results in a 404 error.