### PR TITLE
modify timestamp to be ms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "4.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "23.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10272,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "19.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "20.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "19.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a#f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "4.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "23.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10272,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10287,7 +10287,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "4.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "19.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10389,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "20.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "19.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#ca29681a10fe783f0a9745b46412c2d7c73ba4c8"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?branch=timestamp-ms#c1198c522bec2b2a25c83d2eb2bcffa21a7dbc46"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -12356,7 +12356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -12938,7 +12938,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -770,18 +770,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "417644c" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f3dde53ca8f0bc6e482db09f606fd3f8ce699c1a"}
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", branch = "timestamp-ms"}
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "2b50433"}
 

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -87,7 +87,7 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
-timestamp-in-seconds = ["reth-node-api/timestamp-in-seconds"]
+timestamp-in-seconds = ["reth-node-api/timestamp-in-seconds", "reth-primitives-traits/timestamp-in-seconds"]
 
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices
 ethereum = []

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -87,6 +87,8 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+timestamp-in-seconds = ["reth-node-api/timestamp-in-seconds"]
+
 # no-op feature flag for switching between the `optimism` and default functionality in CI matrices
 ethereum = []
 

--- a/bin/seismic-reth/Cargo.toml
+++ b/bin/seismic-reth/Cargo.toml
@@ -57,3 +57,6 @@ min-trace-logs = ["tracing/release_max_level_trace"]
 [[bin]]
 name = "seismic-reth"
 path = "src/main.rs"
+
+timestamp-in-seconds = ["reth-seismic-node/timestamp-in-seconds"]
+

--- a/bin/seismic-reth/Cargo.toml
+++ b/bin/seismic-reth/Cargo.toml
@@ -54,9 +54,10 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+timestamp-in-seconds = ["reth-seismic-node/timestamp-in-seconds"]
+
 [[bin]]
 name = "seismic-reth"
 path = "src/main.rs"
 
-timestamp-in-seconds = ["reth-seismic-node/timestamp-in-seconds"]
 

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -69,3 +69,7 @@ arbitrary = [
 test-utils = [
     "reth-primitives-traits/test-utils",
 ]
+
+timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]
+
+

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -41,11 +41,12 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
         .active_at_block(0)
         .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE));
 
+    let genesis_timestamp_seconds = genesis.timestamp / 1000;
     // If shanghai is activated, initialize the header with an empty withdrawals hash, and
     // empty withdrawals list.
     let withdrawals_root = hardforks
         .fork(EthereumHardfork::Shanghai)
-        .active_at_timestamp(genesis.timestamp)
+        .active_at_timestamp(genesis_timestamp_seconds)
         .then_some(EMPTY_WITHDRAWALS);
 
     // If Cancun is activated at genesis, we set:
@@ -53,7 +54,7 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
     // * blob gas used to provided genesis or 0x0
     // * excess blob gas to provided genesis or 0x0
     let (parent_beacon_block_root, blob_gas_used, excess_blob_gas) =
-        if hardforks.fork(EthereumHardfork::Cancun).active_at_timestamp(genesis.timestamp) {
+        if hardforks.fork(EthereumHardfork::Cancun).active_at_timestamp(genesis_timestamp_seconds) {
             let blob_gas_used = genesis.blob_gas_used.unwrap_or(0);
             let excess_blob_gas = genesis.excess_blob_gas.unwrap_or(0);
             (Some(B256::ZERO), Some(blob_gas_used), Some(excess_blob_gas))
@@ -64,7 +65,7 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
     // If Prague is activated at genesis we set requests root to an empty trie root.
     let requests_hash = hardforks
         .fork(EthereumHardfork::Prague)
-        .active_at_timestamp(genesis.timestamp)
+        .active_at_timestamp(genesis_timestamp_seconds)
         .then_some(EMPTY_REQUESTS_HASH);
 
     Header {
@@ -485,7 +486,7 @@ impl ChainSpec {
             })
         });
 
-        ForkFilter::new(head, self.genesis_hash(), self.genesis_timestamp(), forks)
+        ForkFilter::new(head, self.genesis_hash(), self.genesis_timestamp() / 1000, forks)
     }
 
     /// Compute the [`ForkId`] for the given [`Head`] following eip-6122 spec.
@@ -528,9 +529,12 @@ impl ChainSpec {
         // this filter ensures that no block-based forks are returned
         for timestamp in self.hardforks.forks_iter().filter_map(|(_, cond)| {
             // ensure we only get timestamp forks activated __after__ the genesis block
-            cond.as_timestamp().filter(|time| time > &self.genesis.timestamp)
+            let genesis_timestamp_seconds = self.genesis.timestamp / 1000;
+            cond.as_timestamp().filter(|time| time > &genesis_timestamp_seconds)
         }) {
-            if head.timestamp >= timestamp {
+
+            // modified to assume timestamps are in ms
+            if head.timestamp / 1000 >= timestamp {
                 // skip duplicated hardfork activated at the same timestamp
                 if timestamp != current_applied {
                     forkhash += timestamp;
@@ -555,7 +559,8 @@ impl ChainSpec {
                 // to satisfy every timestamp ForkCondition, we find the last ForkCondition::Block
                 // if one exists, and include its block_num in the returned Head
                 Head {
-                    timestamp,
+                    // go from seconds to ms in head
+                    timestamp: timestamp * 1000,
                     number: self.last_block_fork_before_merge_or_timestamp().unwrap_or_default(),
                     ..Default::default()
                 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -565,18 +565,16 @@ impl ChainSpec {
     pub(crate) fn satisfy(&self, cond: ForkCondition) -> Head {
         match cond {
             ForkCondition::Block(number) => Head { number, ..Default::default() },
+            // this timestamp is in seconds
             ForkCondition::Timestamp(timestamp) => {
                 // to satisfy every timestamp ForkCondition, we find the last ForkCondition::Block
                 // if one exists, and include its block_num in the returned Head
 
-                #[cfg(feature = "timestamp-in-seconds")]
-                let timestamp_seconds = timestamp;
-                #[cfg(not(feature = "timestamp-in-seconds"))]
-                let timestamp_seconds = timestamp * 1000;
+                let timestamp = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp * 1000 };
 
                 Head {
                     // go from seconds to ms in head
-                    timestamp: timestamp_seconds,
+                    timestamp: timestamp,
                     number: self.last_block_fork_before_merge_or_timestamp().unwrap_or_default(),
                     ..Default::default()
                 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -41,7 +41,9 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
         .active_at_block(0)
         .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE));
 
-    let genesis_timestamp_seconds = genesis.timestamp / 1000;
+   
+    let genesis_timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { genesis.timestamp } else { genesis.timestamp / 1000 };  
+
     // If shanghai is activated, initialize the header with an empty withdrawals hash, and
     // empty withdrawals list.
     let withdrawals_root = hardforks
@@ -421,7 +423,10 @@ impl ChainSpec {
 
     /// Get the timestamp of the genesis block in seconds
     pub(crate) fn genesis_timestamp_seconds(&self) -> u64 {
-        self.genesis.timestamp / 1000
+        #[cfg(feature = "timestamp-in-seconds")]
+        return self.genesis.timestamp;
+        #[cfg(not(feature = "timestamp-in-seconds"))]
+        return self.genesis.timestamp / 1000;
     }
 
     /// Get the timestamp of the genesis block.
@@ -534,12 +539,12 @@ impl ChainSpec {
         // this filter ensures that no block-based forks are returned
         for timestamp in self.hardforks.forks_iter().filter_map(|(_, cond)| {
             // ensure we only get timestamp forks activated __after__ the genesis block
-            let genesis_timestamp_seconds = self.genesis.timestamp / 1000;
+            let genesis_timestamp_seconds = self.genesis_timestamp_seconds();
             cond.as_timestamp().filter(|time| time > &genesis_timestamp_seconds)
         }) {
 
-            // modified to assume timestamps are in ms
-            if head.timestamp / 1000 >= timestamp {
+            // MODIFIED:: timestamp is in seconds, not milliseconds
+            if head.timestamp >= timestamp {
                 // skip duplicated hardfork activated at the same timestamp
                 if timestamp != current_applied {
                     forkhash += timestamp;
@@ -563,9 +568,15 @@ impl ChainSpec {
             ForkCondition::Timestamp(timestamp) => {
                 // to satisfy every timestamp ForkCondition, we find the last ForkCondition::Block
                 // if one exists, and include its block_num in the returned Head
+
+                #[cfg(feature = "timestamp-in-seconds")]
+                let timestamp_seconds = timestamp;
+                #[cfg(not(feature = "timestamp-in-seconds"))]
+                let timestamp_seconds = timestamp * 1000;
+
                 Head {
                     // go from seconds to ms in head
-                    timestamp: timestamp * 1000,
+                    timestamp: timestamp_seconds,
                     number: self.last_block_fork_before_merge_or_timestamp().unwrap_or_default(),
                     ..Default::default()
                 }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -159,11 +159,11 @@ where
     }
 
     // EIP-4895: Beacon chain push withdrawals as operations
-    if chain_spec.is_shanghai_active_at_timestamp(block.timestamp()) {
+    if chain_spec.is_shanghai_active_at_timestamp(block.timestamp_seconds()) {
         validate_shanghai_withdrawals(block)?;
     }
 
-    if chain_spec.is_cancun_active_at_timestamp(block.timestamp()) {
+    if chain_spec.is_cancun_active_at_timestamp(block.timestamp_seconds()) {
         validate_cancun_gas(block)?;
     }
 
@@ -283,7 +283,7 @@ pub fn validate_against_parent_eip1559_base_fee<
                 parent.gas_used(),
                 parent.gas_limit(),
                 base_fee,
-                chain_spec.base_fee_params_at_timestamp(header.timestamp()),
+                chain_spec.base_fee_params_at_timestamp(header.timestamp_seconds()),
             )
         };
         if expected_base_fee != base_fee {

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -67,3 +67,5 @@ derive_more.workspace = true
 
 [features]
 optimism = ["dep:op-alloy-rpc-types-engine", "dep:reth-optimism-primitives"]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]
+

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -53,3 +53,5 @@ op = [
     "reth-payload-primitives/op",
     "reth-evm/op",
 ]
+
+timestamp-in-seconds = []

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -84,7 +84,7 @@ pub struct LocalMiner<T: PayloadTypes, B> {
     /// The payload builder for the engine
     payload_builder: PayloadBuilderHandle<T>,
     /// Timestamp for the next block
-    /// NOTE: this is in MILLISECONDS. different from upstream reth, which holds this in seconds
+    /// NOTE: this is in MILLISECONDS when timestamp-in-seconds feature is disabled. different from upstream reth, which holds this in seconds
     last_timestamp: u64,
     /// Stores latest mined blocks.
     last_block_hashes: Vec<B256>,
@@ -178,8 +178,17 @@ where
     /// Generates payload attributes for a new block, passes them to FCU and inserts built payload
     /// through newPayload.
     async fn advance(&mut self) -> eyre::Result<()> {
+        #[cfg(feature = "timestamp-in-seconds")]
         let timestamp = std::cmp::max(
             self.last_timestamp + 1,
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("cannot be earlier than UNIX_EPOCH")
+                .as_secs() as u64,
+        );
+        #[cfg(not(feature = "timestamp-in-seconds"))]
+        let timestamp = std::cmp::max(
+            self.last_timestamp + 1000,
             std::time::SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("cannot be earlier than UNIX_EPOCH")

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -83,7 +83,7 @@ pub struct LocalMiner<T: PayloadTypes, B> {
     mode: MiningMode,
     /// The payload builder for the engine
     payload_builder: PayloadBuilderHandle<T>,
-    /// Timestamp for the next block.
+    /// Timestamp for the next block, in milliseconds.
     last_timestamp: u64,
     /// Stores latest mined blocks.
     last_block_hashes: Vec<B256>,
@@ -102,6 +102,8 @@ where
         mode: MiningMode,
         payload_builder: PayloadBuilderHandle<T>,
     ) {
+
+        // header block timestamp should be in milliseconds here
         let latest_header =
             provider.sealed_header(provider.best_block_number().unwrap()).unwrap().unwrap();
 
@@ -180,8 +182,9 @@ where
             std::time::SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("cannot be earlier than UNIX_EPOCH")
-                .as_secs(),
+                .as_millis() as u64,
         );
+
 
         let (tx, rx) = oneshot::channel();
         self.to_engine.send(BeaconEngineMessage::ForkchoiceUpdated {

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -31,7 +31,7 @@ where
 
     fn build(&self, timestamp: u64) -> EthPayloadAttributes {
 
-        let timestamp_seconds: u64 = timestamp / 1000;
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp / 1000 };  
 
         EthPayloadAttributes {
             timestamp: timestamp,

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -26,18 +26,24 @@ impl<ChainSpec> PayloadAttributesBuilder<EthPayloadAttributes>
 where
     ChainSpec: Send + Sync + EthereumHardforks + 'static,
 {
+    // timestamp is in milliseconds when passed into here,  will store it as milliseconds in payload attributes (similar to payload attributes emitted from consensus layer)
+    // use timestamp in seconds for is_shanghai_active_at_timestamp and is_cancun_active_at_timestamp
+
     fn build(&self, timestamp: u64) -> EthPayloadAttributes {
+
+        let timestamp_seconds: u64 = timestamp / 1000;
+
         EthPayloadAttributes {
-            timestamp,
+            timestamp: timestamp,
             prev_randao: B256::random(),
             suggested_fee_recipient: Address::random(),
             withdrawals: self
                 .chain_spec
-                .is_shanghai_active_at_timestamp(timestamp)
+                .is_shanghai_active_at_timestamp(timestamp_seconds)
                 .then(Default::default),
             parent_beacon_block_root: self
                 .chain_spec
-                .is_cancun_active_at_timestamp(timestamp)
+                .is_cancun_active_at_timestamp(timestamp_seconds)
                 .then(B256::random),
         }
     }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -136,3 +136,5 @@ test-utils = [
     "reth-node-ethereum/test-utils",
     "reth-evm-ethereum/test-utils",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -116,3 +116,5 @@ min-warn-logs = ["tracing/release_max_level_warn"]
 min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
+
+timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]

--- a/crates/ethereum/cli/src/debug_cmd/build_block.rs
+++ b/crates/ethereum/cli/src/debug_cmd/build_block.rs
@@ -75,7 +75,11 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
 
     // function to get timestamp in seconds
     pub fn timestamp_seconds(&self) -> u64 {
-        self.timestamp / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.timestamp
+        } else {
+            self.timestamp / 1000
+        }
     }
 
     /// Fetches the best block from the database.

--- a/crates/ethereum/cli/src/debug_cmd/build_block.rs
+++ b/crates/ethereum/cli/src/debug_cmd/build_block.rs
@@ -189,7 +189,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             // Set empty withdrawals vector if Shanghai is active, None otherwise
             withdrawals: provider_factory
                 .chain_spec()
-                .is_shanghai_active_at_timestamp(self.timestamp)
+                .is_shanghai_active_at_timestamp(self.timestamp / 1000)
                 .then(Vec::new),
         };
         let payload_config = PayloadConfig::new(

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -61,7 +61,7 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
         {
             parent.gas_limit() *
                 self.chain_spec
-                    .base_fee_params_at_timestamp(header.timestamp())
+                    .base_fee_params_at_timestamp(header.timestamp_seconds())
                     .elasticity_multiplier as u64
         } else {
             parent.gas_limit()
@@ -159,11 +159,11 @@ where
                     .unwrap()
                     .as_secs();
 
-                if header.timestamp() >
+                if header.timestamp_seconds() >
                     present_timestamp + alloy_eips::merge::ALLOWED_FUTURE_BLOCK_TIME_SECONDS
                 {
                     return Err(ConsensusError::TimestampIsInFuture {
-                        timestamp: header.timestamp(),
+                        timestamp: header.timestamp_seconds(),
                         present_timestamp,
                     });
                 }
@@ -174,22 +174,22 @@ where
         validate_header_base_fee(header, &self.chain_spec)?;
 
         // EIP-4895: Beacon chain push withdrawals as operations
-        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) &&
+        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp_seconds()) &&
             header.withdrawals_root().is_none()
         {
             return Err(ConsensusError::WithdrawalsRootMissing)
-        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) &&
+        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp_seconds()) &&
             header.withdrawals_root().is_some()
         {
             return Err(ConsensusError::WithdrawalsRootUnexpected)
         }
 
         // Ensures that EIP-4844 fields are valid once cancun is active.
-        if self.chain_spec.is_cancun_active_at_timestamp(header.timestamp()) {
+        if self.chain_spec.is_cancun_active_at_timestamp(header.timestamp_seconds()) {
             validate_4844_header_standalone(
                 header,
                 self.chain_spec
-                    .blob_params_at_timestamp(header.timestamp())
+                    .blob_params_at_timestamp(header.timestamp_seconds())
                     .unwrap_or_else(BlobParams::cancun),
             )?;
         } else if header.blob_gas_used().is_some() {
@@ -200,7 +200,7 @@ where
             return Err(ConsensusError::ParentBeaconBlockRootUnexpected)
         }
 
-        if self.chain_spec.is_prague_active_at_timestamp(header.timestamp()) {
+        if self.chain_spec.is_prague_active_at_timestamp(header.timestamp_seconds()) {
             if header.requests_hash().is_none() {
                 return Err(ConsensusError::RequestsHashMissing)
             }
@@ -229,9 +229,9 @@ where
             parent.header(),
             &self.chain_spec,
         )?;
-
+        
         // ensure that the blob gas fields for this block
-        if let Some(blob_params) = self.chain_spec.blob_params_at_timestamp(header.timestamp()) {
+        if let Some(blob_params) = self.chain_spec.blob_params_at_timestamp(header.timestamp_seconds()) {
             validate_against_parent_4844(header.header(), parent.header(), blob_params)?;
         }
 

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -47,7 +47,7 @@ where
     }
 
     // Validate that the header requests hash matches the calculated requests hash
-    if chain_spec.is_prague_active_at_timestamp(block.header().timestamp()) {
+    if chain_spec.is_prague_active_at_timestamp(block.timestamp_seconds()) {
         let Some(header_requests_hash) = block.header().requests_hash() else {
             return Err(ConsensusError::RequestsHashMissing)
         };

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -50,3 +50,5 @@ std = [
     "reth-engine-primitives/std",
     "reth-primitives-traits/std",
 ]
+
+timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -371,6 +371,8 @@ impl From<alloc::vec::IntoIter<BlobTransactionSidecarEip7594>> for BlobSidecars 
 
 /// Container type for all components required to build a payload.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+
+// Modified miner such that timestamp is in milliseconds (similar to payload attributes emitted from consensus layer)
 pub struct EthPayloadBuilderAttributes {
     /// Id of the payload
     pub id: PayloadId,
@@ -378,7 +380,7 @@ pub struct EthPayloadBuilderAttributes {
     pub parent: B256,
     /// Unix timestamp for the generated payload
     ///
-    /// Number of seconds since the Unix epoch.
+    /// MODIFIED: Number of milliseconds since the Unix epoch instead of seconds.
     pub timestamp: u64,
     /// Address of the recipient for collecting transaction fee
     pub suggested_fee_recipient: Address,
@@ -398,10 +400,16 @@ impl EthPayloadBuilderAttributes {
         self.id
     }
 
+    /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
+    pub fn timestamp_seconds(&self) -> u64 {
+        self.timestamp / 1000
+    }
+
     /// Creates a new payload builder for the given parent block and the attributes.
     ///
     /// Derives the unique [`PayloadId`] for the given parent and attributes
     pub fn new(parent: B256, attributes: PayloadAttributes) -> Self {
+        
         let id = payload_id(&parent, &attributes);
 
         Self {

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -402,7 +402,11 @@ impl EthPayloadBuilderAttributes {
 
     /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
     pub fn timestamp_seconds(&self) -> u64 {
-        self.timestamp / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.timestamp
+        } else {
+            self.timestamp / 1000
+        }
     }
 
     /// Creates a new payload builder for the given parent block and the attributes.

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -65,3 +65,5 @@ test-utils = [
     "reth-evm/test-utils",
     "reth-primitives-traits/test-utils",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -54,7 +54,7 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
-        let timestamp_seconds = timestamp / 1000;
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp / 1000 };  
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root = Receipt::calculate_receipt_root_no_memo(receipts);

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -54,6 +54,7 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
+        let timestamp_seconds = timestamp / 1000;
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root = Receipt::calculate_receipt_root_no_memo(receipts);
@@ -61,26 +62,26 @@ where
 
         let withdrawals = self
             .chain_spec
-            .is_shanghai_active_at_timestamp(timestamp)
+            .is_shanghai_active_at_timestamp(timestamp_seconds)
             .then(|| ctx.withdrawals.map(|w| w.into_owned()).unwrap_or_default());
 
         let withdrawals_root =
             withdrawals.as_deref().map(|w| proofs::calculate_withdrawals_root(w));
         let requests_hash = self
             .chain_spec
-            .is_prague_active_at_timestamp(timestamp)
+            .is_prague_active_at_timestamp(timestamp_seconds)
             .then(|| requests.requests_hash());
 
         let mut excess_blob_gas = None;
         let mut blob_gas_used = None;
 
         // only determine cancun fields when active
-        if self.chain_spec.is_cancun_active_at_timestamp(timestamp) {
+        if self.chain_spec.is_cancun_active_at_timestamp(timestamp_seconds) {
             blob_gas_used =
                 Some(transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum());
-            excess_blob_gas = if self.chain_spec.is_cancun_active_at_timestamp(parent.timestamp) {
+            excess_blob_gas = if self.chain_spec.is_cancun_active_at_timestamp(parent.timestamp_seconds()) {
                 parent.maybe_next_block_excess_blob_gas(
-                    self.chain_spec.blob_params_at_timestamp(timestamp),
+                    self.chain_spec.blob_params_at_timestamp(timestamp_seconds),
                 )
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -160,7 +160,7 @@ where
         // blobparams
         let blob_excess_gas_and_price = header
             .excess_blob_gas
-            .zip(self.chain_spec().blob_params_at_timestamp(header.timestamp))
+            .zip(self.chain_spec().blob_params_at_timestamp(header.timestamp() / 1000))
             .map(|(excess_blob_gas, params)| {
                 let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
                 BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }
@@ -188,7 +188,7 @@ where
         // ensure we're not missing any timestamp based hardforks
         let spec_id = revm_spec_by_timestamp_and_block_number(
             self.chain_spec(),
-            attributes.timestamp,
+            attributes.timestamp_seconds(),
             parent.number() + 1,
         );
 
@@ -198,7 +198,7 @@ where
             .with_spec(spec_id)
             .with_blob_max_and_target_count(self.blob_max_and_target_count_by_hardfork());
 
-        let blob_params = self.chain_spec().blob_params_at_timestamp(attributes.timestamp);
+        let blob_params = self.chain_spec().blob_params_at_timestamp(attributes.timestamp_seconds());
         // if the parent block did not have excess blob gas (i.e. it was pre-cancun), but it is
         // cancun now, we need to set the excess blob gas to the default value(0)
         let blob_excess_gas_and_price = parent
@@ -211,7 +211,7 @@ where
             });
 
         let mut basefee = parent.next_block_base_fee(
-            self.chain_spec().base_fee_params_at_timestamp(attributes.timestamp),
+            self.chain_spec().base_fee_params_at_timestamp(attributes.timestamp_seconds()),
         );
 
         let mut gas_limit = attributes.gas_limit;
@@ -222,7 +222,7 @@ where
         {
             let elasticity_multiplier = self
                 .chain_spec()
-                .base_fee_params_at_timestamp(attributes.timestamp)
+                .base_fee_params_at_timestamp(attributes.timestamp_seconds())
                 .elasticity_multiplier;
 
             // multiply the gas limit by the elasticity multiplier

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -156,11 +156,13 @@ where
             .with_spec(spec)
             .with_blob_max_and_target_count(self.blob_max_and_target_count_by_hardfork());
 
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { header.timestamp() } else { header.timestamp() / 1000 };    
+
         // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
         // blobparams
         let blob_excess_gas_and_price = header
             .excess_blob_gas
-            .zip(self.chain_spec().blob_params_at_timestamp(header.timestamp() / 1000))
+            .zip(self.chain_spec().blob_params_at_timestamp(timestamp_seconds))
             .map(|(excess_blob_gas, params)| {
                 let blob_gasprice = params.calc_blob_fee(excess_blob_gas);
                 BlobExcessGasAndPrice { excess_blob_gas, blob_gasprice }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -95,3 +95,5 @@ test-utils = [
     "reth-primitives-traits/test-utils",
     "reth-evm-ethereum/test-utils",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/ethereum/payload/Cargo.toml
+++ b/crates/ethereum/payload/Cargo.toml
@@ -39,3 +39,6 @@ alloy-eips.workspace = true
 
 # misc
 tracing.workspace = true
+
+[features]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -194,7 +194,7 @@ where
 
     let mut block_blob_count = 0;
 
-    let blob_params = chain_spec.blob_params_at_timestamp(attributes.timestamp);
+    let blob_params = chain_spec.blob_params_at_timestamp(attributes.timestamp_seconds());
     let max_blob_count =
         blob_params.as_ref().map(|params| params.max_blob_count).unwrap_or_default();
 
@@ -250,7 +250,7 @@ where
                     break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
                 };
 
-                if chain_spec.is_osaka_active_at_timestamp(attributes.timestamp) {
+                if chain_spec.is_osaka_active_at_timestamp(attributes.timestamp_seconds()) {
                     if sidecar.is_eip7594() {
                         Ok(sidecar)
                     } else {
@@ -330,7 +330,7 @@ where
     let BlockBuilderOutcome { execution_result, block, .. } = builder.finish(&state_provider)?;
 
     let requests = chain_spec
-        .is_prague_active_at_timestamp(attributes.timestamp)
+        .is_prague_active_at_timestamp(attributes.timestamp_seconds())
         .then_some(execution_result.requests);
 
     let sealed_block = Arc::new(block.sealed_block().clone());

--- a/crates/ethereum/payload/src/validator.rs
+++ b/crates/ethereum/payload/src/validator.rs
@@ -90,19 +90,19 @@ impl<ChainSpec: EthereumHardforks> EthereumExecutionPayloadValidator<ChainSpec> 
 
         shanghai::ensure_well_formed_fields(
             sealed_block.body(),
-            self.is_shanghai_active_at_timestamp(sealed_block.timestamp),
+            self.is_shanghai_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         cancun::ensure_well_formed_fields(
             &sealed_block,
             sidecar.cancun(),
-            self.is_cancun_active_at_timestamp(sealed_block.timestamp),
+            self.is_cancun_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         prague::ensure_well_formed_fields(
             sealed_block.body(),
             sidecar.prague(),
-            self.is_prague_active_at_timestamp(sealed_block.timestamp),
+            self.is_prague_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         Ok(sealed_block)

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -69,3 +69,5 @@ test-utils = [
     "reth-ethereum-primitives/test-utils",
 ]
 op = ["alloy-evm/op", "reth-primitives-traits/op"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -294,8 +294,10 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
 /// [`ConfigureEvm::next_evm_env`] and contains fields that can't be derived from the
 /// parent header alone (attributes that are determined by the CL.)
 #[derive(Debug, Clone, PartialEq, Eq)]
+
+// this is created in crates/payload/basic/src/lib.rs - timestamp should be in milliseconds 
 pub struct NextBlockEnvAttributes {
-    /// The timestamp of the next block.
+    /// The timestamp of the next block, in milliseconds.
     pub timestamp: u64,
     /// The suggested fee recipient for the next block.
     pub suggested_fee_recipient: Address,
@@ -307,6 +309,13 @@ pub struct NextBlockEnvAttributes {
     pub parent_beacon_block_root: Option<B256>,
     /// Withdrawals
     pub withdrawals: Option<Withdrawals>,
+}
+
+impl NextBlockEnvAttributes {
+    /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
+    pub fn timestamp_seconds(&self) -> u64 {
+        self.timestamp / 1000
+    }
 }
 
 /// Abstraction over transaction environment.

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -314,7 +314,11 @@ pub struct NextBlockEnvAttributes {
 impl NextBlockEnvAttributes {
     /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
     pub fn timestamp_seconds(&self) -> u64 {
-        self.timestamp / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.timestamp
+        } else {
+            self.timestamp / 1000
+        }
     }
 }
 

--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -71,3 +71,5 @@ std = [
     "reth-trie-common/std",
     "alloy-evm/std",
 ]
+
+timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]

--- a/crates/node/api/Cargo.toml
+++ b/crates/node/api/Cargo.toml
@@ -31,3 +31,6 @@ reth-tokio-util.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 eyre.workspace = true
+
+[features]
+timestamp-in-seconds = ["reth-db-api/timestamp-in-seconds"]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -111,3 +111,7 @@ op = [
     "reth-engine-local/op",
     "reth-evm/op",
 ]
+
+timestamp-in-seconds = [
+    "reth-engine-local/timestamp-in-seconds",
+]

--- a/crates/optimism/consensus/Cargo.toml
+++ b/crates/optimism/consensus/Cargo.toml
@@ -76,3 +76,5 @@ std = [
     "thiserror/std",
     "reth-execution-types/std",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -101,7 +101,7 @@ impl<ChainSpec: EthChainSpec + OpHardforks, B: Block> Consensus<B>
         }
 
         // Check empty shanghai-withdrawals
-        if self.chain_spec.is_canyon_active_at_timestamp(block.timestamp()) {
+        if self.chain_spec.is_canyon_active_at_timestamp(block.timestamp_seconds()) {
             canyon::ensure_empty_shanghai_withdrawals(block.body()).map_err(|err| {
                 ConsensusError::Other(format!("failed to verify block {}: {err}", block.number()))
             })?
@@ -109,12 +109,12 @@ impl<ChainSpec: EthChainSpec + OpHardforks, B: Block> Consensus<B>
             return Ok(())
         }
 
-        if self.chain_spec.is_ecotone_active_at_timestamp(block.timestamp()) {
+        if self.chain_spec.is_ecotone_active_at_timestamp(block.timestamp_seconds()) {
             validate_cancun_gas(block)?;
         }
 
         // Check withdrawals root field in header
-        if self.chain_spec.is_isthmus_active_at_timestamp(block.timestamp()) {
+        if self.chain_spec.is_isthmus_active_at_timestamp(block.timestamp_seconds()) {
             // storage root of withdrawals pre-deploy is verified post-execution
             isthmus::ensure_withdrawals_storage_root_is_some(block.header()).map_err(|err| {
                 ConsensusError::Other(format!("failed to verify block {}: {err}", block.number()))
@@ -176,11 +176,11 @@ impl<ChainSpec: EthChainSpec + OpHardforks, H: BlockHeader> HeaderValidator<H>
         // <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation>
         // > if Holocene is active in parent_header.timestamp, then the parameters from
         // > parent_header.extraData are used.
-        if self.chain_spec.is_holocene_active_at_timestamp(parent.timestamp()) {
+        if self.chain_spec.is_holocene_active_at_timestamp(parent.timestamp_seconds()) {
             let header_base_fee =
                 header.base_fee_per_gas().ok_or(ConsensusError::BaseFeeMissing)?;
             let expected_base_fee =
-                decode_holocene_base_fee(&self.chain_spec, parent.header(), header.timestamp())
+                decode_holocene_base_fee(&self.chain_spec, parent.header(), header.timestamp_seconds())
                     .map_err(|_| ConsensusError::BaseFeeMissing)?;
             if expected_base_fee != header_base_fee {
                 return Err(ConsensusError::BaseFeeDiff(GotExpected {
@@ -197,7 +197,7 @@ impl<ChainSpec: EthChainSpec + OpHardforks, H: BlockHeader> HeaderValidator<H>
         }
 
         // ensure that the blob gas fields for this block
-        if let Some(blob_params) = self.chain_spec.blob_params_at_timestamp(header.timestamp()) {
+        if let Some(blob_params) = self.chain_spec.blob_params_at_timestamp(header.timestamp_seconds()) {
             validate_against_parent_4844(header.header(), parent.header(), blob_params)?;
         }
 

--- a/crates/optimism/consensus/src/validation/mod.rs
+++ b/crates/optimism/consensus/src/validation/mod.rs
@@ -52,7 +52,7 @@ where
         (Some(header_withdrawals_root), Some(withdrawals_root)) => {
             // after isthmus, the withdrawals root field is repurposed and no longer mirrors the
             // withdrawals root computed from the body
-            if chain_spec.is_isthmus_active_at_timestamp(header.timestamp()) {
+            if chain_spec.is_isthmus_active_at_timestamp(header.timestamp_seconds()) {
                 // After isthmus we only ensure that the body has empty withdrawals
                 if withdrawals_root != EMPTY_ROOT_HASH {
                     return Err(ConsensusError::BodyWithdrawalsRootDiff(
@@ -97,7 +97,7 @@ pub fn validate_block_post_execution<R: DepositReceipt>(
             header.logs_bloom(),
             receipts,
             chain_spec,
-            header.timestamp(),
+            header.timestamp_seconds(),
         ) {
             tracing::debug!(%error, ?receipts, "receipts verification failed");
             return Err(error)
@@ -171,6 +171,8 @@ fn compare_receipts_root_and_logs_bloom(
 /// Caution: Caller must ensure that holocene is active in the parent header.
 ///
 /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation)
+/// 
+/// timestamp needs to be in seconds here ? 
 pub fn decode_holocene_base_fee(
     chain_spec: impl EthChainSpec + OpHardforks,
     parent: impl BlockHeader,
@@ -197,7 +199,7 @@ pub fn next_block_base_fee(
     // If we are in the Holocene, we need to use the base fee params
     // from the parent block's extra data.
     // Else, use the base fee params (default values) from chainspec
-    if chain_spec.is_holocene_active_at_timestamp(parent.timestamp()) {
+    if chain_spec.is_holocene_active_at_timestamp(parent.timestamp_seconds()) {
         Ok(decode_holocene_base_fee(chain_spec, parent, timestamp)?)
     } else {
         Ok(parent

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -72,3 +72,5 @@ std = [
     "reth-evm/std",
 ]
 portable = ["reth-revm/portable"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "op-revm/timestamp-in-seconds"]

--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -61,7 +61,7 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
-        let timestamp_seconds = timestamp / 1000;
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp / 1000 };  
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root =

--- a/crates/optimism/evm/src/build.rs
+++ b/crates/optimism/evm/src/build.rs
@@ -61,15 +61,16 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
+        let timestamp_seconds = timestamp / 1000;
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root =
-            calculate_receipt_root_no_memo_optimism(receipts, &self.chain_spec, timestamp);
+            calculate_receipt_root_no_memo_optimism(receipts, &self.chain_spec, timestamp_seconds);
         let logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
 
         let mut requests_hash = None;
 
-        let withdrawals_root = if self.chain_spec.is_isthmus_active_at_timestamp(timestamp) {
+        let withdrawals_root = if self.chain_spec.is_isthmus_active_at_timestamp(timestamp_seconds) {
             // always empty requests hash post isthmus
             requests_hash = Some(EMPTY_REQUESTS_HASH);
 
@@ -79,14 +80,14 @@ where
                 isthmus::withdrawals_root(bundle_state, state_provider)
                     .map_err(BlockExecutionError::other)?,
             )
-        } else if self.chain_spec.is_canyon_active_at_timestamp(timestamp) {
+        } else if self.chain_spec.is_canyon_active_at_timestamp(timestamp_seconds) {
             Some(EMPTY_WITHDRAWALS)
         } else {
             None
         };
 
         let (excess_blob_gas, blob_gas_used) =
-            if self.chain_spec.is_ecotone_active_at_timestamp(timestamp) {
+            if self.chain_spec.is_ecotone_active_at_timestamp(timestamp_seconds) {
                 (Some(0), Some(0))
             } else {
                 (None, None)
@@ -123,7 +124,7 @@ where
                 ommers: Default::default(),
                 withdrawals: self
                     .chain_spec
-                    .is_canyon_active_at_timestamp(timestamp)
+                    .is_canyon_active_at_timestamp(timestamp_seconds)
                     .then(Default::default),
             },
         ))

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -173,7 +173,7 @@ where
         // cancun now, we need to set the excess blob gas to the default value(0)
         let blob_excess_gas_and_price = parent
             .maybe_next_block_excess_blob_gas(
-                self.chain_spec().blob_params_at_timestamp(attributes.timestamp),
+                self.chain_spec().blob_params_at_timestamp(attributes.timestamp_seconds()),
             )
             .or_else(|| (spec_id.into_eth_spec().is_enabled_in(SpecId::CANCUN)).then_some(0))
             .map(|gas| BlobExcessGasAndPrice::new(gas, false));
@@ -186,7 +186,7 @@ where
             prevrandao: Some(attributes.prev_randao),
             gas_limit: attributes.gas_limit,
             // calculate basefee based on parent block's gas usage
-            basefee: next_block_base_fee(self.chain_spec(), parent, attributes.timestamp)?,
+            basefee: next_block_base_fee(self.chain_spec(), parent, attributes.timestamp_seconds())?,
             // calculate excess gas based on parent block's blob gas usage
             blob_excess_gas_and_price,
         };

--- a/crates/optimism/node/Cargo.toml
+++ b/crates/optimism/node/Cargo.toml
@@ -122,3 +122,5 @@ test-utils = [
 reth-codec = [
     "reth-optimism-primitives/reth-codec",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "op-revm/timestamp-in-seconds"]

--- a/crates/optimism/node/src/engine.rs
+++ b/crates/optimism/node/src/engine.rs
@@ -116,7 +116,7 @@ where
         state_updates: &HashedPostState,
         block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
-        if self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp()) {
+        if self.chain_spec().is_isthmus_active_at_timestamp(block.timestamp_seconds()) {
             let Ok(state) = self.provider.state_by_block_hash(block.parent_hash()) else {
                 // FIXME: we don't necessarily have access to the parent block here because the
                 // parent block isn't necessarily part of the canonical chain yet. Instead this
@@ -147,6 +147,8 @@ where
     Types: PayloadTypes<PayloadAttributes = OpPayloadAttributes, ExecutionData = OpExecutionData>,
     P: StateProviderFactory + Unpin + 'static,
 {
+
+    // modified to use timestamp seconds, unsure if needed
     fn validate_version_specific_fields(
         &self,
         version: EngineApiMessageVersion,
@@ -156,14 +158,14 @@ where
             self.chain_spec(),
             version,
             payload_or_attrs.message_validation_kind(),
-            payload_or_attrs.timestamp(),
+            payload_or_attrs.timestamp_seconds(),
             payload_or_attrs.withdrawals().is_some(),
         )?;
         validate_parent_beacon_block_root_presence(
             self.chain_spec(),
             version,
             payload_or_attrs.message_validation_kind(),
-            payload_or_attrs.timestamp(),
+            payload_or_attrs.timestamp_seconds(),
             payload_or_attrs.parent_beacon_block_root().is_some(),
         )
     }
@@ -189,7 +191,7 @@ where
 
         if self
             .chain_spec()
-            .is_holocene_active_at_timestamp(attributes.payload_attributes.timestamp)
+            .is_holocene_active_at_timestamp(attributes.payload_attributes.timestamp_seconds())
         {
             let (elasticity, denominator) =
                 attributes.decode_eip_1559_params().ok_or_else(|| {
@@ -288,8 +290,9 @@ mod test {
             eip_1559_params,
             transactions: None,
             no_tx_pool: None,
+            let timestamp_ms = timestamp * 1000;
             payload_attributes: PayloadAttributes {
-                timestamp,
+                timestamp: timestamp_ms,
                 prev_randao: B256::ZERO,
                 suggested_fee_recipient: Address::ZERO,
                 withdrawals: Some(vec![]),

--- a/crates/optimism/node/src/node.rs
+++ b/crates/optimism/node/src/node.rs
@@ -586,7 +586,7 @@ where
         let data_dir = ctx.config().datadir();
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), Default::default())?;
         // supervisor used for interop
-        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) &&
+        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp_seconds()) &&
             self.supervisor_http == DEFAULT_SUPERVISOR_URL
         {
             info!(target: "reth::cli",

--- a/crates/optimism/payload/Cargo.toml
+++ b/crates/optimism/payload/Cargo.toml
@@ -51,3 +51,6 @@ tracing.workspace = true
 thiserror.workspace = true
 sha2.workspace = true
 serde.workspace = true
+
+[features]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -379,7 +379,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         ctx.execute_sequencer_transactions(&mut builder)?;
         builder.into_executor().apply_post_execution_changes()?;
 
-        if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp()) {
+        if ctx.chain_spec.is_isthmus_active_at_timestamp(ctx.attributes().timestamp_seconds()) {
             // force load `L2ToL1MessagePasser.sol` so l2 withdrawals root can be computed even if
             // no l2 withdrawals in block
             _ = db.load_cache_account(ADDRESS_L2_TO_L1_MESSAGE_PASSER)?;
@@ -516,7 +516,7 @@ where
             self.attributes()
                 .get_holocene_extra_data(
                     self.chain_spec.base_fee_params_at_timestamp(
-                        self.attributes().payload_attributes.timestamp,
+                        self.attributes().payload_attributes.timestamp_seconds(),
                     ),
                 )
                 .map_err(PayloadBuilderError::other)
@@ -540,7 +540,7 @@ where
 
     /// Returns true if holocene is active for the payload.
     pub fn is_holocene_active(&self) -> bool {
-        self.chain_spec.is_holocene_active_at_timestamp(self.attributes().timestamp())
+        self.chain_spec.is_holocene_active_at_timestamp(self.attributes().timestamp_seconds())
     }
 
     /// Returns true if the fees are higher than the previous payload.

--- a/crates/optimism/payload/src/validator.rs
+++ b/crates/optimism/payload/src/validator.rs
@@ -65,19 +65,19 @@ where
 
         shanghai::ensure_well_formed_fields(
             sealed_block.body(),
-            self.is_shanghai_active_at_timestamp(sealed_block.timestamp),
+            self.is_shanghai_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         cancun::ensure_well_formed_header_and_sidecar_fields(
             &sealed_block,
             sidecar.canyon(),
-            self.is_cancun_active_at_timestamp(sealed_block.timestamp),
+            self.is_cancun_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         prague::ensure_well_formed_fields(
             sealed_block.body(),
             sidecar.isthmus(),
-            self.is_prague_active_at_timestamp(sealed_block.timestamp),
+            self.is_prague_active_at_timestamp(sealed_block.timestamp_seconds()),
         )?;
 
         Ok(sealed_block)

--- a/crates/optimism/rpc/Cargo.toml
+++ b/crates/optimism/rpc/Cargo.toml
@@ -84,3 +84,5 @@ client = [
     "jsonrpsee/async-client",
     "reth-rpc-eth-api/client",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "op-revm/timestamp-in-seconds"]

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -66,7 +66,7 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(OpNextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12),
+            timestamp: parent.timestamp().saturating_add(12000),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -66,8 +66,13 @@ where
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
+
+        
+
         Ok(OpNextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12000),
+            timestamp: parent.timestamp().saturating_add(
+                if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12000 }
+            ),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/optimism/rpc/src/eth/pending_block.rs
+++ b/crates/optimism/rpc/src/eth/pending_block.rs
@@ -67,8 +67,6 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
 
-        
-
         Ok(OpNextBlockEnvAttributes {
             timestamp: parent.timestamp().saturating_add(
                 if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12000 }

--- a/crates/optimism/rpc/src/eth/receipt.rs
+++ b/crates/optimism/rpc/src/eth/receipt.rs
@@ -1,5 +1,8 @@
 //! Loads and formats OP receipt RPC response.
 
+
+// need to make sure timestamps work here - not modifid yet 
+
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};

--- a/crates/optimism/storage/src/chain.rs
+++ b/crates/optimism/storage/src/chain.rs
@@ -61,7 +61,7 @@ where
 
         for (header, transactions) in inputs {
             let mut withdrawals = None;
-            if chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) {
+            if chain_spec.is_shanghai_active_at_timestamp(header.timestamp_seconds()) {
                 // after shanghai the body should have an empty withdrawals list
                 withdrawals.replace(vec![].into());
             }

--- a/crates/optimism/txpool/Cargo.toml
+++ b/crates/optimism/txpool/Cargo.toml
@@ -56,3 +56,6 @@ tokio = { workspace = true, features = ["time"] }
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
+
+[features]
+timestamp-in-seconds = ["op-revm/timestamp-in-seconds"]

--- a/crates/optimism/txpool/src/validator.rs
+++ b/crates/optimism/txpool/src/validator.rs
@@ -147,7 +147,7 @@ where
             *self.block_info.l1_block_info.write() = cost_addition;
         }
 
-        if self.chain_spec().is_interop_active_at_timestamp(header.timestamp()) {
+        if self.chain_spec().is_interop_active_at_timestamp(header.timestamp_seconds()) {
             self.fork_tracker.interop.store(true, Ordering::Relaxed);
         }
     }

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -49,3 +49,5 @@ test-utils = [
     "reth-primitives-traits/test-utils",
     "tokio/rt",
 ]
+
+timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -83,6 +83,7 @@ pub trait PayloadAttributes:
     serde::de::DeserializeOwned + serde::Serialize + fmt::Debug + Clone + Send + Sync + 'static
 {
     /// Returns the timestamp to be used in the payload job.
+    /// Assumes timestamp is in milliseconds since from CL node 
     fn timestamp(&self) -> u64;
 
     /// Returns the withdrawals for the given payload attributes.

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -158,3 +158,5 @@ op = [
 rayon = [
     "dep:rayon",
 ]
+
+timestamp-in-seconds = []

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -36,7 +36,11 @@ pub trait BlockHeader:
 {
     /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
     fn timestamp_seconds(&self) -> u64 {
-        self.timestamp() / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.timestamp()
+        } else {
+            self.timestamp() / 1000
+        }
     }
 }
 

--- a/crates/primitives-traits/src/block/header.rs
+++ b/crates/primitives-traits/src/block/header.rs
@@ -34,6 +34,10 @@ pub trait BlockHeader:
     + AsRef<Self>
     + 'static
 {
+    /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
+    fn timestamp_seconds(&self) -> u64 {
+        self.timestamp() / 1000
+    }
 }
 
 impl BlockHeader for alloy_consensus::Header {}

--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -196,7 +196,11 @@ impl<B: Block> SealedBlock<B> {
 
     /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
     pub fn timestamp_seconds(&self) -> u64 {
-        self.timestamp() / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.timestamp()
+        } else {
+            self.timestamp() / 1000
+        }
     }
 
     /// Returns the Sealed header.

--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -194,6 +194,11 @@ impl<B: Block> SealedBlock<B> {
         BlockWithParent { parent: self.parent_hash(), block: self.num_hash() }
     }
 
+    /// Returns the timestamp in seconds, assuming the timestamp is in milliseconds.
+    pub fn timestamp_seconds(&self) -> u64 {
+        self.timestamp() / 1000
+    }
+
     /// Returns the Sealed header.
     pub const fn sealed_header(&self) -> &SealedHeader<B::Header> {
         &self.header

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -130,7 +130,11 @@ impl<H: alloy_consensus::BlockHeader + Sealable> SealedHeader<H> {
 
     /// Returns the timestamp in seconds (header timestamp is in milliseconds)
     pub fn timestamp_seconds(&self) -> u64 {
-        self.header.timestamp() / 1000
+        if cfg!(feature = "timestamp-in-seconds") {
+            self.header.timestamp()
+        } else {
+            self.header.timestamp() / 1000
+        }
     }
 }
 

--- a/crates/primitives-traits/src/header/sealed.rs
+++ b/crates/primitives-traits/src/header/sealed.rs
@@ -127,6 +127,11 @@ impl<H: alloy_consensus::BlockHeader + Sealable> SealedHeader<H> {
     pub fn block_with_parent(&self) -> BlockWithParent {
         BlockWithParent { parent: self.parent_hash(), block: self.num_hash() }
     }
+
+    /// Returns the timestamp in seconds (header timestamp is in milliseconds)
+    pub fn timestamp_seconds(&self) -> u64 {
+        self.header.timestamp() / 1000
+    }
 }
 
 impl<H: Sealable> Eq for SealedHeader<H> {}

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -56,3 +56,5 @@ serde = [
     "reth-primitives-traits/serde",
 ]
 portable = ["revm/portable"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -61,3 +61,5 @@ tracing.workspace = true
 [features]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -175,7 +175,7 @@ pub trait EthFees: LoadFee {
 
                     let blob_params = self.provider()
                         .chain_spec()
-                        .blob_params_at_timestamp(header.timestamp())
+                        .blob_params_at_timestamp(header.timestamp_seconds())
                         .unwrap_or_else(BlobParams::cancun);
 
                     base_fee_per_blob_gas.push(header.blob_fee(blob_params).unwrap_or_default());
@@ -214,7 +214,7 @@ pub trait EthFees: LoadFee {
                     last_header.next_block_base_fee(
                     self.provider()
                         .chain_spec()
-                        .base_fee_params_at_timestamp(last_header.timestamp())).unwrap_or_default() as u128
+                        .base_fee_params_at_timestamp(last_header.timestamp_seconds())).unwrap_or_default() as u128
                 );
 
                 // Same goes for the `base_fee_per_blob_gas`:
@@ -222,7 +222,7 @@ pub trait EthFees: LoadFee {
                 base_fee_per_blob_gas.push(
                     last_header
                     .maybe_next_block_blob_fee(
-                        self.provider().chain_spec().blob_params_at_timestamp(last_header.timestamp())
+                        self.provider().chain_spec().blob_params_at_timestamp(last_header.timestamp_seconds())
                     ).unwrap_or_default()
                 );
             };
@@ -351,7 +351,7 @@ pub trait LoadFee: LoadBlock {
                 .await?
                 .and_then(|h| {
                     h.maybe_next_block_blob_fee(
-                        self.provider().chain_spec().blob_params_at_timestamp(h.timestamp()),
+                        self.provider().chain_spec().blob_params_at_timestamp(h.timestamp_seconds()),
                     )
                 })
                 .ok_or(EthApiError::ExcessBlobGasNotSet.into())

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -228,7 +228,7 @@ pub trait LoadPendingBlock:
         let blob_params = self
             .provider()
             .chain_spec()
-            .blob_params_at_timestamp(parent.timestamp())
+            .blob_params_at_timestamp(parent.timestamp_seconds())
             .unwrap_or_else(BlobParams::cancun);
         let mut cumulative_gas_used = 0;
         let mut sum_blob_gas_used = 0;

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -67,3 +67,5 @@ serde_json.workspace = true
 
 [features]
 js-tracer = ["revm-inspectors/js-tracer"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -85,7 +85,7 @@ impl FeeHistoryCache {
         for (block, receipts) in blocks {
             let mut fee_history_entry = FeeHistoryEntry::new(
                 block,
-                chain_spec.blob_params_at_timestamp(block.header().timestamp()),
+                chain_spec.blob_params_at_timestamp(block.timestamp_seconds()),
             );
             fee_history_entry.rewards = calculate_reward_percentiles_for_block(
                 &percentiles,
@@ -359,7 +359,7 @@ pub struct FeeHistoryEntry {
     pub header_hash: B256,
     /// Approximated rewards for the configured percentiles.
     pub rewards: Vec<u128>,
-    /// The timestamp of the block.
+    /// The timestamp of the block in seconds
     pub timestamp: u64,
     /// Blob parameters for this block.
     pub blob_params: Option<BlobParams>,
@@ -389,7 +389,8 @@ impl FeeHistoryEntry {
             header_hash: block.hash(),
             gas_limit: block.header().gas_limit(),
             rewards: Vec::new(),
-            timestamp: block.header().timestamp(),
+            // modified to use timestamp seconds here instead of ms
+            timestamp: block.timestamp_seconds(),
             blob_params,
         }
     }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -102,3 +102,5 @@ jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -92,10 +92,11 @@ where
         }
 
         // need to adjust the timestamp for the next block
+        // modified to assume timestamps are in ms
         if let Some(timestamp) = timestamp {
             evm_env.block_env.timestamp = timestamp;
         } else {
-            evm_env.block_env.timestamp += 12;
+            evm_env.block_env.timestamp += 12000;
         }
 
         if let Some(difficulty) = difficulty {
@@ -104,13 +105,15 @@ where
 
         // Validate that the bundle does not contain more than MAX_BLOB_NUMBER_PER_BLOCK blob
         // transactions.
+
+        // modify block env timestamp which is in ms to seconds
         let blob_gas_used = transactions.iter().filter_map(|tx| tx.blob_gas_used()).sum::<u64>();
         if blob_gas_used > 0 {
             let blob_params = self
                 .eth_api()
                 .provider()
                 .chain_spec()
-                .blob_params_at_timestamp(evm_env.block_env.timestamp)
+                .blob_params_at_timestamp(evm_env.block_env.timestamp / 1000)
                 .unwrap_or_else(BlobParams::cancun);
             if transactions.iter().filter_map(|tx| tx.blob_gas_used()).sum::<u64>() >
                 blob_params.max_blob_gas_per_block()

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -91,12 +91,15 @@ where
             evm_env.block_env.beneficiary = coinbase;
         }
 
+        
+
         // need to adjust the timestamp for the next block
         // modified to assume timestamps are in ms
         if let Some(timestamp) = timestamp {
             evm_env.block_env.timestamp = timestamp;
         } else {
-            evm_env.block_env.timestamp += 12000;
+            let increment: u64 = if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12000 };
+            evm_env.block_env.timestamp += increment;
         }
 
         if let Some(difficulty) = difficulty {
@@ -113,7 +116,13 @@ where
                 .eth_api()
                 .provider()
                 .chain_spec()
-                .blob_params_at_timestamp(evm_env.block_env.timestamp / 1000)
+                .blob_params_at_timestamp(
+                    if cfg!(feature = "timestamp-in-seconds") {
+                        evm_env.block_env.timestamp
+                    } else {
+                        evm_env.block_env.timestamp / 1000
+                    }
+                )
                 .unwrap_or_else(BlobParams::cancun);
             if transactions.iter().filter_map(|tx| tx.blob_gas_used()).sum::<u64>() >
                 blob_params.max_blob_gas_per_block()

--- a/crates/rpc/rpc/src/eth/helpers/block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/block.rs
@@ -40,7 +40,7 @@ where
             let block_hash = block.hash();
             let excess_blob_gas = block.excess_blob_gas();
             let timestamp = block.timestamp();
-            let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp);
+            let blob_params = self.provider().chain_spec().blob_params_at_timestamp(block.timestamp_seconds());
 
             return block
                 .body()

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -66,7 +66,7 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12),
+            timestamp: parent.timestamp().saturating_add(12000),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/rpc/rpc/src/eth/helpers/pending_block.rs
+++ b/crates/rpc/rpc/src/eth/helpers/pending_block.rs
@@ -67,7 +67,9 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12000),
+            timestamp: parent.timestamp().saturating_add(
+                if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12000 }
+            ),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -17,6 +17,8 @@ where
     >,
     Provider: BlockReader + ChainSpecProvider,
 {
+
+    // modified to assume timestamps are in ms
     async fn build_transaction_receipt(
         &self,
         tx: TransactionSigned,
@@ -31,7 +33,7 @@ where
             .await
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
-        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(meta.timestamp);
+        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(meta.timestamp / 1000);
 
         Ok(EthReceiptBuilder::new(&tx, meta, &receipt, &all_receipts, blob_params)?.build())
     }

--- a/crates/rpc/rpc/src/eth/helpers/receipt.rs
+++ b/crates/rpc/rpc/src/eth/helpers/receipt.rs
@@ -33,7 +33,13 @@ where
             .await
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
-        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(meta.timestamp / 1000);
+        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(
+            if cfg!(feature = "timestamp-in-seconds") {
+                meta.timestamp
+            } else {
+                meta.timestamp / 1000
+            }
+        );
 
         Ok(EthReceiptBuilder::new(&tx, meta, &receipt, &all_receipts, blob_params)?.build())
     }

--- a/crates/seismic/evm/Cargo.toml
+++ b/crates/seismic/evm/Cargo.toml
@@ -85,3 +85,4 @@ std = [
     "tracing/std",
 ]
 portable = ["reth-revm/portable"]
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]

--- a/crates/seismic/evm/src/build.rs
+++ b/crates/seismic/evm/src/build.rs
@@ -43,6 +43,8 @@ where
 {
     type Block = Block<SeismicTransactionSigned>;
 
+
+    // Modified under assumption that timestamp is in milliseconds in headers and also in block env.timestamp
     fn assemble_block(
         &self,
         input: BlockAssemblerInput<'_, '_, F>,
@@ -58,6 +60,7 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
+        let timestamp_seconds: u64 = timestamp / 1000;
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root = SeismicReceipt::calculate_receipt_root_no_memo(receipts);
@@ -65,26 +68,26 @@ where
 
         let withdrawals = self
             .chain_spec
-            .is_shanghai_active_at_timestamp(timestamp)
+            .is_shanghai_active_at_timestamp(timestamp_seconds)
             .then(|| ctx.withdrawals.map(|w| w.into_owned()).unwrap_or_default());
 
         let withdrawals_root =
             withdrawals.as_deref().map(|w| proofs::calculate_withdrawals_root(w));
         let requests_hash = self
             .chain_spec
-            .is_prague_active_at_timestamp(timestamp)
+            .is_prague_active_at_timestamp(timestamp_seconds)
             .then(|| requests.requests_hash());
 
         let mut excess_blob_gas = None;
         let mut blob_gas_used = None;
 
         // only determine cancun fields when active
-        if self.chain_spec.is_cancun_active_at_timestamp(timestamp) {
+        if self.chain_spec.is_cancun_active_at_timestamp(timestamp_seconds) {
             blob_gas_used =
                 Some(transactions.iter().map(|tx| tx.blob_gas_used().unwrap_or_default()).sum());
-            excess_blob_gas = if self.chain_spec.is_cancun_active_at_timestamp(parent.timestamp) {
+            excess_blob_gas = if self.chain_spec.is_cancun_active_at_timestamp(parent.timestamp_seconds()) {
                 parent.maybe_next_block_excess_blob_gas(
-                    self.chain_spec.blob_params_at_timestamp(timestamp),
+                    self.chain_spec.blob_params_at_timestamp(timestamp_seconds),
                 )
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and

--- a/crates/seismic/evm/src/build.rs
+++ b/crates/seismic/evm/src/build.rs
@@ -60,7 +60,7 @@ where
         } = input;
 
         let timestamp = evm_env.block_env.timestamp;
-        let timestamp_seconds: u64 = timestamp / 1000;
+        let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp / 1000 };  
 
         let transactions_root = proofs::calculate_transaction_root(&transactions);
         let receipts_root = SeismicReceipt::calculate_receipt_root_no_memo(receipts);

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -170,12 +170,12 @@ where
         // cancun now, we need to set the excess blob gas to the default value(0)
         let blob_excess_gas_and_price = parent
             .maybe_next_block_excess_blob_gas(
-                self.chain_spec().blob_params_at_timestamp(attributes.timestamp),
+                self.chain_spec().blob_params_at_timestamp(attributes.timestamp_seconds()),
             )
             .map(|gas| BlobExcessGasAndPrice::new(gas, spec_id >= SeismicSpecId::MERCURY));
 
         let mut basefee = parent.next_block_base_fee(
-            self.chain_spec().base_fee_params_at_timestamp(attributes.timestamp),
+            self.chain_spec().base_fee_params_at_timestamp(attributes.timestamp_seconds()),
         );
 
         let mut gas_limit = attributes.gas_limit;
@@ -186,7 +186,7 @@ where
         {
             let elasticity_multiplier = self
                 .chain_spec()
-                .base_fee_params_at_timestamp(attributes.timestamp)
+                .base_fee_params_at_timestamp(attributes.timestamp_seconds())
                 .elasticity_multiplier;
 
             // multiply the gas limit by the elasticity multiplier

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -129,4 +129,4 @@ test-utils = [
 reth-codec = [
     "reth-seismic-primitives/reth-codec",
 ]
-timestamp-in-seconds = ["reth-seismic-evm/timestamp-in-seconds", "reth-seismic-payload-builder/timestamp-in-seconds", "reth-seismic-primitives/timestamp-in-seconds", "reth-seismic-rpc/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]
+timestamp-in-seconds = ["reth-seismic-evm/timestamp-in-seconds", "reth-seismic-payload-builder/timestamp-in-seconds", "reth-seismic-primitives/timestamp-in-seconds", "reth-seismic-rpc/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds", "reth-primitives-traits/timestamp-in-seconds", "reth-node-builder/timestamp-in-seconds"]

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -129,3 +129,4 @@ test-utils = [
 reth-codec = [
     "reth-seismic-primitives/reth-codec",
 ]
+timestamp-in-seconds = ["reth-seismic-evm/timestamp-in-seconds", "reth-seismic-payload-builder/timestamp-in-seconds", "reth-seismic-primitives/timestamp-in-seconds", "reth-seismic-rpc/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -404,8 +404,11 @@ where
             DiskFileBlobStoreConfig::default().with_max_cached_entries(blob_cache_size);
 
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), custom_config)?;
+        
+        let head_timestamp_seconds: u64 = ctx.head().timestamp / 1000;
+
         let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
-            .with_head_timestamp(ctx.head().timestamp)
+            .with_head_timestamp(head_timestamp_seconds)
             .kzg_settings(ctx.kzg_settings()?)
             .with_local_transactions_config(pool_config.local_transactions_config.clone())
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -405,7 +405,7 @@ where
 
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), custom_config)?;
         
-        let head_timestamp_seconds: u64 = ctx.head().timestamp / 1000;
+        let head_timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { ctx.head().timestamp } else { ctx.head().timestamp / 1000 };  
 
         let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
             .with_head_timestamp(head_timestamp_seconds)

--- a/crates/seismic/payload/Cargo.toml
+++ b/crates/seismic/payload/Cargo.toml
@@ -51,3 +51,6 @@ reth-execution-errors.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 reth-execution-types.workspace = true
+
+[features]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/crates/seismic/payload/src/builder.rs
+++ b/crates/seismic/payload/src/builder.rs
@@ -244,14 +244,14 @@ where
     let BlockBuilderOutcome { execution_result, block, .. } = builder.finish(&state_provider)?;
 
     let requests = chain_spec
-        .is_prague_active_at_timestamp(attributes.timestamp)
+        .is_prague_active_at_timestamp(attributes.timestamp_seconds())
         .then_some(execution_result.requests);
 
     // initialize empty blob sidecars at first. If cancun is active then this will
     let mut blob_sidecars = Vec::new();
 
     // only determine cancun fields when active
-    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
+    if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp_seconds()) {
         // grab the blob sidecars from the executed txs
         blob_sidecars = pool
             .get_all_blobs_exact(

--- a/crates/seismic/primitives/Cargo.toml
+++ b/crates/seismic/primitives/Cargo.toml
@@ -152,3 +152,4 @@ arbitrary = [
     "alloy-rpc-types-eth?/arbitrary",
     "alloy-serde?/arbitrary",
 ]
+timestamp-in-seconds = ["seismic-revm/timestamp-in-seconds"]

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -96,3 +96,5 @@ client = [
     "jsonrpsee/async-client",
     "reth-rpc-eth-api/client",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds", "reth-seismic-primitives/timestamp-in-seconds"]

--- a/crates/seismic/rpc/src/eth/block.rs
+++ b/crates/seismic/rpc/src/eth/block.rs
@@ -29,6 +29,7 @@ where
         Provider: BlockReader + ChainSpecProvider<ChainSpec = ChainSpec> + HeaderProvider,
     >,
 {
+    // Modified under assumption that timestamp is in milliseconds in headers and block timestamp returns header timestamp
     async fn block_receipts(
         &self,
         block_id: BlockId,
@@ -42,7 +43,8 @@ where
             let block_hash = block.hash();
             let excess_blob_gas = block.excess_blob_gas();
             let timestamp = block.timestamp();
-            let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp);
+            let timestamp_seconds: u64 = timestamp / 1000;
+            let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp_seconds);
 
             return block
                 .body()

--- a/crates/seismic/rpc/src/eth/block.rs
+++ b/crates/seismic/rpc/src/eth/block.rs
@@ -43,7 +43,7 @@ where
             let block_hash = block.hash();
             let excess_blob_gas = block.excess_blob_gas();
             let timestamp = block.timestamp();
-            let timestamp_seconds: u64 = timestamp / 1000;
+            let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") { timestamp } else { timestamp / 1000 };  
             let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp_seconds);
 
             return block

--- a/crates/seismic/rpc/src/eth/pending_block.rs
+++ b/crates/seismic/rpc/src/eth/pending_block.rs
@@ -65,7 +65,9 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12000),
+            timestamp: parent.timestamp().saturating_add(
+                if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12000 }
+            ),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/seismic/rpc/src/eth/pending_block.rs
+++ b/crates/seismic/rpc/src/eth/pending_block.rs
@@ -64,7 +64,9 @@ where
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
     ) -> Result<<Self::Evm as reth_evm::ConfigureEvm>::NextBlockEnvCtx, Self::Error> {
         Ok(NextBlockEnvAttributes {
-            timestamp: parent.timestamp().saturating_add(12),
+            // timestamp: parent.timestamp().saturating_add(12),
+            // timestamp is in milliseconds, add 12 seconds but keep as milliseconds
+            timestamp: parent.timestamp().saturating_add(12000),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),

--- a/crates/seismic/rpc/src/eth/receipt.rs
+++ b/crates/seismic/rpc/src/eth/receipt.rs
@@ -21,6 +21,7 @@ where
         + ReceiptProvider<Receipt = SeismicReceipt>
         + ChainSpecProvider<ChainSpec = ChainSpec>,
 {
+    // Modified under assumption that timestamp is in milliseconds 
     async fn build_transaction_receipt(
         &self,
         tx: SeismicTransactionSigned,
@@ -36,7 +37,9 @@ where
             .await
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
-        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(meta.timestamp);
+
+        let timestamp_seconds: u64 = meta.timestamp / 1000;
+        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp_seconds);
 
         Ok(SeismicReceiptBuilder::new(&tx, meta, &receipt, &all_receipts, blob_params)?.build())
     }

--- a/crates/seismic/rpc/src/eth/receipt.rs
+++ b/crates/seismic/rpc/src/eth/receipt.rs
@@ -38,8 +38,13 @@ where
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
 
-        let timestamp_seconds: u64 = meta.timestamp / 1000;
-        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(timestamp_seconds);
+        let blob_params = self.provider().chain_spec().blob_params_at_timestamp(
+            if cfg!(feature = "timestamp-in-seconds") {
+                meta.timestamp
+            } else {
+                meta.timestamp / 1000
+            }
+        );
 
         Ok(SeismicReceiptBuilder::new(&tx, meta, &receipt, &all_receipts, blob_params)?.build())
     }

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -94,3 +94,5 @@ op = [
     "reth-primitives-traits/op",
 ]
 bench = []
+
+timestamp-in-seconds = ["reth-seismic-primitives/timestamp-in-seconds"]

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -168,7 +168,7 @@ where
         for (header, transactions) in inputs {
             // If we are past shanghai, then all blocks should have a withdrawal list,
             // even if empty
-            let withdrawals = if chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) {
+            let withdrawals = if chain_spec.is_shanghai_active_at_timestamp(header.timestamp_seconds()) {
                 withdrawals_cursor
                     .seek_exact(header.number())?
                     .map(|(_, w)| w.withdrawals)

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -121,6 +121,8 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
     "revm-primitives/arbitrary",
 ]
+timestamp-in-seconds = ["revm-interpreter/timestamp-in-seconds", "reth-primitives-traits/timestamp-in-seconds"]
+
 
 [[bench]]
 name = "truncate"
@@ -137,4 +139,3 @@ name = "priority"
 required-features = ["arbitrary"]
 harness = false
 
-timestamp-in-seconds = ["revm-interpreter/timestamp-in-seconds", "reth-primitives-traits/timestamp-in-seconds", "reth-execution-types/timestamp-in-seconds"]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -137,4 +137,4 @@ name = "priority"
 required-features = ["arbitrary"]
 harness = false
 
-timestamp-in-seconds = ["revm-interpreter/timestamp-in-seconds"]
+timestamp-in-seconds = ["revm-interpreter/timestamp-in-seconds", "reth-primitives-traits/timestamp-in-seconds", "reth-execution-types/timestamp-in-seconds"]

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -122,7 +122,6 @@ arbitrary = [
     "revm-primitives/arbitrary",
 ]
 
-
 [[bench]]
 name = "truncate"
 required-features = ["test-utils", "arbitrary"]
@@ -137,3 +136,5 @@ harness = false
 name = "priority"
 required-features = ["arbitrary"]
 harness = false
+
+timestamp-in-seconds = ["revm-interpreter/timestamp-in-seconds"]

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -138,10 +138,10 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
             last_seen_block_hash: latest.hash(),
             last_seen_block_number: latest.number(),
             pending_basefee: latest
-                .next_block_base_fee(chain_spec.base_fee_params_at_timestamp(latest.timestamp()))
+                .next_block_base_fee(chain_spec.base_fee_params_at_timestamp(latest.timestamp_seconds()))
                 .unwrap_or_default(),
             pending_blob_fee: latest
-                .maybe_next_block_blob_fee(chain_spec.blob_params_at_timestamp(latest.timestamp())),
+                .maybe_next_block_blob_fee(chain_spec.blob_params_at_timestamp(latest.timestamp_seconds())),
         };
         pool.set_block_info(info);
     }
@@ -320,11 +320,11 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
                 let pending_block_base_fee = new_tip
                     .header()
                     .next_block_base_fee(
-                        chain_spec.base_fee_params_at_timestamp(new_tip.timestamp()),
+                        chain_spec.base_fee_params_at_timestamp(new_tip.timestamp_seconds()),
                     )
                     .unwrap_or_default();
                 let pending_block_blob_fee = new_tip.header().maybe_next_block_blob_fee(
-                    chain_spec.blob_params_at_timestamp(new_tip.timestamp()),
+                    chain_spec.blob_params_at_timestamp(new_tip.timestamp_seconds()),
                 );
 
                 // we know all changed account in the new chain
@@ -425,10 +425,10 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
                 // fees for the next block: `tip+1`
                 let pending_block_base_fee = tip
                     .header()
-                    .next_block_base_fee(chain_spec.base_fee_params_at_timestamp(tip.timestamp()))
+                    .next_block_base_fee(chain_spec.base_fee_params_at_timestamp(tip.timestamp_seconds()))
                     .unwrap_or_default();
                 let pending_block_blob_fee = tip.header().maybe_next_block_blob_fee(
-                    chain_spec.blob_params_at_timestamp(tip.timestamp()),
+                    chain_spec.blob_params_at_timestamp(tip.timestamp_seconds()),
                 );
 
                 let first_block = blocks.first();

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -664,7 +664,7 @@ where
 
     fn on_new_head_block<T: BlockHeader>(&self, new_tip_block: &T) {
 
-        let timestamp = new_tip_block.timestamp() / 1000;
+        let timestamp = if cfg!(feature = "timestamp-in-seconds") { new_tip_block.timestamp() } else { new_tip_block.timestamp() / 1000 };
         // update all forks
         if self.chain_spec().is_shanghai_active_at_timestamp(timestamp) {
             self.fork_tracker.shanghai.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -663,25 +663,27 @@ where
     }
 
     fn on_new_head_block<T: BlockHeader>(&self, new_tip_block: &T) {
+
+        let timestamp = new_tip_block.timestamp() / 1000;
         // update all forks
-        if self.chain_spec().is_shanghai_active_at_timestamp(new_tip_block.timestamp()) {
+        if self.chain_spec().is_shanghai_active_at_timestamp(timestamp) {
             self.fork_tracker.shanghai.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
-        if self.chain_spec().is_cancun_active_at_timestamp(new_tip_block.timestamp()) {
+        if self.chain_spec().is_cancun_active_at_timestamp(timestamp) {
             self.fork_tracker.cancun.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
-        if self.chain_spec().is_prague_active_at_timestamp(new_tip_block.timestamp()) {
+        if self.chain_spec().is_prague_active_at_timestamp(timestamp) {
             self.fork_tracker.prague.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
-        if self.chain_spec().is_osaka_active_at_timestamp(new_tip_block.timestamp()) {
+        if self.chain_spec().is_osaka_active_at_timestamp(timestamp) {
             self.fork_tracker.osaka.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
         if let Some(blob_params) =
-            self.chain_spec().blob_params_at_timestamp(new_tip_block.timestamp())
+            self.chain_spec().blob_params_at_timestamp(timestamp)
         {
             self.fork_tracker
                 .max_blob_count

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -75,3 +75,5 @@ test-utils = [
     "reth-provider/test-utils",
     "reth-trie/test-utils",
 ]
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]

--- a/examples/custom-node/Cargo.toml
+++ b/examples/custom-node/Cargo.toml
@@ -65,3 +65,5 @@ arbitrary = [
     "alloy-rpc-types-engine/arbitrary",
 ]
 default = []
+
+timestamp-in-seconds = ["revm/timestamp-in-seconds", "op-revm/timestamp-in-seconds"]

--- a/examples/custom-node/src/pool.rs
+++ b/examples/custom-node/src/pool.rs
@@ -91,7 +91,7 @@ where
         let data_dir = ctx.config().datadir();
         let blob_store = DiskFileBlobStore::open(data_dir.blobstore(), Default::default())?;
         // supervisor used for interop
-        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp) &&
+        if ctx.chain_spec().is_interop_active_at_timestamp(ctx.head().timestamp_seconds()) &&
             self.supervisor_http == DEFAULT_SUPERVISOR_URL
         {
             // info!(target: "reth::cli",
@@ -106,7 +106,7 @@ where
 
         let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
             .no_eip4844()
-            .with_head_timestamp(ctx.head().timestamp)
+            .with_head_timestamp(ctx.head().timestamp_seconds())
             .kzg_settings(ctx.kzg_settings()?)
             .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
             .with_additional_tasks(

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 [features]
 ef-tests = []
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]
+
 
 [dependencies]
 seismic-alloy-genesis.workspace = true


### PR DESCRIPTION
Modified such that headers and blocks store timestamp in ms
Added timestamp_seconds() function to sealed header, sealed block, nextblockenvattributes, ethpayloadbuilderattributes, block header 
Local miner - timestamp creation in ms now to align with timestamps from CL