### PR TITLE
fix(txpool): cache block hashes + fix race condition on validation

### DIFF
--- a/crates/seismic/txpool/src/lib.rs
+++ b/crates/seismic/txpool/src/lib.rs
@@ -10,11 +10,13 @@
 
 use reth_transaction_pool::{CoinbaseTipOrdering, Pool, TransactionValidationTaskExecutor};
 
+mod recent_block_cache;
 mod transaction;
 mod validator;
 
+pub use recent_block_cache::{RecentBlockCache, SEISMIC_TX_RECENT_BLOCK_LOOKBACK};
 pub use transaction::SeismicPooledTransaction;
-pub use validator::{SeismicTransactionValidator, SEISMIC_TX_RECENT_BLOCK_LOOKBACK};
+pub use validator::SeismicTransactionValidator;
 
 /// Type alias for default seismic transaction pool
 pub type SeismicTransactionPool<Client, S, T = SeismicPooledTransaction> = Pool<

--- a/crates/seismic/txpool/src/recent_block_cache.rs
+++ b/crates/seismic/txpool/src/recent_block_cache.rs
@@ -1,0 +1,324 @@
+//! Bounded cache of recent block hashes for O(1) lookup during transaction validation.
+
+use alloy_primitives::B256;
+use std::collections::{HashSet, VecDeque};
+
+/// Maximum number of blocks to look back for `recent_block_hash` validation.
+pub const SEISMIC_TX_RECENT_BLOCK_LOOKBACK: u64 = 100;
+
+/// A bounded cache that stores recent block hashes with FIFO eviction.
+///
+/// Used by [`SeismicTransactionValidator`](crate::SeismicTransactionValidator) to validate
+/// `recent_block_hash` in seismic transactions without iterating over blocks via the client.
+/// Updated on each new head block via `on_new_head_block`.
+#[derive(Debug)]
+pub struct RecentBlockCache {
+    /// Set of block hashes for O(1) lookup.
+    hashes: HashSet<B256>,
+    /// Ordered queue of block hashes (front = oldest, back = newest) for FIFO eviction.
+    ordered: VecDeque<B256>,
+    /// The block number of the most recently inserted block.
+    current_block_number: u64,
+    /// Maximum number of block hashes to retain.
+    max_size: u64,
+}
+
+impl Default for RecentBlockCache {
+    fn default() -> Self {
+        Self::new(SEISMIC_TX_RECENT_BLOCK_LOOKBACK)
+    }
+}
+
+impl RecentBlockCache {
+    /// Creates a new empty cache with the given maximum size.
+    pub fn new(max_size: u64) -> Self {
+        Self {
+            hashes: HashSet::with_capacity(max_size as usize),
+            ordered: VecDeque::with_capacity(max_size as usize),
+            current_block_number: 0,
+            max_size,
+        }
+    }
+
+    /// Inserts a block hash into the cache, evicting the oldest entry if at capacity.
+    pub fn insert(&mut self, hash: B256, block_number: u64) {
+        self.current_block_number = block_number;
+        self.ordered.push_back(hash);
+        self.hashes.insert(hash);
+        while self.ordered.len() as u64 > self.max_size {
+            if let Some(old) = self.ordered.pop_front() {
+                self.hashes.remove(&old);
+            }
+        }
+    }
+
+    /// Returns `true` if the cache contains the given block hash.
+    pub fn contains(&self, hash: &B256) -> bool {
+        self.hashes.contains(hash)
+    }
+
+    /// Returns the block number of the most recently inserted block.
+    pub const fn current_block_number(&self) -> u64 {
+        self.current_block_number
+    }
+
+    /// Returns `true` if the cache is empty (no blocks have been inserted yet).
+    pub fn is_empty(&self) -> bool {
+        self.ordered.is_empty()
+    }
+
+    /// Returns the hash of the most recently inserted block, if any.
+    pub fn latest_hash(&self) -> Option<&B256> {
+        self.ordered.back()
+    }
+
+    /// Clears the cache and repopulates it from the given entries.
+    ///
+    /// Called on reorgs or any non-sequential block update, since stale hashes from
+    /// the old fork must be purged and replaced with the current canonical chain.
+    pub fn rebuild(&mut self, entries: impl Iterator<Item = (B256, u64)>) {
+        self.hashes.clear();
+        self.ordered.clear();
+        self.current_block_number = 0;
+        for (hash, number) in entries {
+            self.insert(hash, number);
+        }
+    }
+
+    /// Rebuilds the cache from the canonical chain up to the given tip block number.
+    ///
+    /// `canonical_hash_at` is a closure that returns the canonical block hash for a
+    /// given block number, or `None` if unavailable. This is used both at startup
+    /// (to populate the cache) and during reorg recovery.
+    pub fn rebuild_to_tip(&mut self, tip: u64, canonical_hash_at: impl Fn(u64) -> Option<B256>) {
+        let earliest = tip.saturating_sub(self.max_size);
+        self.rebuild((earliest..=tip).filter_map(|n| canonical_hash_at(n).map(|h| (h, n))));
+    }
+
+    /// Updates the cache with a new head block, handling gaps and reorgs.
+    ///
+    /// The cache must always reflect the canonical chain so that validation
+    /// accepts exactly the hashes that the RPC layer would return for
+    /// `eth_getBlockByNumber("latest")`. Three cases:
+    ///
+    /// 1. **Sequential block** (`new == cached + 1`): The common case during normal operation. We
+    ///    just append the new hash — O(1).
+    ///
+    /// 2. **Gap but still canonical** (`new > cached` and our latest hash is still on the canonical
+    ///    chain): Multiple blocks were produced between callbacks (e.g. between `new()` and the
+    ///    first callback, or a slow consumer). We backfill only the missing blocks.
+    ///
+    /// 3. **Stale cache** (reorg, empty, or same/lower height): The cache contains hashes from a
+    ///    fork that is no longer canonical. We clear and rebuild the full lookback window to purge
+    ///    stale fork hashes.
+    pub fn update(
+        &mut self,
+        new_hash: B256,
+        new_number: u64,
+        canonical_hash_at: impl Fn(u64) -> Option<B256>,
+    ) {
+        // Happy path: sequential block, just append
+        if new_number == self.current_block_number + 1 {
+            self.insert(new_hash, new_number);
+            return;
+        }
+
+        // Non-sequential: check if the cache is still on the canonical chain
+        if new_number > self.current_block_number && self.is_on_canonical_chain(&canonical_hash_at)
+        {
+            // Cache is canonical but behind — backfill the gap
+            let backfill_start = self.current_block_number + 1;
+            for n in backfill_start..=new_number {
+                if let Some(hash) = canonical_hash_at(n) {
+                    self.insert(hash, n);
+                }
+            }
+            return;
+        }
+
+        // Cache is stale (reorg, empty, or same/lower height) — full rebuild
+        self.rebuild_to_tip(new_number, canonical_hash_at);
+    }
+
+    /// Checks whether the cache's latest block is still on the canonical chain.
+    ///
+    /// Compares the cache's latest hash against what the canonical chain reports for
+    /// that block number. Returns `false` if the cache is empty, the block has been
+    /// reorged out, or the lookup fails.
+    fn is_on_canonical_chain(&self, canonical_hash_at: &impl Fn(u64) -> Option<B256>) -> bool {
+        let Some(&cached_hash) = self.latest_hash() else {
+            return false;
+        };
+        canonical_hash_at(self.current_block_number).is_some_and(|h| h == cached_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_and_contains() {
+        let mut cache = RecentBlockCache::new(3);
+        let h1 = B256::from([1u8; 32]);
+        let h2 = B256::from([2u8; 32]);
+
+        cache.insert(h1, 1);
+        cache.insert(h2, 2);
+
+        assert!(cache.contains(&h1));
+        assert!(cache.contains(&h2));
+        assert!(!cache.contains(&B256::from([3u8; 32])));
+        assert_eq!(cache.current_block_number(), 2);
+    }
+
+    #[test]
+    fn test_eviction() {
+        let mut cache = RecentBlockCache::new(2);
+        let h1 = B256::from([1u8; 32]);
+        let h2 = B256::from([2u8; 32]);
+        let h3 = B256::from([3u8; 32]);
+
+        cache.insert(h1, 1);
+        cache.insert(h2, 2);
+        cache.insert(h3, 3);
+
+        // h1 should be evicted
+        assert!(!cache.contains(&h1));
+        assert!(cache.contains(&h2));
+        assert!(cache.contains(&h3));
+        assert_eq!(cache.current_block_number(), 3);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut cache = RecentBlockCache::new(5);
+        assert!(cache.is_empty());
+
+        cache.insert(B256::from([1u8; 32]), 1);
+        assert!(!cache.is_empty());
+    }
+
+    #[test]
+    fn test_rebuild_replaces_all_entries() {
+        let mut cache = RecentBlockCache::new(5);
+        let h1 = B256::from([1u8; 32]);
+        let h2 = B256::from([2u8; 32]);
+        let h3 = B256::from([3u8; 32]);
+        let h4 = B256::from([4u8; 32]);
+
+        cache.insert(h1, 10);
+        cache.insert(h2, 11);
+
+        // Rebuild with completely different entries (simulates a reorg)
+        cache.rebuild(vec![(h3, 10), (h4, 11)].into_iter());
+
+        assert!(!cache.contains(&h1));
+        assert!(!cache.contains(&h2));
+        assert!(cache.contains(&h3));
+        assert!(cache.contains(&h4));
+        assert_eq!(cache.current_block_number(), 11);
+    }
+
+    /// Helper: creates a closure that maps block number -> hash for a slice of (hash, number).
+    fn mock_canonical(blocks: &[(B256, u64)]) -> impl Fn(u64) -> Option<B256> + '_ {
+        move |n| blocks.iter().find(|(_, num)| *num == n).map(|(h, _)| *h)
+    }
+
+    #[test]
+    fn test_rebuild_to_tip() {
+        let mut cache = RecentBlockCache::new(3);
+        let h8 = B256::from([8u8; 32]);
+        let h9 = B256::from([9u8; 32]);
+        let h10 = B256::from([10u8; 32]);
+
+        let blocks = [(h8, 8), (h9, 9), (h10, 10)];
+        cache.rebuild_to_tip(10, mock_canonical(&blocks));
+
+        assert!(cache.contains(&h8));
+        assert!(cache.contains(&h9));
+        assert!(cache.contains(&h10));
+        assert_eq!(cache.current_block_number(), 10);
+    }
+
+    #[test]
+    fn test_update_sequential() {
+        let mut cache = RecentBlockCache::new(5);
+        let h1 = B256::from([1u8; 32]);
+        let h2 = B256::from([2u8; 32]);
+
+        cache.insert(h1, 1);
+        // Sequential: block 2 follows block 1
+        #[allow(clippy::panic)]
+        cache.update(h2, 2, |_| panic!("should not be called for sequential"));
+
+        assert!(cache.contains(&h1));
+        assert!(cache.contains(&h2));
+        assert_eq!(cache.current_block_number(), 2);
+    }
+
+    #[test]
+    fn test_update_gap_still_canonical() {
+        let mut cache = RecentBlockCache::new(10);
+        let h5 = B256::from([5u8; 32]);
+        let h6 = B256::from([6u8; 32]);
+        let h7 = B256::from([7u8; 32]);
+        let h8 = B256::from([8u8; 32]);
+
+        cache.insert(h5, 5);
+
+        // Gap: jump from 5 to 8, but cache is still canonical
+        let blocks = [(h5, 5), (h6, 6), (h7, 7), (h8, 8)];
+        cache.update(h8, 8, mock_canonical(&blocks));
+
+        assert!(cache.contains(&h5));
+        assert!(cache.contains(&h6));
+        assert!(cache.contains(&h7));
+        assert!(cache.contains(&h8));
+        assert_eq!(cache.current_block_number(), 8);
+    }
+
+    #[test]
+    fn test_update_reorg_triggers_rebuild() {
+        let mut cache = RecentBlockCache::new(5);
+        let h5_old = B256::from([50u8; 32]);
+        let h6_old = B256::from([60u8; 32]);
+        let h7_old = B256::from([70u8; 32]);
+        let h5_new = B256::from([55u8; 32]);
+        let h6_new = B256::from([66u8; 32]);
+
+        cache.insert(h5_old, 5);
+        cache.insert(h6_old, 6);
+        cache.insert(h7_old, 7);
+
+        // Reorg: new canonical chain is shorter (tip at 6), old fork hashes are stale.
+        // new_number (6) <= current_block_number (7), so this triggers a full rebuild.
+        let blocks = [(h5_new, 5), (h6_new, 6)];
+        cache.update(h6_new, 6, mock_canonical(&blocks));
+
+        // Old fork hashes should be gone, new canonical hashes present
+        assert!(!cache.contains(&h5_old));
+        assert!(!cache.contains(&h6_old));
+        assert!(!cache.contains(&h7_old));
+        assert!(cache.contains(&h5_new));
+        assert!(cache.contains(&h6_new));
+        assert_eq!(cache.current_block_number(), 6);
+    }
+
+    #[test]
+    fn test_update_same_height_triggers_rebuild() {
+        let mut cache = RecentBlockCache::new(5);
+        let h5_old = B256::from([50u8; 32]);
+        let h5_new = B256::from([55u8; 32]);
+
+        cache.insert(h5_old, 5);
+
+        // Same height but different hash (reorg at same level)
+        let blocks = [(h5_new, 5)];
+        cache.update(h5_new, 5, mock_canonical(&blocks));
+
+        assert!(!cache.contains(&h5_old));
+        assert!(cache.contains(&h5_new));
+        assert_eq!(cache.current_block_number(), 5);
+    }
+}

--- a/crates/seismic/txpool/src/validator.rs
+++ b/crates/seismic/txpool/src/validator.rs
@@ -1,5 +1,7 @@
 //! Seismic transaction validator
 
+use crate::recent_block_cache::RecentBlockCache;
+use alloy_consensus::BlockHeader;
 use alloy_primitives::{Sealable, TxKind, B256};
 use reth_chainspec::ChainSpecProvider;
 use reth_primitives_traits::{transaction::error::InvalidTransactionError, Block};
@@ -11,16 +13,19 @@ use reth_transaction_pool::{
     EthPoolTransaction, EthTransactionValidator, TransactionOrigin,
 };
 use seismic_alloy_consensus::SeismicTxType;
-use std::{fmt, marker::PhantomData, sync::Arc};
-
-/// Maximum number of blocks to look back for `recent_block_hash` validation
-pub const SEISMIC_TX_RECENT_BLOCK_LOOKBACK: u64 = 100;
+use std::{
+    fmt,
+    marker::PhantomData,
+    sync::{Arc, RwLock},
+};
 
 /// Seismic transaction validator that adds seismic-specific validation on top of Ethereum
 /// validation.
 pub struct SeismicTransactionValidator<Client, T> {
     /// Inner Ethereum transaction validator
     inner: Arc<EthTransactionValidator<Client, T>>,
+    /// Cache of recent block hashes for O(1) validation
+    recent_blocks: RwLock<RecentBlockCache>,
     /// Phantom data for transaction type
     _pd: PhantomData<T>,
 }
@@ -29,14 +34,30 @@ impl<Client, T> fmt::Debug for SeismicTransactionValidator<Client, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SeismicTransactionValidator")
             .field("inner", &"EthTransactionValidator")
+            .field("recent_blocks", &"RwLock<RecentBlockCache>")
             .finish()
     }
 }
 
-impl<Client, T> SeismicTransactionValidator<Client, T> {
-    /// Creates a new seismic transaction validator wrapping an Ethereum validator
+impl<Client, T> SeismicTransactionValidator<Client, T>
+where
+    Client: BlockReaderIdExt,
+{
+    /// Creates a new seismic transaction validator wrapping an Ethereum validator.
+    ///
+    /// Pre-populates the recent block hash cache from the client so that validation
+    /// works immediately without a cold-start fallback.
     pub fn new(inner: EthTransactionValidator<Client, T>) -> Self {
-        Self { inner: Arc::new(inner), _pd: PhantomData }
+        let mut cache = RecentBlockCache::default();
+
+        // Populate cache from the current canonical chain
+        if let Ok(tip) = inner.client().best_block_number() {
+            cache.rebuild_to_tip(tip, |n| {
+                inner.client().header_by_number(n).ok()?.map(|h| h.hash_slow())
+            });
+        }
+
+        Self { inner: Arc::new(inner), recent_blocks: RwLock::new(cache), _pd: PhantomData }
     }
 
     /// Get a reference to the inner validator
@@ -137,60 +158,48 @@ where
     where
         B: Block,
     {
-        self.inner.on_new_head_block(new_tip_block)
+        self.inner.on_new_head_block(new_tip_block);
+
+        let mut cache = self.recent_blocks.write().unwrap_or_else(|e| e.into_inner());
+        cache.update(new_tip_block.hash(), new_tip_block.header().number(), |n| {
+            self.inner.client().header_by_number(n).ok()?.map(|h| h.hash_slow())
+        });
     }
 }
 
-impl<Client, Tx> SeismicTransactionValidator<Client, Tx>
-where
-    Client: BlockReaderIdExt,
-{
-    /// Validates that the `recent_block_hash` is in the last `SEISMIC_TX_RECENT_BLOCK_LOOKBACK`
-    /// blocks
+impl<Client, Tx> SeismicTransactionValidator<Client, Tx> {
+    /// Validates that the `recent_block_hash` field provided in a Seismic tx
+    /// is in the last `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` blocks.
+    ///
+    /// Uses an in-memory cache populated at startup and updated via `on_new_head_block`
+    /// for O(1) lookup.
     fn validate_recent_block_hash(
         &self,
         recent_block_hash: B256,
     ) -> Result<(), InvalidPoolTransactionError> {
-        // Get the current block number
-        let current_block_num = self
-            .inner
-            .client()
-            .last_block_number()
-            .map_err(|_| InvalidTransactionError::OldLegacyChainId)?;
-
-        // Calculate the earliest acceptable block number
-        let earliest_block = current_block_num.saturating_sub(SEISMIC_TX_RECENT_BLOCK_LOOKBACK);
-
-        // Check if the recent_block_hash exists in the last N blocks
-        for block_num in earliest_block..=current_block_num {
-            if let Ok(Some(header)) = self.inner.client().header_by_number(block_num) {
-                if header.hash_slow() == recent_block_hash {
-                    return Ok(());
-                }
-            }
+        let cache = self.recent_blocks.read().unwrap_or_else(|e| e.into_inner());
+        if cache.contains(&recent_block_hash) {
+            return Ok(());
         }
 
-        // If we get here, the recent_block_hash was not found in the last N blocks
         let err = SeismicTxError::RecentBlockHashNotFound {
             hash: recent_block_hash,
-            lookback: SEISMIC_TX_RECENT_BLOCK_LOOKBACK,
+            lookback: crate::SEISMIC_TX_RECENT_BLOCK_LOOKBACK,
         };
         Err(InvalidTransactionError::SeismicTx(err.to_string()).into())
     }
 
-    /// Validates that the transaction has not expired
+    /// Validates that the transaction has not expired.
+    ///
+    /// Uses the cache's `current_block_number` (updated via `on_new_head_block`) so that
+    /// both hash validation and expiration check use the same consensus-driven source.
     fn validate_expiration(
         &self,
         expires_at_block: u64,
     ) -> Result<(), InvalidPoolTransactionError> {
-        // Get the current block number
-        let current_block_num = self
-            .inner
-            .client()
-            .last_block_number()
-            .map_err(|_| InvalidTransactionError::OldLegacyChainId)?;
+        let current_block_num =
+            self.recent_blocks.read().unwrap_or_else(|e| e.into_inner()).current_block_number();
 
-        // Check if the transaction has expired
         if current_block_num > expires_at_block {
             let err = SeismicTxError::TransactionExpired {
                 current_block: current_block_num,


### PR DESCRIPTION
The txpool validator was using `last_block_number()` (persisted DB) to validate `recent_block_hash`, while the RPC serves blocks from `best_block_number()` (in-memory consensus state). This data-source mismatch caused intermittent "recent_block_hash not found in the last 100 blocks" errors when the DB lagged behind the in-memory state.

Replace the per-transaction iteration over 100 blocks with a RecentBlockCache (HashSet + VecDeque) that is:
- Pre-populated from the canonical chain on construction
- Updated on each new head block via on_new_head_block
- Smart about gaps: backfills if the cache is still canonical
- Reorg-safe: detects stale fork hashes and rebuilds from the client

This ensures the validator always agrees with what the RPC serves as "latest", handles reorgs correctly by purging stale fork hashes, and reduces validation from O(100) client calls to O(1) cache lookup.