### PR TITLE
Revert nonce handling in estimate gas and call end points 

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -60,8 +60,11 @@ impl EthEvmConfig {
     }
 
     /// Creates a new Ethereum EVM configuration with the given chain spec.
-    pub fn new_with_enclave_client(chain_spec: Arc<ChainSpec>, tee_client: EnclaveClient) -> Self {
-        Self { chain_spec, enclave_client: tee_client }
+    pub fn new_with_enclave_client(
+        chain_spec: Arc<ChainSpec>,
+        enclave_client: EnclaveClient,
+    ) -> Self {
+        Self { chain_spec, enclave_client }
     }
 
     /// Creates a new Ethereum EVM configuration with the given chain spec and enclave address and
@@ -73,8 +76,9 @@ impl EthEvmConfig {
     ) -> Self {
         debug!(target: "reth::evm", ?enclave_addr, ?enclave_port, "Creating new enclave client");
 
-        let tee_client = EnclaveClient::new_from_addr_port(enclave_addr.to_string(), enclave_port);
-        Self::new_with_enclave_client(chain_spec, tee_client)
+        let enclave_client =
+            EnclaveClient::new_from_addr_port(enclave_addr.to_string(), enclave_port);
+        Self::new_with_enclave_client(chain_spec, enclave_client)
     }
 
     /// Returns the chain spec associated with this configuration.
@@ -135,11 +139,11 @@ impl ConfigureEvmEnv for EthEvmConfig {
     ) -> EVMResultGeneric<(), EnclaveError> {
         debug!(target: "reth::fill_tx_env", ?tx, "Parsing Seismic transaction");
 
-        let tee_decryption = self.decrypt(&tx.input, &tx.seismic_elements)?;
+        let enclave_decryption = self.decrypt(&tx.input, &tx.seismic_elements)?;
 
-        let data = Bytes::from(tee_decryption.clone());
+        let data = Bytes::from(enclave_decryption.clone());
 
-        debug!(target: "reth::fill_tx_env", ?data, ?tee_decryption, ?tx.input, "Decrypted input data");
+        debug!(target: "reth::fill_tx_env", ?data, ?enclave_decryption, ?tx.input, "Decrypted input data");
 
         tx_env.caller = sender;
         tx_env.gas_limit = tx.gas_limit;

--- a/crates/node/core/src/args/enclave.rs
+++ b/crates/node/core/src/args/enclave.rs
@@ -46,7 +46,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tee_args_parser() {
+    fn test_enclave_args_parser() {
         let args = CommandParser::<EnclaveArgs>::parse_from(["reth node"]).args;
 
         let addr = args.enclave_server_addr;


### PR DESCRIPTION
Because TxSeismicElements now has a new encryption nonce we are going to use the encryption nonce. Reverts back the  nonce handling