### PR TITLE
perf(hashing_storage): allocate correct vec capacity

### DIFF
--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -102,7 +102,7 @@ where
                 // Spawn the hashing task onto the global rayon pool
                 rayon::spawn(move || {
                     for (address, slot) in chunk {
-                        let mut addr_key_is_private = Vec::with_capacity(64);
+                        let mut addr_key_is_private = Vec::with_capacity(65);
                         addr_key_is_private.put_slice(keccak256(address).as_slice());
                         addr_key_is_private.put_slice(keccak256(slot.key).as_slice());
                         addr_key_is_private.put_u8(slot.value.is_private as u8);


### PR DESCRIPTION
addr_key_is_private vec was being preallocated with 64 bytes, but 65 bytes were pushed into it. Fixed it to allocate exactly 65 bytes.