### PR TITLE
chore(cargo.toml): update seismic-evm patch commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=a183d1be5769f8fc7cc4de689a6eb69f3e8f7061#a183d1be5769f8fc7cc4de689a6eb69f3e8f7061"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=aef8ee6355075dc48c376b25c2580ef3a22372f5#aef8ee6355075dc48c376b25c2580ef3a22372f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=a183d1be5769f8fc7cc4de689a6eb69f3e8f7061#a183d1be5769f8fc7cc4de689a6eb69f3e8f7061"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=aef8ee6355075dc48c376b25c2580ef3a22372f5#aef8ee6355075dc48c376b25c2580ef3a22372f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -803,6 +803,6 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
 
 # alloy-evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "a183d1be5769f8fc7cc4de689a6eb69f3e8f7061" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "a183d1be5769f8fc7cc4de689a6eb69f3e8f7061" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
 


### PR DESCRIPTION
This is a no-op change. I just force rebased the seismic branch on seismic-evm repo to clean up its history. So the commit is different but it's pointing to the exact same code (old commit kept as head of seismic-pre-rebase branch).