### PR TITLE
fix(docs): update broken blockchain-tree link to current provider implementation

### DIFF
--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -95,7 +95,7 @@ Crates related to transaction execution.
 
 These crates implement the main syncing drivers of reth.
 
--   [`blockchain-tree`](../../crates/blockchain-tree): A tree-like structure for handling multiple chains of unfinalized blocks. This is the main component during live sync (i.e. syncing at the tip)
+-   [`blockchain_provider.rs`](../../crates/storage/provider/src/providers/blockchain_provider.rs): A tree-like structure for handling multiple chains of unfinalized blocks. This is the main component during live sync (i.e. syncing at the tip)
 -   [`stages`](../../crates/stages): A pipelined sync, including implementation of various stages. This is used during initial sync and is faster than the tree-like structure for longer sync ranges.
 
 ### RPC


### PR DESCRIPTION
The old link to `crates/blockchain-tree` was broken. Updated the documentation to reference the actual implementation in `crates/storage/provider/src/providers/blockchain_provider.rs`, where the blockchain tree logic now resides.