### PR TITLE
fix: include EIP-4844 transactions in fuzz tests

### DIFF
--- a/crates/seismic/fuzz/src/tx_gen.rs
+++ b/crates/seismic/fuzz/src/tx_gen.rs
@@ -3,7 +3,7 @@
 //! Provides `Arbitrary`-derivable input types that convert to
 //! `SeismicTransaction<TxEnv>` for EVM execution fuzzing.
 
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use arbitrary::Arbitrary;
 use revm::context::TxEnv;
 use seismic_revm::transaction::abstraction::{RngMode, SeismicTransaction};
@@ -35,6 +35,12 @@ pub struct FuzzSeismicTx {
     pub tx_type_selector: u8,
     /// Whether to use execution mode for RNG.
     pub rng_mode_execution: bool,
+    /// Number of blob hashes (0-6) for EIP-4844 txs.
+    pub blob_hash_count: u8,
+    /// Seed for generating blob hash bytes.
+    pub blob_hash_seed: [u8; 32],
+    /// Max fee per blob gas for EIP-4844 txs.
+    pub max_fee_per_blob_gas: u32,
 }
 
 impl FuzzSeismicTx {
@@ -46,12 +52,28 @@ impl FuzzSeismicTx {
             TxKind::Call(Address::from(self.to_address))
         };
 
-        // 0=Legacy, 1=EIP-2930, 2=EIP-1559, 3=Seismic (0x4A)
-        let tx_type = match self.tx_type_selector % 4 {
+        // 0=Legacy, 1=EIP-2930, 2=EIP-1559, 3=EIP-4844, 4=Seismic (0x4A)
+        let tx_type = match self.tx_type_selector % 5 {
             0 => 0u8,
             1 => 1,
             2 => 2,
+            3 => 3,
             _ => 0x4A,
+        };
+
+        // Populate blob fields when tx_type is EIP-4844
+        let (blob_hashes, max_fee_per_blob_gas) = if tx_type == 3 {
+            let count = (self.blob_hash_count % 7).max(1) as usize; // 1-6 blobs
+            let hashes: Vec<B256> = (0..count)
+                .map(|i| {
+                    let mut hash = self.blob_hash_seed;
+                    hash[0] = i as u8; // vary each hash
+                    B256::from(hash)
+                })
+                .collect();
+            (hashes, self.max_fee_per_blob_gas as u128)
+        } else {
+            (Vec::new(), 0)
         };
 
         SeismicTransaction {
@@ -66,8 +88,8 @@ impl FuzzSeismicTx {
                 chain_id: Some(FUZZ_CHAIN_ID),
                 nonce: self.nonce,
                 access_list: Default::default(),
-                blob_hashes: Default::default(),
-                max_fee_per_blob_gas: Default::default(),
+                blob_hashes,
+                max_fee_per_blob_gas,
                 authorization_list: Default::default(),
                 tx_type,
             },
@@ -80,9 +102,9 @@ impl FuzzSeismicTx {
         }
     }
 
-    /// Forces tx_type to non-seismic (Legacy/EIP-2930/EIP-1559) for differential testing.
+    /// Forces tx_type to non-seismic (Legacy/EIP-2930/EIP-1559/EIP-4844) for differential testing.
     pub fn into_eth_compatible_tx(mut self) -> SeismicTransaction<TxEnv> {
-        self.tx_type_selector = self.tx_type_selector % 3;
+        self.tx_type_selector = self.tx_type_selector % 4;
         self.into_seismic_tx()
     }
 }

--- a/crates/seismic/fuzz/tests/tx_encoding.rs
+++ b/crates/seismic/fuzz/tests/tx_encoding.rs
@@ -11,7 +11,6 @@ use proptest::prelude::*;
 use proptest_arbitrary_interop::arb;
 use reth_codecs::Compact;
 use reth_seismic_primitives::SeismicTransactionSigned;
-use seismic_alloy_consensus::SeismicTxType;
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -22,7 +21,6 @@ proptest! {
     /// Feed arbitrary bytes into `Decodable2718` — must never panic.
     #[test]
     fn tx_decode_arbitrary_bytes_never_panics(data in proptest::collection::vec(any::<u8>(), 0..4096)) {
-        // Must not panic regardless of input
         let result = std::panic::catch_unwind(|| {
             let _ = SeismicTransactionSigned::decode_2718(&mut &data[..]);
         });
@@ -30,13 +28,9 @@ proptest! {
     }
 
     /// Roundtrip through EIP-2718 encoding: encode then decode must match.
+    /// Covers all tx types including EIP-4844.
     #[test]
     fn tx_roundtrip_2718(tx in arb::<SeismicTransactionSigned>()) {
-        // Skip EIP-4844 (blob transactions have known encoding limitations)
-        if tx.tx_type() == SeismicTxType::Eip4844 as u8 {
-            return Ok(());
-        }
-
         let mut encoded = Vec::new();
         tx.encode_2718(&mut encoded);
 
@@ -49,7 +43,6 @@ proptest! {
                 prop_assert_eq!(&decoded, &tx, "2718 roundtrip mismatch");
             }
             Ok(Err(e)) => {
-                // Decode error on our own encoding is a bug
                 prop_assert!(false, "Failed to decode our own encoding: {e}");
             }
             Err(_) => {
@@ -59,15 +52,9 @@ proptest! {
     }
 
     /// Roundtrip through `Compact` codec (exercises zstd compression).
+    /// Covers all tx types including EIP-4844.
     #[test]
     fn tx_roundtrip_compact(tx in arb::<SeismicTransactionSigned>()) {
-        // Skip EIP-4844
-        // TODO: Fuzz EIP-4844 transactions 
-        // if tx.tx_type() == SeismicTxType::Eip4844 as u8 {
-        //     return Ok(());
-        // }
-        println!("tx_type: {}", tx.tx_type());
-
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut buf = Vec::new();
             let len = tx.to_compact(&mut buf);
@@ -95,7 +82,6 @@ proptest! {
     #[should_panic]
     fn tx_compact_decode_arbitrary_bytes_panics_on_corrupt_data(data in proptest::collection::vec(any::<u8>(), 0..4096)) {
         let result = std::panic::catch_unwind(|| {
-            // Use an arbitrary length value for the identifier
             for len in [0, 1, 2, 3, 0x4A] {
                 let _ = SeismicTransactionSigned::from_compact(&data, len);
             }

--- a/crates/seismic/fuzz/tests/tx_encoding.rs
+++ b/crates/seismic/fuzz/tests/tx_encoding.rs
@@ -61,10 +61,12 @@ proptest! {
     /// Roundtrip through `Compact` codec (exercises zstd compression).
     #[test]
     fn tx_roundtrip_compact(tx in arb::<SeismicTransactionSigned>()) {
-        // Skip EIP-4844 (blob transactions have known encoding limitations)
-        if tx.tx_type() == SeismicTxType::Eip4844 as u8 {
-            return Ok(());
-        }
+        // Skip EIP-4844
+        // TODO: Fuzz EIP-4844 transactions 
+        // if tx.tx_type() == SeismicTxType::Eip4844 as u8 {
+        //     return Ok(());
+        // }
+        println!("tx_type: {}", tx.tx_type());
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut buf = Vec::new();


### PR DESCRIPTION
This PR introduces EIP-4844 (blob transaction) coverage to the fuzz testing framework.

## What changed

- Removed the EIP-4844 skip guards in `tx_encoding.rs` that were blocking roundtrip fuzz coverage. The `arbitrary(skip)` on the EIP-4844 variant in `seismic-alloy` has been removed upstream, so `proptest` now generates blob transactions naturally (~20% of cases). The "known encoding limitations" comment was stale — both EIP-2718 and `Compact` roundtrips pass for EIP-4844.

- Added `tx_type = 3` (EIP-4844) to the `FuzzSeismicTx` generator in `tx_gen.rs`. The selector changed from `% 4` to `% 5`, and blob-specific fields (`blob_hashes`, `max_fee_per_blob_gas`) are populated when generating blob transactions. This means EVM execution, differential, and flagged storage fuzz tests now exercise EIP-4844 code paths.

- Updated `into_eth_compatible_tx` to include EIP-4844 in differential testing (it's a standard Ethereum tx type).

## What's now fuzzed

- `tx_roundtrip_2718` — EIP-4844 encode/decode roundtrip
- `tx_roundtrip_compact` — EIP-4844 `Compact`/zstd roundtrip
- `evm_transact_never_panics` — EVM execution with `tx_type=3` and blob fields
- `differential_eth_vs_seismic_outcome` — `SeismicEvm` vs plain `revm` with blob txs