### PR TITLE
chore(vscode): commit settings.json with nightly rustfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ dist/
 # Database debugging tools
 db-tools/
 
-# VSCode
-.vscode
+# VSCode (use .vscode/settings.local.json for local/private settings)
+.vscode/*
+!.vscode/settings.json
 
 # Coverage report
 lcov.info

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ]
+}


### PR DESCRIPTION
This matches CLAUDE.md recommended settings, so I think it should be committed. This way vscode will format rust files properly.