### PR TITLE
refactor(optimism): minimize diff with main branch (upstream)

### DIFF
--- a/crates/optimism/bin/src/lib.rs
+++ b/crates/optimism/bin/src/lib.rs
@@ -21,7 +21,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -215,10 +215,8 @@ impl OpChainSpecBuilder {
     /// [`Self::genesis`])
     pub fn build(self) -> OpChainSpec {
         let mut inner = self.inner.build();
-        inner.genesis_header = SealedHeader::seal_slow(make_op_genesis_header(
-            &inner.genesis.clone(),
-            &inner.hardforks,
-        ));
+        inner.genesis_header =
+            SealedHeader::seal_slow(make_op_genesis_header(&inner.genesis, &inner.hardforks));
 
         OpChainSpec { inner }
     }

--- a/crates/optimism/cli/src/lib.rs
+++ b/crates/optimism/cli/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/optimism/consensus/src/lib.rs
+++ b/crates/optimism/consensus/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/optimism/consensus/src/validation/isthmus.rs
+++ b/crates/optimism/consensus/src/validation/isthmus.rs
@@ -128,74 +128,73 @@ where
     Ok(())
 }
 
-// #[cfg(test)]
-// mod test {
-//     use super::*;
-//     use alloc::sync::Arc;
-//     use alloy_chains::Chain;
-//     use alloy_consensus::Header;
-//     use alloy_primitives::{keccak256, B256, U256};
-//     use core::str::FromStr;
-//     use reth_db_common::init::init_genesis;
-//     use reth_optimism_chainspec::OpChainSpecBuilder;
-//     use reth_optimism_node::OpNode;
-//     use reth_optimism_primitives::ADDRESS_L2_TO_L1_MESSAGE_PASSER;
-//     use reth_provider::{
-//         providers::BlockchainProvider, test_utils::create_test_provider_factory_with_node_types,
-//         StateWriter,
-//     };
-//     use reth_revm::db::BundleState;
-//     use reth_storage_api::StateProviderFactory;
-//     use reth_trie::{test_utils::storage_root_prehashed, HashedStorage};
-//     use reth_trie_common::HashedPostState;
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::sync::Arc;
+    use alloy_chains::Chain;
+    use alloy_consensus::Header;
+    use alloy_primitives::{keccak256, B256, U256};
+    use core::str::FromStr;
+    use reth_db_common::init::init_genesis;
+    use reth_optimism_chainspec::OpChainSpecBuilder;
+    use reth_optimism_node::OpNode;
+    use reth_optimism_primitives::ADDRESS_L2_TO_L1_MESSAGE_PASSER;
+    use reth_provider::{
+        providers::BlockchainProvider, test_utils::create_test_provider_factory_with_node_types,
+        StateWriter,
+    };
+    use reth_revm::db::BundleState;
+    use reth_storage_api::StateProviderFactory;
+    use reth_trie::{test_utils::storage_root_prehashed, HashedStorage};
+    use reth_trie_common::HashedPostState;
 
-//     #[test]
-//     fn l2tol1_message_passer_no_withdrawals() {
-//         let hashed_address = keccak256(ADDRESS_L2_TO_L1_MESSAGE_PASSER);
+    #[test]
+    fn l2tol1_message_passer_no_withdrawals() {
+        let hashed_address = keccak256(ADDRESS_L2_TO_L1_MESSAGE_PASSER);
 
-//         // create account storage
-//         let init_storage = HashedStorage::from_iter(
-//             false,
-//             [
-//                 "50000000000000000000000000000004253371b55351a08cb3267d4d265530b6",
-//                 "512428ed685fff57294d1a9cbb147b18ae5db9cf6ae4b312fa1946ba0561882e",
-//                 "51e6784c736ef8548f856909870b38e49ef7a4e3e77e5e945e0d5e6fcaa3037f",
-//             ]
-//             .into_iter()
-//             .map(|str| (B256::from_str(str).unwrap(), U256::from(1))),
-//         );
-//         let mut state = HashedPostState::default();
-//         state.storages.insert(hashed_address, init_storage.clone());
+        // create account storage
+        let init_storage = HashedStorage::from_iter(
+            false,
+            [
+                "50000000000000000000000000000004253371b55351a08cb3267d4d265530b6",
+                "512428ed685fff57294d1a9cbb147b18ae5db9cf6ae4b312fa1946ba0561882e",
+                "51e6784c736ef8548f856909870b38e49ef7a4e3e77e5e945e0d5e6fcaa3037f",
+            ]
+            .into_iter()
+            .map(|str| (B256::from_str(str).unwrap(), U256::from(1))),
+        );
+        let mut state = HashedPostState::default();
+        state.storages.insert(hashed_address, init_storage.clone());
 
-//         // init test db
-//         // note: must be empty (default) chain spec to ensure storage is empty after init
-// genesis,         // otherwise can't use `storage_root_prehashed` to determine storage root later
-//         let provider_factory = create_test_provider_factory_with_node_types::<OpNode>(Arc::new(
-//
-// OpChainSpecBuilder::default().chain(Chain::dev()).genesis(Default::default()).build(),
-//         ));
-//         let _ = init_genesis(&provider_factory).unwrap();
+        // init test db
+        // note: must be empty (default) chain spec to ensure storage is empty after init genesis,
+        // otherwise can't use `storage_root_prehashed` to determine storage root later
+        let provider_factory = create_test_provider_factory_with_node_types::<OpNode>(Arc::new(
+            OpChainSpecBuilder::default().chain(Chain::dev()).genesis(Default::default()).build(),
+        ));
+        let _ = init_genesis(&provider_factory).unwrap();
 
-//         // write account storage to database
-//         let provider_rw = provider_factory.provider_rw().unwrap();
-//         provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
-//         provider_rw.commit().unwrap();
+        // write account storage to database
+        let provider_rw = provider_factory.provider_rw().unwrap();
+        provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
+        provider_rw.commit().unwrap();
 
-//         // create block header with withdrawals root set to storage root of l2tol1-msg-passer
-//         let header = Header {
-//             withdrawals_root: Some(storage_root_prehashed(init_storage.storage)),
-//             ..Default::default()
-//         };
+        // create block header with withdrawals root set to storage root of l2tol1-msg-passer
+        let header = Header {
+            withdrawals_root: Some(storage_root_prehashed(init_storage.storage)),
+            ..Default::default()
+        };
 
-//         // create state provider factory
-//         let state_provider_factory = BlockchainProvider::new(provider_factory).unwrap();
+        // create state provider factory
+        let state_provider_factory = BlockchainProvider::new(provider_factory).unwrap();
 
-//         // validate block against existing state by passing empty state updates
-//         verify_withdrawals_root(
-//             &BundleState::default(),
-//             state_provider_factory.latest().expect("load state"),
-//             &header,
-//         )
-//         .unwrap();
-//     }
-// }
+        // validate block against existing state by passing empty state updates
+        verify_withdrawals_root(
+            &BundleState::default(),
+            state_provider_factory.latest().expect("load state"),
+            &header,
+        )
+        .unwrap();
+    }
+}

--- a/crates/optimism/evm/Cargo.toml
+++ b/crates/optimism/evm/Cargo.toml
@@ -69,7 +69,7 @@ std = [
     "reth-execution-errors/std",
     "reth-execution-types/std",
     "alloy-evm/std",
-    # "alloy-op-evm/std",
+    "alloy-op-evm/std",
     "op-revm/std",
     "reth-evm/std",
     "op-alloy-rpc-types-engine/std",

--- a/crates/optimism/evm/src/lib.rs
+++ b/crates/optimism/evm/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/optimism/hardforks/src/lib.rs
+++ b/crates/optimism/hardforks/src/lib.rs
@@ -10,7 +10,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/crates/optimism/node/src/lib.rs
+++ b/crates/optimism/node/src/lib.rs
@@ -6,7 +6,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/crates/optimism/payload/src/lib.rs
+++ b/crates/optimism/payload/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/optimism/primitives/src/lib.rs
+++ b/crates/optimism/primitives/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/crates/optimism/rpc/src/historical.rs
+++ b/crates/optimism/rpc/src/historical.rs
@@ -303,7 +303,7 @@ fn extract_block_id_for_method(method: &str, params: &Params<'_>) -> Option<Bloc
         "eth_estimateGas" |
         "eth_createAccessList" |
         "debug_traceCall" => parse_block_id_from_params(params, 1),
-        "eth_getStorageAt" | "eth_getFlaggedStorageAt" | "eth_getProof" => parse_block_id_from_params(params, 2),
+        "eth_getStorageAt" | "eth_getProof" => parse_block_id_from_params(params, 2),
         _ => None,
     }
 }

--- a/crates/optimism/rpc/src/lib.rs
+++ b/crates/optimism/rpc/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
     html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
-    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
All of the changes are purely syntactic. Just diffed the seismic branch with the main branch and removed any diff that was not necessary. Intention is to keep our diff surface smaller, to make rebasing against upstream easier and to make it easier when checking diff manually to only look at semantically relevant changes.

The optimism crate diff is now down from 15+ files to 2 files:
<img width="368" height="118" alt="image" src="https://github.com/user-attachments/assets/98ff5de1-f68b-4b41-bc21-bee36f8ac3ba" />

The remaining diff is because we forked the chainspec crate to use FlaggedStorage in our genesis files.
Claude analyzed and said we can probably get rid of this by not forking and using a SeismicChainSpec under crates/seismic, but that would require more thought/analysis and a bigger diff, so keeping for a future PR.