### PR TITLE
fix: reorder imports to satisfy nightly rustfmt

### DIFF
--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -490,8 +490,8 @@ pub(super) mod serde_bincode_compat {
 mod compact {
     use super::*;
     use reth_codecs::{
-        Compact,
         __private::{modular_bitfield::prelude::*, Buf},
+        Compact,
     };
 
     impl Receipt {


### PR DESCRIPTION
## Summary
- Reorder imports in `crates/ethereum/primitives/src/receipt.rs` to satisfy nightly rustfmt's updated sorting rules (`_`-prefixed identifiers now sort before alphabetic ones)

## Test plan
- CI `cargo fmt --all --check` should pass