### PR TITLE
docs: fix incorrect block order documentation in MemoryOverlayStateProviderRef

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -40,7 +40,7 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
     ///
     /// ## Arguments
     ///
-    /// - `in_memory` - the collection of executed ancestor blocks in reverse.
+    /// - `in_memory` - the collection of executed ancestor blocks, ordered from newest to oldest.
     /// - `historical` - a historical state provider for the latest ancestor block stored in the
     ///   database.
     pub fn new(
@@ -95,8 +95,8 @@ impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N>
             }
         }
 
-        // `self.in_memory` stores executed blocks in ascending order (oldest to newest).
-        // However, `in_memory_hashes` should be constructed in descending order (newest to oldest),
+        // `self.in_memory` stores executed blocks in descending order (newest to oldest).
+        // However, `in_memory_hashes` should be constructed in ascending order (oldest to newest),
         // so we reverse the vector after collecting the hashes.
         in_memory_hashes.reverse();
 


### PR DESCRIPTION
Corrected documentation comments that incorrectly stated the block order in
in_memory vector. The blocks are stored in descending order (newest to oldest),
not ascending. Updated both the constructor parameter documentation and the
canonical_hashes_range method comment to reflect the actual behavior.