### PR TITLE
fix(eip1186): eth_getProof shouldnt return private slot info

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -179,10 +179,10 @@ pub struct MultiProof {
 impl MultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty() &&
-            self.branch_node_hash_masks.is_empty() &&
-            self.branch_node_tree_masks.is_empty() &&
-            self.storages.is_empty()
+        self.account_subtree.is_empty()
+            && self.branch_node_hash_masks.is_empty()
+            && self.branch_node_tree_masks.is_empty()
+            && self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -310,10 +310,10 @@ pub struct DecodedMultiProof {
 impl DecodedMultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty() &&
-            self.branch_node_hash_masks.is_empty() &&
-            self.branch_node_tree_masks.is_empty() &&
-            self.storages.is_empty()
+        self.account_subtree.is_empty()
+            && self.branch_node_hash_masks.is_empty()
+            && self.branch_node_tree_masks.is_empty()
+            && self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -629,10 +629,10 @@ impl AccountProof {
         } = proof;
         let storage_proofs = storage_proof.into_iter().map(Into::into).collect();
 
-        let (storage_root, info) = if nonce == 0 &&
-            balance.is_zero() &&
-            storage_hash.is_zero() &&
-            code_hash == KECCAK_EMPTY
+        let (storage_root, info) = if nonce == 0
+            && balance.is_zero()
+            && storage_hash.is_zero()
+            && code_hash == KECCAK_EMPTY
         {
             // Account does not exist in state. Return `None` here to prevent proof
             // verification.
@@ -785,11 +785,7 @@ impl StorageProof {
         slot: alloy_serde::JsonStorageKey,
     ) -> alloy_rpc_types_eth::EIP1186StorageProof {
         if self.is_private {
-            alloy_rpc_types_eth::EIP1186StorageProof {
-                key: slot,
-                value: U256::ZERO,
-                proof: vec![],
-            }
+            alloy_rpc_types_eth::EIP1186StorageProof { key: slot, value: U256::ZERO, proof: vec![] }
         } else {
             alloy_rpc_types_eth::EIP1186StorageProof {
                 key: slot,

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -179,10 +179,10 @@ pub struct MultiProof {
 impl MultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty()
-            && self.branch_node_hash_masks.is_empty()
-            && self.branch_node_tree_masks.is_empty()
-            && self.storages.is_empty()
+        self.account_subtree.is_empty() &&
+            self.branch_node_hash_masks.is_empty() &&
+            self.branch_node_tree_masks.is_empty() &&
+            self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -310,10 +310,10 @@ pub struct DecodedMultiProof {
 impl DecodedMultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty()
-            && self.branch_node_hash_masks.is_empty()
-            && self.branch_node_tree_masks.is_empty()
-            && self.storages.is_empty()
+        self.account_subtree.is_empty() &&
+            self.branch_node_hash_masks.is_empty() &&
+            self.branch_node_tree_masks.is_empty() &&
+            self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -629,10 +629,10 @@ impl AccountProof {
         } = proof;
         let storage_proofs = storage_proof.into_iter().map(Into::into).collect();
 
-        let (storage_root, info) = if nonce == 0
-            && balance.is_zero()
-            && storage_hash.is_zero()
-            && code_hash == KECCAK_EMPTY
+        let (storage_root, info) = if nonce == 0 &&
+            balance.is_zero() &&
+            storage_hash.is_zero() &&
+            code_hash == KECCAK_EMPTY
         {
             // Account does not exist in state. Return `None` here to prevent proof
             // verification.

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -776,12 +776,27 @@ impl StorageProof {
 
 #[cfg(feature = "eip1186")]
 impl StorageProof {
-    /// Convert into an EIP-1186 storage proof
+    /// Convert into an EIP-1186 storage proof.
+    ///
+    /// For private storage slots, returns a zeroed value and empty proof to avoid leaking
+    /// private storage information, matching the behavior of `eth_getStorageAt`.
     pub fn into_eip1186_proof(
         self,
         slot: alloy_serde::JsonStorageKey,
     ) -> alloy_rpc_types_eth::EIP1186StorageProof {
-        alloy_rpc_types_eth::EIP1186StorageProof { key: slot, value: self.value, proof: self.proof }
+        if self.is_private {
+            alloy_rpc_types_eth::EIP1186StorageProof {
+                key: slot,
+                value: U256::ZERO,
+                proof: vec![],
+            }
+        } else {
+            alloy_rpc_types_eth::EIP1186StorageProof {
+                key: slot,
+                value: self.value,
+                proof: self.proof,
+            }
+        }
     }
 
     /// Convert from an


### PR DESCRIPTION
Current behavior of eth_getProof is that it returns proofs for any slots, including private slots.
We've already decided that eth_getStorageAt should return 0x00 for private slots, so eth_getProof should follow this behavior.

### Design Options

There are 3 places where we could have prevented this:
1. (lowest level): disallow even generating proofs inside our seismic-trie fork
2. disallow generating [StorageProof](https://github.com/SeismicSystems/seismic-reth/blob/22816a566d49bdeeb7b40f696be876a7b90c67d8/crates/trie/common/src/proofs.rs#L732) structs for private slots
3. (highest-level: what this PR implements): retract slot+proof when converting StorageProof->EIP1186StorageProof (which is returned by the eth_getProof rpc)

Opting for option 3. One downside is that there is confidential information potentially sticking around in memory, which has chances of leaking to logs (see this [issue](https://github.com/SeismicSystems/seismic-trie/issues/17)) or being extracted from TEE from exploits somehow.

The upside is that we can try to make our fork as minimal as possible and leave all the low-level librairies almost stock (I think there is a world where we can even completely get rid of our seismic-trie fork).

This choice also mimicks how we implement CLOAD/CSTORE in the evm: the journal/storage layer behaves exactly the same as for sload/cload and will return any data: its the job of the evm instruction evaluation (highest-level) to enforce the privacy semantics and halt when SLOAD from the journal has returned a private slot.