### PR TITLE
ci: add Claude Code PR review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 # Requires ANTHROPIC_API_KEY secret in repo Settings > Secrets and variables > Actions.
 #
-# Note: PR diffs are attacker-controlled content. The allowedTools scope is
-# restricted to read-only operations to limit impact of prompt injection.
+# Prompt injection: the action sanitizes untrusted PR content (strips HTML comments,
+# invisible chars, hidden attributes). Tools are restricted to read-only as a second layer.
 
 name: Claude Code
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,10 +1,15 @@
 # Requires ANTHROPIC_API_KEY secret in repo Settings > Secrets and variables > Actions.
+#
+# Note: PR diffs are attacker-controlled content. The allowedTools scope is
+# restricted to read-only operations to limit impact of prompt injection.
 
 name: Claude Code
 
 on:
   pull_request:
     types: [opened, synchronize]
+  # issue_comment covers PR conversation comments; pull_request_review_comment
+  # covers inline code review comments. These are distinct events and do not overlap.
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -14,34 +19,36 @@ jobs:
   claude:
     if: >
       github.event_name == 'pull_request' ||
-      contains(github.event.comment.body, '@claude')
+      (contains(github.event.comment.body, '@claude') &&
+       github.event.issue.pull_request &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      # Pin to commit SHA for supply chain safety. Tag: v1.
+      - uses: anthropics/claude-code-action@273fe825408ddced56cb02b228a74c72bed8241e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git:*)"
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             You are a PR reviewer. ONLY review the files changed in this PR.
             Use gh pr diff to see what changed. Do NOT review unchanged files.
 
             After your review, post your findings as a single PR comment using:
-            gh pr comment ${{ github.event.pull_request.number }} --body "your review"
+            gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }} --body "your review"
 
             Only post GitHub comments - do not submit review text as messages.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,79 @@
+# Requires ANTHROPIC_API_KEY secret in repo Settings > Secrets and variables > Actions.
+
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: >
+      github.event_name == 'pull_request' ||
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are a PR reviewer. ONLY review the files changed in this PR.
+            Use gh pr diff to see what changed. Do NOT review unchanged files.
+
+            After your review, post your findings as a single PR comment using:
+            gh pr comment ${{ github.event.pull_request.number }} --body "your review"
+
+            Only post GitHub comments - do not submit review text as messages.
+
+            Format your comment as:
+
+            ## PR Review Summary
+
+            ### Changes
+            Brief description of what this PR changes.
+
+            ### Blocking Issues
+            Numbered list of critical issues that must be fixed before merge.
+            Include file path and line numbers. Explain the issue and provide a fix.
+            If none, write None found.
+
+            ### Suggestions
+            Numbered list of non-blocking improvements.
+            If none, write None.
+
+            ### Positive Notes
+            Brief bullet points of what looks good.
+
+            Review focus areas:
+            - Rust safety (unsafe blocks, memory management, ownership)
+            - Security vulnerabilities (especially cryptographic and smart contract logic)
+            - Confidential txs (type 0x4a): encryption_pubkey/nonce handling, no plaintext leaks in logs/errors/RPC responses
+            - Enclave/TEE: purpose keys (tx_io_pk/tx_io_sk) never logged or serialized, mock server gated to test/dev
+            - EVM execution: SeismicSpecId mapping, confidential state isolation, SeismicReceipt correctness
+            - TxPool: RecentBlockCache block hash validation, RwLock race conditions
+            - RPC: signed_read_to_plaintext_tx coverage, purpose key endpoint safety
+            - Hardforks: Mercury activation correctness, all standard forks at genesis
+            - Codec backward compatibility, no libmdbx modifications
+            - Clippy strictness: no unwrap/expect/indexing/panic/unreachable/todo (Seismic CI enforces as errors)
+            - Performance and error handling
+            - Test coverage gaps

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
           claude_args: |
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,26 +7,27 @@ name: Claude Code PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-  # issue_comment covers PR conversation comments; pull_request_review_comment
-  # covers inline code review comments. These are distinct events and do not overlap.
+    types: [opened, synchronize, ready_for_review]
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   claude:
     if: >
-      github.event_name == 'pull_request' ||
-      (contains(github.event.comment.body, '@claude') &&
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
        github.event.issue.pull_request &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
-      issues: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,7 +3,7 @@
 # Prompt injection: the action sanitizes untrusted PR content (strips HTML comments,
 # invisible chars, hidden attributes). Tools are restricted to read-only as a second layer.
 
-name: Claude Code
+name: Claude Code PR Review
 
 on:
   pull_request:


### PR DESCRIPTION
Adds automated PR review via Claude Code GitHub Action.

Reviews trigger on every PR open/push and on `@claude` mentions in PR comments. Scoped to read-only tools (gh pr diff/view/comment, git).

Review focus includes Seismic-specific concerns:
- Confidential tx (0x4a) encryption handling and plaintext leak prevention
- Enclave/TEE purpose key safety
- EVM execution and confidential state isolation
- TxPool RecentBlockCache correctness
- RPC extension safety
- Clippy strictness (no unwrap/expect/indexing/panic/unreachable/todo)

Requires `ANTHROPIC_API_KEY` secret to be set in repo Settings > Secrets and variables > Actions.