### PR TITLE
chore: bump seismic-enclave commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "seismic-enclave"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=ac5e28dac1ee8ec0e3922b010e6da072d6e784aa#ac5e28dac1ee8ec0e3922b010e6da072d6e784aa"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=f90b02f38a6190e8b2ff2d051d9043f3480cd3ac#f90b02f38a6190e8b2ff2d051d9043f3480cd3ac"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11435,6 +11435,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "sha2",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -768,7 +768,7 @@ vergen-git2 = "1.0.5"
 
 [patch.crates-io]
 # Seismic enclave
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "ac5e28dac1ee8ec0e3922b010e6da072d6e784aa" }
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
 
 # seismic-alloy-core
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }


### PR DESCRIPTION
Just a small change where enclave uses tracing instead of println so that --quiet actually doesnt show the enclave logs.
Only incorporates this one commit: https://github.com/SeismicSystems/enclave/pull/173