### PR TITLE
modify start up test to use a random port

### DIFF
--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -109,14 +109,13 @@ async fn test_discv5_and_rlpx_same_socket_ok_without_discv4() {
         .listener_port(test_port)
         .disable_discv4_discovery()
         .discovery_v5(
-            reth_discv5::Config::builder((DEFAULT_DISCOVERY_ADDR, test_port).into())
-                .discv5_config(
-                    discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
-                        DEFAULT_DISCOVERY_ADDR,
-                        test_port,
-                    ))
-                    .build(),
-                ),
+            reth_discv5::Config::builder((DEFAULT_DISCOVERY_ADDR, test_port).into()).discv5_config(
+                discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
+                    DEFAULT_DISCOVERY_ADDR,
+                    test_port,
+                ))
+                .build(),
+            ),
         )
         .disable_dns_discovery()
         .build(NoopProvider::default());

--- a/crates/net/network/tests/it/startup.rs
+++ b/crates/net/network/tests/it/startup.rs
@@ -97,16 +97,23 @@ async fn test_discv5_and_discv4_same_socket_fails() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_discv5_and_rlpx_same_socket_ok_without_discv4() {
+    let test_port: u16 = TcpListener::bind("127.0.0.1:0") // 0 means OS assigns a free port
+        .await
+        .expect("Failed to bind to a port")
+        .local_addr()
+        .unwrap()
+        .port();
+
     let secret_key = SecretKey::new(&mut rand_08::thread_rng());
     let config = NetworkConfigBuilder::eth(secret_key)
-        .listener_port(DEFAULT_DISCOVERY_PORT)
+        .listener_port(test_port)
         .disable_discv4_discovery()
         .discovery_v5(
-            reth_discv5::Config::builder((DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT).into())
+            reth_discv5::Config::builder((DEFAULT_DISCOVERY_ADDR, test_port).into())
                 .discv5_config(
                     discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
                         DEFAULT_DISCOVERY_ADDR,
-                        DEFAULT_DISCOVERY_PORT,
+                        test_port,
                     ))
                     .build(),
                 ),


### PR DESCRIPTION
This makes it not conflict with the seismic integration test