### PR TITLE
fix: update broken Reth Book link to Seismic Reth documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ _Adapted from the [Foundry contributing guide][foundry-contributing]_.
 
 [dev-tg]: https://t.me/paradigm_reth
 
-[reth-book]: https://github.com/paradigmxyz/reth/tree/main/book
+[reth-book]: https://seismicsystems.github.io/seismic-reth
 
 [mcve]: https://stackoverflow.com/help/mcve
 


### PR DESCRIPTION
Replace the broken link to the old Reth Book repository with the correct
link to the Seismic Reth documentation hosted at seismicsystems.github.io.

The previous link https://github.com/paradigmxyz/reth/tree/main/book was
returning a 404 error. The new link https://seismicsystems.github.io/seismic-reth
points to the current, maintained documentation for the Seismic Reth project.

This ensures that contributors can access up-to-date documentation when
seeking help or guidance.