### PR TITLE
feat: get rid of seismic-trie fork

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [seismic]
   pull_request:
-    branches: [seismic]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.24"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b163ff4acf0eac29af05a911397cc418a76e153467b859398adc26cb9335a611"
+checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -125,7 +125,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -162,13 +162,13 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -195,7 +195,7 @@ dependencies = [
  "crc",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ dependencies = [
  "revm",
  "seismic-alloy-consensus",
  "seismic-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -325,7 +325,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -352,7 +352,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -394,7 +394,7 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -447,7 +447,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -471,16 +471,16 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -489,13 +489,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -518,7 +518,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -587,7 +587,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -644,7 +644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -747,36 +747,36 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-input"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -793,14 +793,14 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "serde",
  "winnow",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -833,9 +833,9 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -851,7 +851,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -896,8 +896,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.1"
-source = "git+https://github.com/SeismicSystems/seismic-trie.git?rev=d8425918ced1d62043c3a64b382d6fa1d8c25518#d8425918ced1d62043c3a64b382d6fa1d8c25518"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -907,22 +908,22 @@ dependencies = [
  "derive_more 2.1.1",
  "nybbles",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive 0.7.0",
  "serde",
  "smallvec",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dac443033e83b14f68fac56e8c27e76421f1253729574197ceccd06598f3ef"
+version = "1.1.0"
+source = "git+https://github.com/alloy-rs/alloy?tag=v1.1.0#78b254e4d47fca0690a4141e0f42031da8b32a09"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -992,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aquamarine"
@@ -1007,7 +1008,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1149,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1187,7 +1188,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1276,7 +1277,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1326,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "asn1_der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "assert_matches"
@@ -1338,13 +1339,12 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.36"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -1368,7 +1368,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1379,7 +1379,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1391,6 +1391,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -1417,7 +1426,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1428,9 +1437,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "az"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "backon"
@@ -1478,9 +1487,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
@@ -1504,32 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1538,7 +1527,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1547,7 +1536,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1556,7 +1545,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1598,9 +1587,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "arbitrary",
  "serde_core",
@@ -1655,11 +1644,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "num-bigint",
  "rustc-hash 2.1.1",
 ]
@@ -1671,7 +1660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -1685,7 +1674,7 @@ dependencies = [
  "fast-float2",
  "hashbrown 0.15.5",
  "icu_normalizer 1.5.0",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "intrusive-collections",
  "itertools 0.13.0",
  "num-bigint",
@@ -1705,7 +1694,7 @@ dependencies = [
  "static_assertions",
  "tap",
  "thin-vec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1731,7 +1720,7 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.15.5",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "once_cell",
  "phf 0.11.3",
  "rustc-hash 2.1.1",
@@ -1746,7 +1735,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1756,7 +1745,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -1808,7 +1797,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1864,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1882,9 +1871,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1897,7 +1886,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1908,18 +1897,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
 dependencies = [
  "arbitrary",
  "blst",
@@ -1950,13 +1939,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -1969,11 +1968,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.2",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2037,9 +2050,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2099,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2109,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2121,21 +2134,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"
@@ -2144,6 +2157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2280,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm 0.29.0",
  "unicode-segmentation",
@@ -2305,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
@@ -2346,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2404,16 +2426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2530,7 +2542,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -2546,11 +2558,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -2646,7 +2658,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2690,7 +2702,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2705,7 +2717,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2718,7 +2730,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2729,7 +2741,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2740,7 +2752,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2751,7 +2763,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2783,15 +2795,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2799,12 +2811,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2836,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -2863,7 +2875,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2874,7 +2886,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2895,7 +2907,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2905,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2934,7 +2946,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2948,7 +2960,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.113",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -3062,7 +3074,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3141,7 +3153,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3182,7 +3194,7 @@ dependencies = [
  "seismic-alloy-genesis",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -3214,6 +3226,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -3250,7 +3274,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3270,7 +3294,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3346,7 +3370,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3421,14 +3445,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3445,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3512,9 +3535,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3527,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3537,15 +3560,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3554,32 +3577,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -3593,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3605,7 +3628,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3654,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3674,9 +3696,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3701,11 +3736,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -3797,7 +3832,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3820,6 +3855,15 @@ name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3886,6 +3930,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3931,7 +3989,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3955,7 +4013,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4090,7 +4148,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4111,14 +4169,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -4127,7 +4184,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4135,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -4353,8 +4410,14 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -4410,7 +4473,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4451,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -4477,7 +4540,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -4511,14 +4574,14 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "interprocess"
-version = "2.2.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4552,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -4650,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4734,7 +4797,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -4789,10 +4852,10 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -4839,9 +4902,9 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -4855,7 +4918,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4868,7 +4931,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4890,11 +4953,11 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -4919,7 +4982,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4942,7 +5005,7 @@ dependencies = [
  "jsonrpsee-client-transport 0.26.0",
  "jsonrpsee-core 0.26.0",
  "jsonrpsee-types 0.26.0",
- "tower 0.5.2",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -4968,7 +5031,7 @@ dependencies = [
  "jsonrpsee-client-transport 0.26.0",
  "jsonrpsee-core 0.26.0",
  "jsonrpsee-types 0.26.0",
- "tower 0.5.2",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -5004,18 +5067,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5048,10 +5111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.179"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libgit2-sys"
@@ -5077,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
@@ -5095,7 +5164,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -5113,20 +5182,21 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",
@@ -5158,9 +5228,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -5260,12 +5330,9 @@ checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
 name = "mach2"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
@@ -5275,18 +5342,18 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "match-lookup"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5300,15 +5367,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -5346,14 +5413,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-derive"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
+checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "regex",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5363,7 +5429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5372,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f615e08e049bd14a44c4425415782efb9bcd479fc1e19ddeb971509074c060d0"
+checksum = "4268d87f64a752f5a651314fc683f04da10be65701ea3e721ba4d74f79163cac"
 dependencies = [
  "libc",
  "libproc",
@@ -5395,7 +5461,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.5",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "metrics",
  "ordered-float",
  "quanta",
@@ -5487,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5551,17 +5617,17 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5582,7 +5648,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5596,15 +5662,18 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -5654,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -5728,7 +5797,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5742,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -5794,7 +5863,7 @@ dependencies = [
  "derive_more 2.1.1",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5829,7 +5898,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5850,7 +5919,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5875,7 +5944,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5892,20 +5961,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -5929,7 +5992,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5961,7 +6024,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5997,7 +6060,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6065,7 +6128,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6125,9 +6188,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6194,7 +6257,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6207,7 +6270,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6230,29 +6293,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -6275,6 +6338,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -6333,9 +6402,22 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -6378,7 +6460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6403,11 +6485,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -6429,14 +6511,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6447,7 +6529,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "chrono",
  "flate2",
  "hex",
@@ -6461,9 +6543,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "procfs-core 0.18.0",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6472,7 +6554,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "chrono",
  "hex",
 ]
@@ -6483,19 +6565,19 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hex",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -6518,24 +6600,24 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.113",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6558,7 +6640,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6567,7 +6649,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "memchr",
  "unicase",
 ]
@@ -6615,8 +6697,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6637,7 +6719,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6652,16 +6734,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6671,6 +6753,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -6697,7 +6785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "serde",
 ]
 
@@ -6718,7 +6806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6727,14 +6815,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
@@ -6746,7 +6834,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6755,7 +6843,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6764,7 +6852,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -6785,7 +6873,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6820,16 +6908,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6838,7 +6926,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -6849,9 +6937,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6871,14 +6959,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6888,9 +6976,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6899,9 +6987,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
@@ -6954,7 +7042,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6962,7 +7050,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7074,9 +7162,9 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -7251,7 +7339,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "snmalloc-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "tracy-client",
 ]
@@ -7291,7 +7379,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "similar-asserts",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7320,7 +7408,7 @@ dependencies = [
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7392,7 +7480,7 @@ dependencies = [
  "strum 0.27.2",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7452,7 +7540,7 @@ dependencies = [
  "seismic-alloy-genesis",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -7494,7 +7582,7 @@ dependencies = [
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7521,7 +7609,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tracing",
  "secp256k1 0.30.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -7548,7 +7636,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7586,7 +7674,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7672,7 +7760,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "sha2",
  "sha3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7723,7 +7811,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -7753,7 +7841,7 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -7825,7 +7913,7 @@ dependencies = [
  "schnellru",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -7875,7 +7963,7 @@ dependencies = [
  "snap",
  "tempfile",
  "test-case",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -7929,7 +8017,7 @@ dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7963,7 +8051,7 @@ dependencies = [
  "serde",
  "snap",
  "test-fuzz",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7992,7 +8080,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8089,7 +8177,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8143,7 +8231,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "derive_more 2.1.1",
  "modular-bitfield",
  "proptest",
@@ -8229,7 +8317,7 @@ dependencies = [
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8241,7 +8329,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "derive_more 2.1.1",
  "rand 0.9.2",
  "reth-ethereum-primitives",
@@ -8291,7 +8379,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "seismic-alloy-genesis",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8324,7 +8412,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -8335,7 +8423,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "rand 0.9.2",
  "reth-chain-state",
  "reth-ethereum-primitives",
@@ -8351,7 +8439,7 @@ version = "1.7.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8362,7 +8450,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
 ]
@@ -8407,11 +8495,11 @@ dependencies = [
  "reth-tracing",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -8419,18 +8507,18 @@ dependencies = [
 name = "reth-libmdbx"
 version = "1.7.0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "derive_more 2.1.1",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "parking_lot",
  "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -8469,7 +8557,7 @@ dependencies = [
  "reqwest",
  "reth-tracing",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8526,7 +8614,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8553,7 +8641,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -8592,7 +8680,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -8615,7 +8703,7 @@ name = "reth-nippy-jar"
 version = "1.7.0"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode",
  "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
@@ -8623,7 +8711,7 @@ dependencies = [
  "reth-fs-util",
  "serde",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -8766,7 +8854,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -8844,7 +8932,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -8893,7 +8981,7 @@ dependencies = [
  "socket2 0.5.10",
  "tikv-jemalloc-ctl",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -8930,10 +9018,11 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "seismic-alloy-genesis",
+ "seismic-alloy-trie",
  "serde",
  "serde_json",
  "tar-no-std",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8955,7 +9044,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "modular-bitfield",
  "op-alloy-consensus",
@@ -9019,7 +9108,7 @@ dependencies = [
  "reth-errors",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -9076,7 +9165,7 @@ dependencies = [
  "alloy-trie",
  "arbitrary",
  "auto_impl",
- "bincode 1.3.3",
+ "bincode",
  "byteorder",
  "bytes",
  "derive_more 2.1.1",
@@ -9100,7 +9189,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-fuzz",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9179,7 +9268,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "rustc-hash 2.1.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9199,7 +9288,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-fuzz",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml",
 ]
 
@@ -9343,10 +9432,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "tracing-futures",
 ]
@@ -9443,10 +9532,10 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -9472,7 +9561,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "revm-context",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9527,7 +9616,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9617,7 +9706,7 @@ dependencies = [
  "seismic-revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9635,7 +9724,7 @@ dependencies = [
  "pin-project",
  "reqwest",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -9704,7 +9793,7 @@ dependencies = [
  "seismic-alloy-genesis",
  "seismic-alloy-rpc-types",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9770,7 +9859,7 @@ dependencies = [
  "seismic-alloy-genesis",
  "seismic-enclave",
  "seismic-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -9938,7 +10027,7 @@ dependencies = [
  "alloy-signer-local",
  "anyhow",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "derive_more 2.1.1",
  "enr",
@@ -10023,7 +10112,7 @@ dependencies = [
  "seismic-enclave",
  "seismic-revm",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10056,7 +10145,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
- "bincode 1.3.3",
+ "bincode",
  "codspeed-criterion-compat",
  "eyre",
  "futures-util",
@@ -10099,7 +10188,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10127,7 +10216,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-testing-utils",
  "reth-tokio-util",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10172,7 +10261,7 @@ dependencies = [
  "reth-trie-sparse",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10245,7 +10334,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10288,7 +10377,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -10356,7 +10445,7 @@ dependencies = [
  "aquamarine",
  "assert_matches",
  "auto_impl",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "codspeed-criterion-compat",
  "futures",
  "futures-util",
@@ -10388,7 +10477,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10439,7 +10528,7 @@ dependencies = [
  "alloy-serde",
  "alloy-trie",
  "arbitrary",
- "bincode 1.3.3",
+ "bincode",
  "bytes",
  "codspeed-criterion-compat",
  "derive_more 2.1.1",
@@ -10455,6 +10544,7 @@ dependencies = [
  "revm-database",
  "revm-state",
  "seismic-alloy-genesis",
+ "seismic-alloy-trie",
  "serde",
  "serde_json",
  "serde_with",
@@ -10513,7 +10603,7 @@ dependencies = [
  "reth-trie-sparse",
  "revm-primitives",
  "revm-state",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10723,7 +10813,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10778,7 +10868,7 @@ name = "revm-state"
 version = "7.0.5"
 source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -10802,7 +10892,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -10825,9 +10915,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
 dependencies = [
  "libc",
 ]
@@ -10912,15 +11002,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.113",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rug"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -10965,9 +11055,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -11014,7 +11104,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -11023,22 +11113,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -11055,17 +11145,17 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -11077,7 +11167,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -11086,7 +11176,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -11100,9 +11190,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -11129,9 +11219,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
@@ -11171,9 +11261,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -11283,25 +11373,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "bitflags 2.11.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -11309,9 +11386,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11320,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=ebc3628c9e384b1db5a41044dd32756b3e79aacb#ebc3628c9e384b1db5a41044dd32756b3e79aacb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11341,18 +11418,19 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "seismic-alloy-genesis"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=ebc3628c9e384b1db5a41044dd32756b3e79aacb#ebc3628c9e384b1db5a41044dd32756b3e79aacb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "seismic-alloy-trie",
  "serde",
  "serde_json",
 ]
@@ -11360,7 +11438,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=ebc3628c9e384b1db5a41044dd32756b3e79aacb#ebc3628c9e384b1db5a41044dd32756b3e79aacb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -11387,7 +11465,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=ebc3628c9e384b1db5a41044dd32756b3e79aacb#ebc3628c9e384b1db5a41044dd32756b3e79aacb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -11406,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=ebc3628c9e384b1db5a41044dd32756b3e79aacb#ebc3628c9e384b1db5a41044dd32756b3e79aacb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11419,6 +11497,16 @@ dependencies = [
  "seismic-enclave",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "seismic-alloy-trie"
+version = "0.0.1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?branch=feat--no-trie-fork#c0622057d4b1353d06b90408fb050eb7ad640396"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -11572,7 +11660,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11581,7 +11669,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -11612,17 +11700,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -11631,14 +11719,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11685,9 +11773,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11704,9 +11792,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -11787,21 +11875,21 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skeptic"
@@ -11820,15 +11908,15 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -11877,9 +11965,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -11899,6 +11987,15 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -11963,7 +12060,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11975,7 +12072,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11997,9 +12094,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.113"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678faa00651c9eb72dd2020cbdf275d92eccb2400d568e419efdd64838145cb4"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12009,12 +12106,12 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "1.4.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?branch=feat--no-trie-fork#690360686c2842acb8456cb632ddbfcf72c51790"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12034,7 +12131,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12079,21 +12176,21 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "log",
  "num-traits",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -12115,7 +12212,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12126,15 +12223,15 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
 [[package]]
 name = "test-fuzz"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e5c77910b1d5b469a342be541cf44933f0ad2c4b8d5acb32ee46697fd60546"
+checksum = "bdcc9e8244ec7140f52b55bb67ff77fe5e10f1e7651a9d7ca1187555344a212d"
 dependencies = [
  "serde",
  "serde_combinators",
@@ -12145,35 +12242,35 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-internal"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25f2f0ee315b130411a98570dd128dfe344bfaa0a28bf33d38f4a1fe85f39b"
+checksum = "b36ec8e4151160eb1b1d42d4691c24b5a6f3891c75d41afb343346801ab60ce5"
 dependencies = [
- "bincode 2.0.1",
  "cargo_metadata 0.19.2",
+ "postcard",
  "serde",
 ]
 
 [[package]]
 name = "test-fuzz-macro"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c03ba0a9e3e4032f94d71c85e149af147843c6f212e4ca4383542d606b04a6"
+checksum = "bd45ef045619b976f1efa036aee72b6a80dc359d800e11f9d636332ebf6655f9"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "heck",
  "itertools 0.14.0",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "test-fuzz-runtime"
-version = "7.2.5"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4ac481aa983d386e857a7be0006c2f0ef26e0c5326bbc7262f73c2891b91d"
+checksum = "91e243f304ded602493cfd77bee2f627f376bec4ea185cf8e9674b6150ea3837"
 dependencies = [
  "hex",
  "num-traits",
@@ -12199,11 +12296,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12214,18 +12311,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12279,9 +12376,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -12290,22 +12387,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -12367,9 +12464,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -12377,20 +12474,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12480,9 +12577,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -12493,7 +12590,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -12503,21 +12600,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
 dependencies = [
- "indexmap 2.12.1",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "indexmap 2.13.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -12566,14 +12663,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12592,7 +12689,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12608,7 +12705,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -12646,7 +12743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
 ]
@@ -12659,7 +12756,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12706,9 +12803,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
+checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
 dependencies = [
  "time",
  "tracing",
@@ -12818,7 +12915,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12858,7 +12955,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -12912,9 +13009,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12974,12 +13071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13018,11 +13109,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -13041,12 +13132,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -13056,9 +13147,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.7"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13071,9 +13162,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13087,12 +13178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "visibility"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13100,7 +13185,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13139,18 +13224,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13161,11 +13255,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -13174,9 +13269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13184,24 +13279,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -13215,6 +13332,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -13233,9 +13362,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13257,14 +13386,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.5",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13275,14 +13404,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13399,7 +13528,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13410,7 +13539,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13421,7 +13550,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13432,7 +13561,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13805,9 +13934,91 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "write16"
@@ -13840,7 +14051,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -13862,7 +14073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -13902,7 +14113,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -13914,28 +14125,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13955,7 +14166,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -13976,7 +14187,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14020,7 +14231,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14031,14 +14242,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.113",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"
@@ -14067,8 +14278,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-tx-macros"
-version = "1.1.0"
-source = "git+https://github.com/alloy-rs/alloy?tag=v1.1.0#78b254e4d47fca0690a4141e0f42031da8b32a09"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,14 +365,15 @@ seismic-enclave = "0.1.0"
 seismic-revm = "1.0.0"
 alloy-seismic-evm = "0.20.1"
 
-seismic-alloy-rpc-types = {version = "0.0.1", default-features = false}
-seismic-alloy-consensus = {version = "0.0.1", default-features = false}
-seismic-alloy-provider = {version = "0.0.1", default-features = false}
-seismic-alloy-genesis = {version = "0.0.1", default-features = false}
+seismic-alloy-rpc-types = { version = "0.0.1", default-features = false }
+seismic-alloy-consensus = { version = "0.0.1", default-features = false }
+seismic-alloy-provider = { version = "0.0.1", default-features = false }
+seismic-alloy-genesis = { version = "0.0.1", default-features = false }
+seismic-alloy-trie = { version = "0.0.1", default-features = false }
 
-seismic-alloy-rpc-types-engine = {version = "0.0.1", default-features = false}
-seismic-alloy-network = {version = "0.0.1", default-features = false}
-seismic-alloy-flz = {version = "0.0.1", default-features = false}
+seismic-alloy-rpc-types-engine = { version = "0.0.1", default-features = false }
+seismic-alloy-network = { version = "0.0.1", default-features = false }
+seismic-alloy-flz = { version = "0.0.1", default-features = false }
 
 alloy-json-abi = { version = "1.1.2", default-features = false } # only used by seismic rn
 
@@ -530,8 +531,12 @@ alloy-chains = { version = "0.2.5", default-features = false }
 alloy-dyn-abi = "1.3.1"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-evm = { version = "0.20.1", default-features = false }
-alloy-primitives = { version = "1.3.1", default-features = false, features = ["map-foldhash"] }
-alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
+alloy-primitives = { version = "1.3.1", default-features = false, features = [
+    "map-foldhash",
+] }
+alloy-rlp = { version = "0.3.10", default-features = false, features = [
+    "core-net",
+] }
 alloy-sol-macro = "1.3.1"
 alloy-sol-types = { version = "1.3.1", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
@@ -545,10 +550,14 @@ alloy-genesis = { version = "=1.1.0", default-features = false }
 alloy-json-rpc = { version = "=1.1.0", default-features = false }
 alloy-network = { version = "=1.1.0", default-features = false }
 alloy-network-primitives = { version = "=1.1.0", default-features = false }
-alloy-provider = { version = "=1.1.0", features = ["reqwest"], default-features = false }
+alloy-provider = { version = "=1.1.0", features = [
+    "reqwest",
+], default-features = false }
 alloy-pubsub = { version = "=1.1.0", default-features = false }
 alloy-rpc-client = { version = "=1.1.0", default-features = false }
-alloy-rpc-types = { version = "=1.1.0", features = ["eth"], default-features = false }
+alloy-rpc-types = { version = "=1.1.0", features = [
+    "eth",
+], default-features = false }
 alloy-rpc-types-admin = { version = "=1.1.0", default-features = false }
 alloy-rpc-types-anvil = { version = "=1.1.0", default-features = false }
 alloy-rpc-types-beacon = { version = "=1.1.0", default-features = false }
@@ -562,7 +571,9 @@ alloy-serde = { version = "=1.1.0", default-features = false }
 alloy-signer = { version = "=1.1.0", default-features = false }
 alloy-signer-local = { version = "=1.1.0", default-features = false }
 alloy-transport = { version = "=1.1.0" }
-alloy-transport-http = { version = "=1.1.0", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-http = { version = "=1.1.0", features = [
+    "reqwest-rustls-tls",
+], default-features = false }
 alloy-transport-ipc = { version = "=1.1.0", default-features = false }
 alloy-transport-ws = { version = "=1.1.0", default-features = false }
 
@@ -580,7 +591,10 @@ op-alloy-flz = { version = "0.13.1", default-features = false }
 either = { version = "1.15.0", default-features = false }
 aquamarine = "0.6"
 auto_impl = "1"
-backon = { version = "1.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }
+backon = { version = "1.2", default-features = false, features = [
+    "std-blocking-sleep",
+    "tokio-sleep",
+] }
 bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
@@ -601,9 +615,13 @@ itertools = { version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 lz4 = "1.28.1"
 modular-bitfield = "0.11.2"
-notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "8.0.0", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = { version = "0.4.2", default-features = false }
-once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.19", default-features = false, features = [
+    "critical-section",
+] }
 parking_lot = "0.12"
 paste = "1.0"
 rand = "0.9"
@@ -683,7 +701,10 @@ proptest-arbitrary-interop = "0.1.0"
 # crypto
 enr = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
-secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
+secp256k1 = { version = "0.30", default-features = false, features = [
+    "global-context",
+    "recovery",
+] }
 schnorrkel = { version = "0.11.2" }
 # rand 8 for secp256k1
 rand_08 = { package = "rand", version = "0.8" }
@@ -764,26 +785,33 @@ typenum = "1.15.0"
 vergen = "9.0.4"
 visibility = "0.1.1"
 walkdir = "2.3.3"
-vergen-git2 = "1.0.5"
+vergen-git2 = "9.1.0"
 
 [patch.crates-io]
 # Seismic enclave
 seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
 
 # seismic-alloy-core
-alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
-alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
+# TODO(samlaf): pointing to https://github.com/SeismicSystems/seismic-alloy-core/pull/58
+# Before merging this PR, merge that one and update the rev here.
+alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+# alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
 
 # This is needed because alloy-consensus depends on this crate for some proc macro, and the versions aren't locked together.
 # seismic-prelude -> alloy-consensus (=1.1.0 in alloy's Cargo.toml) -> alloy-tx-macros (floating version which didnt respect semver)
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
-
-alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "d8425918ced1d62043c3a64b382d6fa1d8c25518" }
 
 # revm
 revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
@@ -802,13 +830,20 @@ seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "9e26c0a55f522ad7d8cf4716d9df9d79b8116d52" }
 
 # Seismic alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
-seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+# TODO(samlaf): pointing to https://github.com/SeismicSystems/seismic-alloy/pull/80
+# Before merging this PR, merge that PR and update the rev here.
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+seismic-alloy-trie = { git = "https://github.com/SeismicSystems/seismic-alloy.git", branch = "feat--no-trie-fork" }
+# seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+# seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+# seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+# seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+# seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
 
 # alloy-evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
 alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
-

--- a/crates/engine/tree/src/tree/payload_processor/configured_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/configured_sparse_trie.rs
@@ -94,12 +94,11 @@ impl SparseTrieInterface for ConfiguredSparseTrie {
         &mut self,
         full_path: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider: P,
     ) -> SparseTrieResult<()> {
         match self {
-            Self::Serial(trie) => trie.update_leaf(full_path, value, is_private, provider),
-            Self::Parallel(trie) => trie.update_leaf(full_path, value, is_private, provider),
+            Self::Serial(trie) => trie.update_leaf(full_path, value, provider),
+            Self::Parallel(trie) => trie.update_leaf(full_path, value, provider),
         }
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -192,7 +192,6 @@ where
                 storage_trie.update_leaf(
                     slot_nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
-                    value.is_private,
                     &storage_provider,
                 )?;
             }

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -12,8 +12,11 @@ description = "EVM chain spec implementation for optimism."
 workspace = true
 
 [dependencies]
-# seismic
+# TODO(samlaf): these seismic deps shouldn't be needed here. They are needed because ChainSpec.genesis uses
+# seismic_alloy_genesis::Genesis (with FlaggedStorage), which contaminates this crate.
+# We should probably keep chainspec clean and use a separate seismic chainspec crate for seismic-related code.
 seismic-alloy-genesis.workspace = true
+seismic-alloy-trie.workspace = true
 
 # reth
 reth-chainspec.workspace = true

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -58,7 +58,8 @@ pub use reth_optimism_forks::*;
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use alloy_chains::Chain;
-use alloy_consensus::{proofs::storage_root_unhashed, BlockHeader, Header};
+use alloy_consensus::{BlockHeader, Header};
+use seismic_alloy_trie::storage_root_unhashed;
 use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -59,7 +59,6 @@ pub use reth_optimism_forks::*;
 use alloc::{boxed::Box, vec, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::{BlockHeader, Header};
-use seismic_alloy_trie::storage_root_unhashed;
 use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
@@ -73,6 +72,7 @@ use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
 use reth_network_peers::NodeRecord;
 use reth_optimism_primitives::ADDRESS_L2_TO_L1_MESSAGE_PASSER;
 use reth_primitives_traits::{sync::LazyLock, SealedHeader};
+use seismic_alloy_trie::storage_root_unhashed;
 
 /// Chain spec builder for a OP stack chain.
 #[derive(Debug, Default, From)]

--- a/crates/stateless/src/trie.rs
+++ b/crates/stateless/src/trie.rs
@@ -274,7 +274,6 @@ fn calculate_state_root(
                 storage_trie.update_leaf(
                     nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
-                    value.is_private,
                     &storage_provider,
                 )?;
             }

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -16,6 +16,8 @@ workspace = true
 alloy-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
+# TODO(samlaf): should we re-export alloy-trie from seismic-alloy-trie so consumers only need to depend on seismic-alloy-trie and not alloy-trie?
+seismic-alloy-trie.workspace = true
 alloy-consensus.workspace = true
 reth-primitives-traits.workspace = true
 reth-codecs = { workspace = true, optional = true }
@@ -76,6 +78,7 @@ std = [
     "alloy-rpc-types-eth?/std",
     "alloy-serde?/std",
     "alloy-trie/std",
+    "seismic-alloy-trie/std",
     "bytes?/std",
     "derive_more/std",
     "nybbles/std",

--- a/crates/trie/common/src/hash_builder/state.rs
+++ b/crates/trie/common/src/hash_builder/state.rs
@@ -17,8 +17,6 @@ pub struct HashBuilderState {
     pub key: Vec<u8>,
     /// The current node value.
     pub value: HashBuilderValue,
-    /// Whether the state value is private.
-    pub is_private: Option<bool>,
     /// The builder stack.
     pub stack: Vec<RlpNode>,
 
@@ -39,7 +37,6 @@ impl From<HashBuilderState> for HashBuilder {
             key: Nibbles::from_nibbles_unchecked(state.key),
             stack: state.stack,
             value: state.value,
-            is_private: state.is_private,
             state_masks: state.groups,
             tree_masks: state.tree_masks,
             hash_masks: state.hash_masks,
@@ -57,7 +54,6 @@ impl From<HashBuilder> for HashBuilderState {
             key: state.key.to_vec(),
             stack: state.stack,
             value: state.value,
-            is_private: state.is_private,
             groups: state.state_masks,
             tree_masks: state.tree_masks,
             hash_masks: state.hash_masks,
@@ -104,15 +100,6 @@ impl reth_codecs::Compact for HashBuilderState {
             len += (*item).to_compact(buf);
         }
 
-        // Serialize Seismic-specific `is_private: Option<bool>`
-        let private_byte = match self.is_private {
-            None => 0u8,
-            Some(false) => 1u8,
-            Some(true) => 2u8,
-        };
-        buf.put_u8(private_byte);
-        len += 1;
-
         buf.put_u8(self.stored_in_database as u8);
         len += 1;
 
@@ -158,15 +145,6 @@ impl reth_codecs::Compact for HashBuilderState {
             buf = rest;
         }
 
-        // Deserialize Seismic-specific `is_private`
-        let private_byte = buf.get_u8();
-        let is_private = match private_byte {
-            0 => None,
-            1 => Some(false),
-            2 => Some(true),
-            _ => panic!("Invalid byte for Option<bool>: {}", private_byte),
-        };
-
         let stored_in_database = buf.get_u8() != 0;
 
         (
@@ -174,7 +152,6 @@ impl reth_codecs::Compact for HashBuilderState {
                 key,
                 stack,
                 value,
-                is_private,
                 groups,
                 tree_masks,
                 hash_masks,
@@ -193,17 +170,6 @@ mod tests {
     #[test]
     fn hash_builder_state_regression() {
         let mut state = HashBuilderState::default();
-        state.stack.push(Default::default());
-        let mut buf = vec![];
-        let len = state.clone().to_compact(&mut buf);
-        let (decoded, _) = HashBuilderState::from_compact(&buf, len);
-        assert_eq!(state, decoded);
-    }
-
-    #[test]
-    fn hash_builder_state_regression_with_private() {
-        let mut state = HashBuilderState::default();
-        state.is_private = Some(true);
         state.stack.push(Default::default());
         let mut buf = vec![];
         let len = state.clone().to_compact(&mut buf);

--- a/crates/trie/common/src/hash_builder/state.rs
+++ b/crates/trie/common/src/hash_builder/state.rs
@@ -147,18 +147,7 @@ impl reth_codecs::Compact for HashBuilderState {
 
         let stored_in_database = buf.get_u8() != 0;
 
-        (
-            Self {
-                key,
-                stack,
-                value,
-                groups,
-                tree_masks,
-                hash_masks,
-                stored_in_database,
-            },
-            buf,
-        )
+        (Self { key, stack, value, groups, tree_masks, hash_masks, stored_in_database }, buf)
     }
 }
 

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -6,7 +6,7 @@ use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, B256Set, HashMap},
-    Address, Bytes, B256, U256,
+    Address, Bytes, FlaggedStorage, B256, U256,
 };
 use alloy_rlp::{encode_fixed_size, Decodable, EMPTY_STRING_CODE};
 use alloy_trie::{
@@ -490,8 +490,9 @@ impl StorageMultiProof {
             if let Some(last) = proof.last() {
                 if let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? {
                     if nibbles.ends_with(&leaf.key) {
-                        is_private = leaf.is_private;
-                        break 'value U256::decode(&mut &leaf.value[..])?;
+                        let fs = FlaggedStorage::decode(&mut &leaf.value[..])?;
+                        is_private = fs.is_private;
+                        break 'value fs.value;
                     }
                 }
             }
@@ -543,7 +544,8 @@ impl DecodedStorageMultiProof {
         let value = 'value: {
             if let Some(TrieNode::Leaf(leaf)) = proof.last() {
                 if nibbles.ends_with(&leaf.key) {
-                    break 'value U256::decode(&mut &leaf.value[..])?;
+                    let fs = FlaggedStorage::decode(&mut &leaf.value[..])?;
+                    break 'value fs.value;
                 }
             }
             U256::ZERO
@@ -686,8 +688,7 @@ impl AccountProof {
             ))
         };
         let nibbles = Nibbles::unpack(keccak256(self.address));
-        let account_node_is_private = false; // account nodes are always public
-        verify_proof(root, nibbles, expected, account_node_is_private, &self.proof)
+        verify_proof(root, nibbles, expected, &self.proof)
     }
 }
 
@@ -735,6 +736,7 @@ pub struct StorageProof {
     /// The hashed storage key nibbles.
     pub nibbles: Nibbles,
     /// The storage value.
+    // TODO(samlaf): should we use FlaggedStorage instead of separate value and is_private?
     pub value: U256,
     /// Whether the storge node is private.
     pub is_private: bool,
@@ -768,9 +770,12 @@ impl StorageProof {
 
     /// Verify the proof against the provided storage root.
     pub fn verify(&self, root: B256) -> Result<(), ProofVerificationError> {
-        let expected =
-            if self.value.is_zero() { None } else { Some(encode_fixed_size(&self.value).to_vec()) };
-        verify_proof(root, self.nibbles, expected, self.is_private, &self.proof)
+        let expected = if self.value.is_zero() {
+            None
+        } else {
+            Some(encode_fixed_size(&FlaggedStorage::new(self.value, self.is_private)).to_vec())
+        };
+        verify_proof(root, self.nibbles, expected, &self.proof)
     }
 }
 

--- a/crates/trie/common/src/root.rs
+++ b/crates/trie/common/src/root.rs
@@ -1,8 +1,11 @@
 //! Common root computation functions.
 
-// Re-export for convenience.
+// Re-export state root functions from upstream (unchanged).
 #[doc(inline)]
 pub use alloy_trie::root::{
-    state_root, state_root_ref_unhashed, state_root_unhashed, state_root_unsorted, storage_root,
-    storage_root_unhashed, storage_root_unsorted,
+    state_root, state_root_ref_unhashed, state_root_unhashed, state_root_unsorted,
 };
+
+// Re-export FlaggedStorage-aware storage root functions from seismic-alloy-trie.
+#[doc(inline)]
+pub use seismic_alloy_trie::{storage_root, storage_root_unhashed, storage_root_unsorted};

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -312,11 +312,7 @@ mod tests {
         let tx = db.tx().expect("failed to create transaction");
         assert_eq!(
             StateRoot::overlay_root(&tx, post_state).unwrap(),
-            // If we had the same state root calculation as ethereum when all values are public:
-            /*
             hex!("b464525710cafcf5d4044ac85b72c08b1e76231b8d91f288fe438cc41d8eaafd")
-            */
-            hex!("64f7822621afd8a66d71e233b48e945c101ab97334e19398422f22c3fae72223")
         );
     }
 }

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -431,10 +431,7 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(Nibbles::unpack(key6), &encode_account(account6, None));
 
     // Populate account & storage trie DB tables
-    /*
     let expected_root = b256!("0x72861041bc90cd2f93777956f058a545412b56de79af5eb6b8075fe2eabbe015");
-    */
-    let expected_root = b256!("0xf7eac2e1715b2cf20e7d731df7a6cadf6602bac6f66de747c7eb929930c3e976");
     let computed_expected_root: B256 = triehash::trie_root::<KeccakHasher, _, _, _>([
         (key1, encode_account(account1, None)),
         (key2, encode_account(account2, None)),
@@ -485,12 +482,8 @@ fn account_and_storage_trie() {
     let mut prefix_set = PrefixSetMut::default();
     prefix_set.insert(Nibbles::unpack(key4b));
 
-    /*
     let expected_state_root =
         b256!("0x8e263cd4eefb0c3cbbb14e5541a66a755cad25bcfab1e10dd9d706263e811b28");
-    */
-    let expected_state_root =
-        b256!("0x96372312afd49741fe2e31097b80e1f5f7f9dbb23ad662099c797cb44bf88a12");
     let (root, trie_updates) = StateRoot::from_tx(tx.tx_ref())
         .with_prefix_sets(TriePrefixSets {
             account_prefix_set: prefix_set.freeze(),

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -348,7 +348,6 @@ fn storage_root_regression() {
 
 #[test]
 fn account_and_storage_trie() {
-    let account_is_private = false; // accounts are always public
     let ether = U256::from(1e18);
     let storage = BTreeMap::from(
         [
@@ -376,7 +375,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key1),
         &encode_account(account1, None),
-        account_is_private,
     );
 
     // Some address whose hash starts with 0xB040
@@ -389,7 +387,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key2),
         &encode_account(account2, None),
-        account_is_private,
     );
 
     // Some address whose hash starts with 0xB041
@@ -424,7 +421,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key3),
         &encode_account(account3, Some(account3_storage_root)),
-        account_is_private,
     );
 
     let key4a = b256!("0xB1A0000000000000000000000000000000000000000000000000000000000000");
@@ -433,7 +429,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key4a),
         &encode_account(account4a, None),
-        account_is_private,
     );
 
     let key5 = b256!("0xB310000000000000000000000000000000000000000000000000000000000000");
@@ -442,7 +437,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key5),
         &encode_account(account5, None),
-        account_is_private,
     );
 
     let key6 = b256!("0xB340000000000000000000000000000000000000000000000000000000000000");
@@ -451,7 +445,6 @@ fn account_and_storage_trie() {
     hash_builder.add_leaf(
         Nibbles::unpack(key6),
         &encode_account(account6, None),
-        account_is_private,
     );
 
     // Populate account & storage trie DB tables
@@ -761,7 +754,7 @@ fn extension_node_storage_trie<N: ProviderNodeTypes>(
         hashed_storage
             .upsert(hashed_address, &StorageEntry { key: B256::new(key), value })
             .unwrap();
-        hb.add_leaf(Nibbles::unpack(key), &alloy_rlp::encode_fixed_size(&value), value.is_private);
+        hb.add_leaf(Nibbles::unpack(key), &alloy_rlp::encode_fixed_size(&value));
     }
 
     let root = hb.root();
@@ -788,7 +781,7 @@ fn extension_node_trie<N: ProviderNodeTypes>(
         hex!("3100000000000000000000000000000000000000000000000000000000000000"),
     ] {
         hashed_accounts.upsert(B256::new(key), &a).unwrap();
-        hb.add_leaf(Nibbles::unpack(key), &val, false); // account leaves are always public
+        hb.add_leaf(Nibbles::unpack(key), &val);
     }
 
     hb.root()

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -372,10 +372,7 @@ fn account_and_storage_trie() {
     let key1 = b256!("0xb000000000000000000000000000000000000000000000000000000000000000");
     let account1 = Account { nonce: 0, balance: U256::from(3).mul(ether), bytecode_hash: None };
     hashed_account_cursor.upsert(key1, &account1).unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key1),
-        &encode_account(account1, None),
-    );
+    hash_builder.add_leaf(Nibbles::unpack(key1), &encode_account(account1, None));
 
     // Some address whose hash starts with 0xB040
     let address2 = address!("0x7db3e81b72d2695e19764583f6d219dbee0f35ca");
@@ -384,10 +381,7 @@ fn account_and_storage_trie() {
     assert_eq!(key2[1], 0x40);
     let account2 = Account { nonce: 0, balance: ether, ..Default::default() };
     hashed_account_cursor.upsert(key2, &account2).unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key2),
-        &encode_account(account2, None),
-    );
+    hash_builder.add_leaf(Nibbles::unpack(key2), &encode_account(account2, None));
 
     // Some address whose hash starts with 0xB041
     let address3 = address!("0x16b07afd1c635f77172e842a000ead9a2a222459");
@@ -418,34 +412,23 @@ fn account_and_storage_trie() {
             .unwrap();
     }
     let account3_storage_root = StorageRoot::from_tx(tx.tx_ref(), address3).root().unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key3),
-        &encode_account(account3, Some(account3_storage_root)),
-    );
+    hash_builder
+        .add_leaf(Nibbles::unpack(key3), &encode_account(account3, Some(account3_storage_root)));
 
     let key4a = b256!("0xB1A0000000000000000000000000000000000000000000000000000000000000");
     let account4a = Account { nonce: 0, balance: U256::from(4).mul(ether), ..Default::default() };
     hashed_account_cursor.upsert(key4a, &account4a).unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key4a),
-        &encode_account(account4a, None),
-    );
+    hash_builder.add_leaf(Nibbles::unpack(key4a), &encode_account(account4a, None));
 
     let key5 = b256!("0xB310000000000000000000000000000000000000000000000000000000000000");
     let account5 = Account { nonce: 0, balance: U256::from(8).mul(ether), ..Default::default() };
     hashed_account_cursor.upsert(key5, &account5).unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key5),
-        &encode_account(account5, None),
-    );
+    hash_builder.add_leaf(Nibbles::unpack(key5), &encode_account(account5, None));
 
     let key6 = b256!("0xB340000000000000000000000000000000000000000000000000000000000000");
     let account6 = Account { nonce: 0, balance: U256::from(1).mul(ether), ..Default::default() };
     hashed_account_cursor.upsert(key6, &account6).unwrap();
-    hash_builder.add_leaf(
-        Nibbles::unpack(key6),
-        &encode_account(account6, None),
-    );
+    hash_builder.add_leaf(Nibbles::unpack(key6), &encode_account(account6, None));
 
     // Populate account & storage trie DB tables
     /*

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -310,11 +310,9 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(decoded_storage_multiproof.root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_address),
                         &account_rlp,
-                        is_private,
                     );
 
                     // We might be adding leaves that are not necessarily our proof targets.

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -310,10 +310,7 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(decoded_storage_multiproof.root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    hash_builder.add_leaf(
-                        Nibbles::unpack(hashed_address),
-                        &account_rlp,
-                    );
+                    hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
 
                     // We might be adding leaves that are not necessarily our proof targets.
                     if targets.contains_key(&hashed_address) {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -215,10 +215,7 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(storage_root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    hash_builder.add_leaf(
-                        Nibbles::unpack(hashed_address),
-                        &account_rlp,
-                    );
+                    hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
                 }
             }
         }

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -215,11 +215,9 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(storage_root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_address),
                         &account_rlp,
-                        is_private,
                     );
                 }
             }

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -222,8 +222,8 @@ impl SparseTrieInterface for ParallelSparseTrie {
             // rayon's `zip` to be happy.
             let node_groups: Vec<_> = lower_nodes
                 .chunk_by(|node_a, node_b| {
-                    SparseSubtrieType::from_path(&node_a.path)
-                        == SparseSubtrieType::from_path(&node_b.path)
+                    SparseSubtrieType::from_path(&node_a.path) ==
+                        SparseSubtrieType::from_path(&node_b.path)
                 })
                 .collect();
 
@@ -1319,8 +1319,8 @@ impl ParallelSparseTrie {
 
         for (index, subtrie) in self.lower_subtries.iter_mut().enumerate() {
             if let Some(subtrie) = subtrie.take_revealed_if(|subtrie| {
-                prefix_set.contains(&subtrie.path)
-                    || subtrie.nodes.get(&subtrie.path).is_some_and(|n| n.hash().is_none())
+                prefix_set.contains(&subtrie.path) ||
+                    subtrie.nodes.get(&subtrie.path).is_some_and(|n| n.hash().is_none())
             }) {
                 let prefix_set = if prefix_set.all() {
                     unchanged_prefix_set = PrefixSetMut::all();
@@ -1763,8 +1763,8 @@ impl SparseSubtrie {
                                 // node.
                                 hash: Some(*hash),
                                 store_in_db_trie: Some(
-                                    masks.hash_mask.is_some_and(|mask| !mask.is_empty())
-                                        || masks.tree_mask.is_some_and(|mask| !mask.is_empty()),
+                                    masks.hash_mask.is_some_and(|mask| !mask.is_empty()) ||
+                                        masks.tree_mask.is_some_and(|mask| !mask.is_empty()),
                                 ),
                             });
                         }
@@ -1840,9 +1840,9 @@ impl SparseSubtrie {
                     // Leaf node already exists.
                     SparseNode::Leaf { .. } => {}
                     // All other node types can't be handled.
-                    node @ (SparseNode::Empty
-                    | SparseNode::Extension { .. }
-                    | SparseNode::Branch { .. }) => {
+                    node @ (SparseNode::Empty |
+                    SparseNode::Extension { .. } |
+                    SparseNode::Branch { .. }) => {
                         return Err(SparseTrieErrorKind::Reveal {
                             path: *entry.key(),
                             node: Box::new(node.clone()),
@@ -2185,8 +2185,8 @@ impl SparseSubtrieInner {
                                 store_in_db_trie
                             } else {
                                 // A blinded node has the tree mask bit set
-                                child_node_type.is_hash()
-                                    && branch_node_tree_masks
+                                child_node_type.is_hash() &&
+                                    branch_node_tree_masks
                                         .get(&path)
                                         .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
                             };
@@ -2198,11 +2198,11 @@ impl SparseSubtrieInner {
                             // is a blinded node that has its hash mask bit set according to the
                             // database, set the hash mask bit and save the hash.
                             let hash = child.as_hash().filter(|_| {
-                                child_node_type.is_branch()
-                                    || (child_node_type.is_hash()
-                                        && branch_node_hash_masks
-                                            .get(&path)
-                                            .is_some_and(|mask| mask.is_bit_set(last_child_nibble)))
+                                child_node_type.is_branch() ||
+                                    (child_node_type.is_hash() &&
+                                        branch_node_hash_masks.get(&path).is_some_and(
+                                            |mask| mask.is_bit_set(last_child_nibble),
+                                        ))
                             });
                             if let Some(hash) = hash {
                                 hash_mask.set_bit(last_child_nibble);
@@ -2269,15 +2269,15 @@ impl SparseSubtrieInner {
                         );
                         update_actions
                             .push(SparseTrieUpdatesAction::InsertUpdated(path, branch_node));
-                    } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty())
-                        || branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
+                    } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty()) ||
+                        branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
                     {
                         // If new tree and hash masks are empty, but previously they weren't, we
                         // need to remove the node update and add the node itself to the list of
                         // removed nodes.
                         update_actions.push(SparseTrieUpdatesAction::InsertRemoved(path));
-                    } else if branch_node_tree_masks.get(&path).is_none_or(|mask| mask.is_empty())
-                        && branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
+                    } else if branch_node_tree_masks.get(&path).is_none_or(|mask| mask.is_empty()) &&
+                        branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
                     {
                         // If new tree and hash masks are empty, and they were previously empty
                         // as well, we need to remove the node update.

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -159,7 +159,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
     fn reveal_nodes(&mut self, mut nodes: Vec<RevealedSparseNode>) -> SparseTrieResult<()> {
         if nodes.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         // Sort nodes first by their subtrie, and secondarily by their path. This allows for
@@ -222,8 +222,8 @@ impl SparseTrieInterface for ParallelSparseTrie {
             // rayon's `zip` to be happy.
             let node_groups: Vec<_> = lower_nodes
                 .chunk_by(|node_a, node_b| {
-                    SparseSubtrieType::from_path(&node_a.path) ==
-                        SparseSubtrieType::from_path(&node_b.path)
+                    SparseSubtrieType::from_path(&node_a.path)
+                        == SparseSubtrieType::from_path(&node_b.path)
                 })
                 .collect();
 
@@ -264,7 +264,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                         // Reveal each node in the subtrie, returning early on any errors
                         let res = subtrie.reveal_node(node.path, &node.node, node.masks);
                         if res.is_err() {
-                            return (subtrie_idx, subtrie, res)
+                            return (subtrie_idx, subtrie, res);
                         }
                     }
                     (subtrie_idx, subtrie, Ok(()))
@@ -293,14 +293,13 @@ impl SparseTrieInterface for ParallelSparseTrie {
         &mut self,
         full_path: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider: P,
     ) -> SparseTrieResult<()> {
         self.prefix_set.insert(full_path);
         let existing = self.upper_subtrie.inner.values.insert(full_path, value.clone());
         if existing.is_some() {
             // upper trie structure unchanged, return immediately
-            return Ok(())
+            return Ok(());
         }
 
         let retain_updates = self.updates_enabled();
@@ -325,12 +324,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         {
             // Traverse the next node, keeping track of any changed nodes and the next step in the
             // trie
-            match self.upper_subtrie.update_next_node(
-                current,
-                &full_path,
-                is_private,
-                retain_updates,
-            )? {
+            match self.upper_subtrie.update_next_node(current, &full_path, retain_updates)? {
                 LeafUpdateStep::Continue { next_node } => {
                     next = Some(next_node);
                 }
@@ -367,7 +361,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                                 return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                                     path: reveal_path,
                                 }
-                                .into())
+                                .into());
                             }
                         }
                     }
@@ -384,7 +378,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         for node_path in &new_nodes {
             // Skip nodes that belong in the upper subtrie
             if SparseSubtrieType::path_len_is_upper(node_path.len()) {
-                continue
+                continue;
             }
 
             let node =
@@ -439,7 +433,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
             // If we didn't update the target leaf, we need to call update_leaf on the subtrie
             // to ensure that the leaf is updated correctly.
-            subtrie.update_leaf(full_path, value, provider, retain_updates, is_private)?;
+            subtrie.update_leaf(full_path, value, provider, retain_updates)?;
         }
 
         Ok(())
@@ -584,7 +578,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
         // here, all remaining logic is related to the ancestors of the leaf.
         if leaf_path.is_empty() {
             self.upper_subtrie.nodes.insert(leaf_path, SparseNode::Empty);
-            return Ok(())
+            return Ok(());
         }
 
         // If there is a parent branch node (very likely, unless the leaf is at the root) execute
@@ -649,7 +643,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                                 return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                                     path: remaining_child_path,
                                 }
-                                .into())
+                                .into());
                             }
                         }
                         node => node,
@@ -860,7 +854,7 @@ impl SparseTrieInterface for ParallelSparseTrie {
                     path: *full_path,
                     expected: expected_value.cloned(),
                     actual: actual_value.clone(),
-                })
+                });
         }
 
         // If the value does not exist in the `values` map, then this means that the leaf either:
@@ -1010,31 +1004,31 @@ impl ParallelSparseTrie {
                 found_full_path.extend(key);
 
                 if &found_full_path == leaf_full_path {
-                    return FindNextToLeafOutcome::Found
+                    return FindNextToLeafOutcome::Found;
                 }
                 FindNextToLeafOutcome::NotFound
             }
             SparseNode::Extension { key, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
                 child_path.extend(key);
 
                 if !leaf_full_path.starts_with(&child_path) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
                 FindNextToLeafOutcome::ContinueFrom(child_path)
             }
             SparseNode::Branch { state_mask, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let nibble = leaf_full_path.get_unchecked(from_path.len());
                 if !state_mask.is_bit_set(nibble) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
@@ -1142,10 +1136,10 @@ impl ParallelSparseTrie {
             // If the only child is a leaf node, we downgrade the branch node into a
             // leaf node, prepending the nibble to the key, and delete the old
             // child.
-            SparseNode::Leaf { key, is_private, .. } => {
+            SparseNode::Leaf { key, .. } => {
                 let mut new_key = Nibbles::from_nibbles_unchecked([remaining_child_nibble]);
                 new_key.extend(key);
-                (SparseNode::new_leaf(new_key, *is_private), true)
+                (SparseNode::new_leaf(new_key), true)
             }
             // If the only child node is an extension node, we downgrade the branch
             // node into an even longer extension node, prepending the nibble to the
@@ -1192,10 +1186,10 @@ impl ParallelSparseTrie {
             // followed by a leaf node in a complete trie, it's possible here because we
             // could have downgraded the extension node's child into a leaf node from a
             // branch in a previous call to `branch_changes_on_leaf_removal`.
-            SparseNode::Leaf { key, is_private, .. } => {
+            SparseNode::Leaf { key, .. } => {
                 let mut new_key = *parent_key;
                 new_key.extend(key);
-                Some(SparseNode::new_leaf(new_key, *is_private))
+                Some(SparseNode::new_leaf(new_key))
             }
             // Similar to the leaf node, for an extension node, we collapse them into one
             // extension node, extending the key.
@@ -1325,8 +1319,8 @@ impl ParallelSparseTrie {
 
         for (index, subtrie) in self.lower_subtries.iter_mut().enumerate() {
             if let Some(subtrie) = subtrie.take_revealed_if(|subtrie| {
-                prefix_set.contains(&subtrie.path) ||
-                    subtrie.nodes.get(&subtrie.path).is_some_and(|n| n.hash().is_none())
+                prefix_set.contains(&subtrie.path)
+                    || subtrie.nodes.get(&subtrie.path).is_some_and(|n| n.hash().is_none())
             }) {
                 let prefix_set = if prefix_set.all() {
                     unchanged_prefix_set = PrefixSetMut::all();
@@ -1350,7 +1344,7 @@ impl ParallelSparseTrie {
                             // If we're past the subtrie path, we're done with this subtrie. Do not
                             // advance the iterator, the next key will be processed either by the
                             // next subtrie or inserted into the unchanged prefix set.
-                            break
+                            break;
                         }
                     }
                     PrefixSetMut::from(new_prefix_set)
@@ -1530,19 +1524,18 @@ impl SparseSubtrie {
         value: Vec<u8>,
         provider: impl TrieNodeProvider,
         retain_updates: bool,
-        is_private: bool,
     ) -> SparseTrieResult<()> {
         debug_assert!(full_path.starts_with(&self.path));
         let existing = self.inner.values.insert(full_path, value);
         if existing.is_some() {
             // trie structure unchanged, return immediately
-            return Ok(())
+            return Ok(());
         }
 
         // Here we are starting at the root of the subtrie, and traversing from there.
         let mut current = Some(self.path);
         while let Some(current_path) = current {
-            match self.update_next_node(current_path, &full_path, is_private, retain_updates)? {
+            match self.update_next_node(current_path, &full_path, retain_updates)? {
                 LeafUpdateStep::Continue { next_node } => {
                     current = Some(next_node);
                 }
@@ -1576,7 +1569,7 @@ impl SparseSubtrie {
                                 return Err(SparseTrieErrorKind::NodeNotFoundInProvider {
                                     path: reveal_path,
                                 }
-                                .into())
+                                .into());
                             }
                         }
                     }
@@ -1602,7 +1595,6 @@ impl SparseSubtrie {
         &mut self,
         mut current: Nibbles,
         path: &Nibbles,
-        is_private: bool,
         retain_updates: bool,
     ) -> SparseTrieResult<LeafUpdateStep> {
         debug_assert!(path.starts_with(&self.path));
@@ -1616,7 +1608,7 @@ impl SparseSubtrie {
                 // We need to insert the node with a different path and key depending on the path of
                 // the subtrie.
                 let path = path.slice(self.path.len()..);
-                *node = SparseNode::new_leaf(path, is_private);
+                *node = SparseNode::new_leaf(path);
                 Ok(LeafUpdateStep::complete_with_insertions(vec![current], None))
             }
             SparseNode::Hash(hash) => {
@@ -1651,14 +1643,9 @@ impl SparseSubtrie {
                         path.get_unchecked(common),
                     ),
                 );
-                self.nodes.insert(
-                    new_leaf_path,
-                    SparseNode::new_leaf(path.slice(common + 1..), is_private),
-                );
-                self.nodes.insert(
-                    existing_leaf_path,
-                    SparseNode::new_leaf(current.slice(common + 1..), is_private),
-                );
+                self.nodes.insert(new_leaf_path, SparseNode::new_leaf(path.slice(common + 1..)));
+                self.nodes
+                    .insert(existing_leaf_path, SparseNode::new_leaf(current.slice(common + 1..)));
 
                 Ok(LeafUpdateStep::complete_with_insertions(
                     vec![branch_path, new_leaf_path, existing_leaf_path],
@@ -1691,7 +1678,7 @@ impl SparseSubtrie {
                     self.nodes.insert(branch_path, branch);
 
                     // create new leaf
-                    let new_leaf = SparseNode::new_leaf(path.slice(common + 1..), is_private);
+                    let new_leaf = SparseNode::new_leaf(path.slice(common + 1..));
                     self.nodes.insert(new_leaf_path, new_leaf);
 
                     let mut inserted_nodes = vec![branch_path, new_leaf_path];
@@ -1704,7 +1691,10 @@ impl SparseSubtrie {
                         inserted_nodes.push(ext_path);
                     }
 
-                    return Ok(LeafUpdateStep::complete_with_insertions(inserted_nodes, reveal_path))
+                    return Ok(LeafUpdateStep::complete_with_insertions(
+                        inserted_nodes,
+                        reveal_path,
+                    ));
                 }
 
                 Ok(LeafUpdateStep::continue_with(current))
@@ -1714,9 +1704,9 @@ impl SparseSubtrie {
                 current.push_unchecked(nibble);
                 if !state_mask.is_bit_set(nibble) {
                     state_mask.set_bit(nibble);
-                    let new_leaf = SparseNode::new_leaf(path.slice(current.len()..), is_private);
+                    let new_leaf = SparseNode::new_leaf(path.slice(current.len()..));
                     self.nodes.insert(current, new_leaf);
-                    return Ok(LeafUpdateStep::complete_with_insertions(vec![current], None))
+                    return Ok(LeafUpdateStep::complete_with_insertions(vec![current], None));
                 }
 
                 // If the nibble is set, we can continue traversing the branch.
@@ -1736,7 +1726,7 @@ impl SparseSubtrie {
 
         // If the node is already revealed and it's not a hash node, do nothing.
         if self.nodes.get(&path).is_some_and(|node| !node.is_hash()) {
-            return Ok(())
+            return Ok(());
         }
 
         match node {
@@ -1773,8 +1763,8 @@ impl SparseSubtrie {
                                 // node.
                                 hash: Some(*hash),
                                 store_in_db_trie: Some(
-                                    masks.hash_mask.is_some_and(|mask| !mask.is_empty()) ||
-                                        masks.tree_mask.is_some_and(|mask| !mask.is_empty()),
+                                    masks.hash_mask.is_some_and(|mask| !mask.is_empty())
+                                        || masks.tree_mask.is_some_and(|mask| !mask.is_empty()),
                                 ),
                             });
                         }
@@ -1845,15 +1835,14 @@ impl SparseSubtrie {
                             // Memoize the hash of a previously blinded node in a new leaf
                             // node.
                             hash: Some(*hash),
-                            is_private: leaf.is_private,
                         });
                     }
                     // Leaf node already exists.
                     SparseNode::Leaf { .. } => {}
                     // All other node types can't be handled.
-                    node @ (SparseNode::Empty |
-                    SparseNode::Extension { .. } |
-                    SparseNode::Branch { .. }) => {
+                    node @ (SparseNode::Empty
+                    | SparseNode::Extension { .. }
+                    | SparseNode::Branch { .. }) => {
                         return Err(SparseTrieErrorKind::Reveal {
                             path: *entry.key(),
                             node: Box::new(node.clone()),
@@ -1864,7 +1853,7 @@ impl SparseSubtrie {
                 Entry::Vacant(entry) => {
                     let mut full = *entry.key();
                     full.extend(&leaf.key);
-                    entry.insert(SparseNode::new_leaf(leaf.key, leaf.is_private));
+                    entry.insert(SparseNode::new_leaf(leaf.key));
                     self.inner.values.insert(full, leaf.value.clone());
                 }
             },
@@ -1910,7 +1899,7 @@ impl SparseSubtrie {
                     entry.insert(SparseNode::Hash(hash));
                 }
             }
-            return Ok(())
+            return Ok(());
         }
 
         self.reveal_node(path, &TrieNode::decode(&mut &child[..])?, TrieMasks::none())
@@ -2063,7 +2052,7 @@ impl SparseSubtrieInner {
                 // Return pre-computed hash of a blinded node immediately
                 (RlpNode::word_rlp(hash), SparseNodeType::Hash)
             }
-            SparseNode::Leaf { key, hash, is_private } => {
+            SparseNode::Leaf { key, hash } => {
                 let mut path = path;
                 path.extend(key);
                 let value = self.values.get(&path);
@@ -2077,8 +2066,7 @@ impl SparseSubtrieInner {
                     // Encode the leaf node and update its hash
                     let value = self.values.get(&path).unwrap();
                     self.buffers.rlp_buf.clear();
-                    let rlp_node =
-                        LeafNodeRef { key, value, is_private }.rlp(&mut self.buffers.rlp_buf);
+                    let rlp_node = LeafNodeRef { key, value }.rlp(&mut self.buffers.rlp_buf);
                     *hash = rlp_node.as_hash();
                     (rlp_node, SparseNodeType::Leaf)
                 }
@@ -2135,7 +2123,7 @@ impl SparseSubtrieInner {
                         },
                         RlpNodePathStackItem { path: child_path, is_in_prefix_set: None },
                     ]);
-                    return
+                    return;
                 }
             }
             SparseNode::Branch { state_mask, hash, store_in_db_trie } => {
@@ -2151,7 +2139,7 @@ impl SparseSubtrieInner {
                             store_in_db_trie: Some(store_in_db_trie),
                         },
                     });
-                    return
+                    return;
                 }
 
                 let retain_updates = update_actions.is_some() && prefix_set_contains(&path);
@@ -2197,8 +2185,8 @@ impl SparseSubtrieInner {
                                 store_in_db_trie
                             } else {
                                 // A blinded node has the tree mask bit set
-                                child_node_type.is_hash() &&
-                                    branch_node_tree_masks
+                                child_node_type.is_hash()
+                                    && branch_node_tree_masks
                                         .get(&path)
                                         .is_some_and(|mask| mask.is_bit_set(last_child_nibble))
                             };
@@ -2210,11 +2198,11 @@ impl SparseSubtrieInner {
                             // is a blinded node that has its hash mask bit set according to the
                             // database, set the hash mask bit and save the hash.
                             let hash = child.as_hash().filter(|_| {
-                                child_node_type.is_branch() ||
-                                    (child_node_type.is_hash() &&
-                                        branch_node_hash_masks.get(&path).is_some_and(
-                                            |mask| mask.is_bit_set(last_child_nibble),
-                                        ))
+                                child_node_type.is_branch()
+                                    || (child_node_type.is_hash()
+                                        && branch_node_hash_masks
+                                            .get(&path)
+                                            .is_some_and(|mask| mask.is_bit_set(last_child_nibble)))
                             });
                             if let Some(hash) = hash {
                                 hash_mask.set_bit(last_child_nibble);
@@ -2242,7 +2230,7 @@ impl SparseSubtrieInner {
                                 .drain(..)
                                 .map(|path| RlpNodePathStackItem { path, is_in_prefix_set: None }),
                         );
-                        return
+                        return;
                     }
                 }
 
@@ -2281,15 +2269,15 @@ impl SparseSubtrieInner {
                         );
                         update_actions
                             .push(SparseTrieUpdatesAction::InsertUpdated(path, branch_node));
-                    } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty()) ||
-                        branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
+                    } else if branch_node_tree_masks.get(&path).is_some_and(|mask| !mask.is_empty())
+                        || branch_node_hash_masks.get(&path).is_some_and(|mask| !mask.is_empty())
                     {
                         // If new tree and hash masks are empty, but previously they weren't, we
                         // need to remove the node update and add the node itself to the list of
                         // removed nodes.
                         update_actions.push(SparseTrieUpdatesAction::InsertRemoved(path));
-                    } else if branch_node_tree_masks.get(&path).is_none_or(|mask| mask.is_empty()) &&
-                        branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
+                    } else if branch_node_tree_masks.get(&path).is_none_or(|mask| mask.is_empty())
+                        && branch_node_hash_masks.get(&path).is_none_or(|mask| mask.is_empty())
                     {
                         // If new tree and hash masks are empty, and they were previously empty
                         // as well, we need to remove the node update.
@@ -2659,7 +2647,7 @@ mod tests {
             leaves: impl IntoIterator<Item = (Nibbles, Vec<u8>)>,
         ) {
             for (path, value) in leaves {
-                trie.update_leaf(path, value, false, DefaultTrieNodeProvider).unwrap();
+                trie.update_leaf(path, value, DefaultTrieNodeProvider).unwrap();
             }
         }
 
@@ -2778,11 +2766,7 @@ mod tests {
     }
 
     fn create_leaf_node(key: impl AsRef<[u8]>, value_nonce: u64) -> TrieNode {
-        TrieNode::Leaf(LeafNode::new(
-            Nibbles::from_nibbles(key),
-            encode_account_value(value_nonce),
-            false,
-        ))
+        TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles(key), encode_account_value(value_nonce)))
     }
 
     fn create_extension_node(key: impl AsRef<[u8]>, child_hash: B256) -> TrieNode {
@@ -2851,7 +2835,7 @@ mod tests {
                     let account = account.into_trie_account(EMPTY_ROOT_HASH);
                     account.encode(&mut account_rlp);
 
-                    hash_builder.add_leaf(Nibbles::unpack(key), &account_rlp, false);
+                    hash_builder.add_leaf(Nibbles::unpack(key), &account_rlp);
                     account_rlp.clear();
                 }
             }
@@ -3127,7 +3111,7 @@ mod tests {
 
             assert_matches!(
                 trie.upper_subtrie.nodes.get(&path),
-                Some(SparseNode::Leaf { key, hash: None, is_private: false })
+                Some(SparseNode::Leaf { key, hash: None })
                 if key == &Nibbles::from_nibbles([0x2, 0x3])
             );
 
@@ -3156,7 +3140,7 @@ mod tests {
 
             assert_matches!(
                 lower_subtrie.nodes.get(&path),
-                Some(SparseNode::Leaf { key, hash: None, is_private: false })
+                Some(SparseNode::Leaf { key, hash: None })
                 if key == &Nibbles::from_nibbles([0x3, 0x4])
             );
         }
@@ -3540,15 +3524,15 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::new(), false),
+                    SparseNode::new_leaf(Nibbles::new()),
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::new(), false),
+                    SparseNode::new_leaf(Nibbles::new()),
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x7]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x7])),
                 ),
             ]
             .into_iter(),
@@ -3597,11 +3581,11 @@ mod tests {
                 (Nibbles::default(), SparseNode::new_branch(TrieMask::new(0b0011))),
                 (
                     Nibbles::from_nibbles([0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2])),
                 ),
                 (
                     Nibbles::from_nibbles([0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4])),
                 ),
             ]
             .into_iter(),
@@ -3663,11 +3647,11 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(TrieMask::new(0b0011))),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2])),
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4])),
                 ),
             ]
             .into_iter(),
@@ -3718,16 +3702,16 @@ mod tests {
                 (Nibbles::default(), SparseNode::new_branch(TrieMask::new(0b0101))),
                 (
                     Nibbles::from_nibbles([0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2])),
                 ),
                 (Nibbles::from_nibbles([0x2]), SparseNode::new_branch(TrieMask::new(0b0011))),
                 (
                     Nibbles::from_nibbles([0x2, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x4])),
                 ),
                 (
                     Nibbles::from_nibbles([0x2, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x6]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x6])),
                 ),
             ]
             .into_iter(),
@@ -3790,7 +3774,7 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::default(), false),
+                    SparseNode::new_leaf(Nibbles::default()),
                 ),
                 (
                     Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]),
@@ -3802,11 +3786,11 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4, 0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::default(), false),
+                    SparseNode::new_leaf(Nibbles::default()),
                 ),
                 (
                     Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4, 0x5, 0x1]),
-                    SparseNode::new_leaf(Nibbles::default(), false),
+                    SparseNode::new_leaf(Nibbles::default()),
                 ),
             ]
             .into_iter(),
@@ -3862,7 +3846,7 @@ mod tests {
                 (Nibbles::default(), SparseNode::new_branch(TrieMask::new(0b0011))),
                 (
                     Nibbles::from_nibbles([0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2])),
                 ),
                 (Nibbles::from_nibbles([0x1]), SparseNode::Hash(B256::repeat_byte(0xab))),
             ]
@@ -3908,7 +3892,7 @@ mod tests {
         //
         let mut trie = new_test_trie(std::iter::once((
             Nibbles::default(),
-            SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2, 0x3]), false),
+            SparseNode::new_leaf(Nibbles::from_nibbles([0x1, 0x2, 0x3])),
         )));
 
         let provider = MockTrieNodeProvider::new();
@@ -3973,7 +3957,6 @@ mod tests {
                     SparseNode::Leaf {
                         key: Nibbles::from_nibbles([0x3, 0x4]),
                         hash: Some(B256::repeat_byte(0x40)),
-                        is_private: false,
                     },
                 ),
                 (
@@ -3981,7 +3964,6 @@ mod tests {
                     SparseNode::Leaf {
                         key: Nibbles::from_nibbles([0x5, 0x6]),
                         hash: Some(B256::repeat_byte(0x50)),
-                        is_private: false,
                     },
                 ),
                 (
@@ -3989,7 +3971,6 @@ mod tests {
                     SparseNode::Leaf {
                         key: Nibbles::from_nibbles([0x6, 0x7]),
                         hash: Some(B256::repeat_byte(0x60)),
-                        is_private: false,
                     },
                 ),
                 (
@@ -3997,7 +3978,6 @@ mod tests {
                     SparseNode::Leaf {
                         key: Nibbles::from_nibbles([0x7, 0x8]),
                         hash: Some(B256::repeat_byte(0x70)),
-                        is_private: false,
                     },
                 ),
             ]
@@ -4236,7 +4216,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded(), false, &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -4395,29 +4375,29 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::default(), false)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::default(), false)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x1, 0x3]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x1, 0x3]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -4453,25 +4433,25 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::default(), false)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::default(), false)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -4496,21 +4476,21 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -4533,7 +4513,7 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3]),
@@ -4542,11 +4522,11 @@ mod tests {
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -4567,11 +4547,11 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x0, 0x2]), false)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x0, 0x2]))
                 ),
             ])
         );
@@ -4586,7 +4566,7 @@ mod tests {
                 .collect::<BTreeMap<_, _>>(),
             BTreeMap::from_iter([(
                 Nibbles::default(),
-                SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), false)
+                SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]))
             ),])
         );
 
@@ -4607,7 +4587,6 @@ mod tests {
         let leaf = LeafNode::new(
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
-            false,
         );
         let branch = TrieNode::Branch(BranchNode::new(
             vec![
@@ -4657,7 +4636,6 @@ mod tests {
         let leaf = LeafNode::new(
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
-            false,
         );
         let branch = TrieNode::Branch(BranchNode::new(
             vec![
@@ -4721,7 +4699,7 @@ mod tests {
                         let account = account.into_trie_account(EMPTY_ROOT_HASH);
                         let mut account_rlp = Vec::new();
                         account.encode(&mut account_rlp);
-                        sparse.update_leaf(key, account_rlp, false, &default_provider).unwrap();
+                        sparse.update_leaf(key, account_rlp, &default_provider).unwrap();
                     }
                     // We need to clone the sparse trie, so that all updated branch nodes are
                     // preserved, and not only those that were changed after the last call to
@@ -4864,8 +4842,8 @@ mod tests {
                     let account = account.into_trie_account(EMPTY_ROOT_HASH);
                     let mut account_rlp = Vec::new();
                     account.encode(&mut account_rlp);
-                    serial.update_leaf(key, account_rlp.clone(), false, &default_provider).unwrap();
-                    parallel.update_leaf(key, account_rlp, false, &default_provider).unwrap();
+                    serial.update_leaf(key, account_rlp.clone(), &default_provider).unwrap();
+                    parallel.update_leaf(key, account_rlp, &default_provider).unwrap();
                 }
 
                 // Calculate roots and assert their equality
@@ -4964,11 +4942,11 @@ mod tests {
         account.encode(&mut account_rlp);
 
         // Add a leaf and calculate the root.
-        trie.update_leaf(key_50, account_rlp.clone(), false, &provider).unwrap();
+        trie.update_leaf(key_50, account_rlp.clone(), &provider).unwrap();
         trie.root();
 
         // Add a second leaf and assert that the root is the expected value.
-        trie.update_leaf(key_51, account_rlp.clone(), false, &provider).unwrap();
+        trie.update_leaf(key_51, account_rlp.clone(), &provider).unwrap();
 
         let expected_root =
             hex!("0xdaf0ef9f91a2f179bb74501209effdb5301db1697bcab041eca2234b126e25de");
@@ -5050,7 +5028,7 @@ mod tests {
         );
 
         // Insert the leaf for the second key
-        sparse.update_leaf(key2(), value_encoded(), false, &provider).unwrap();
+        sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
 
         // Check that the branch node was updated and another nibble was set
         assert_eq!(
@@ -5252,7 +5230,7 @@ mod tests {
         );
 
         // Insert the leaf with a different prefix
-        sparse.update_leaf(key3(), value_encoded(), false, &provider).unwrap();
+        sparse.update_leaf(key3(), value_encoded(), &provider).unwrap();
 
         // Check that the extension node was turned into a branch node
         assert_matches!(
@@ -5318,7 +5296,7 @@ mod tests {
 
         // First add leaf 0x1345 - this should create a leaf in upper trie at 0x
         let (leaf1_path, value1) = ctx.create_test_leaf([0x1, 0x3, 0x4, 0x5], 1);
-        trie.update_leaf(leaf1_path, value1.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify upper trie has a leaf at the root with key 1345
         ctx.assert_upper_subtrie(&trie)
@@ -5327,7 +5305,7 @@ mod tests {
 
         // Add leaf 0x1234 - this should go first in the upper subtrie
         let (leaf2_path, value2) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 2);
-        trie.update_leaf(leaf2_path, value2.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Upper trie should now have a branch at 0x1
         ctx.assert_upper_subtrie(&trie)
@@ -5337,7 +5315,7 @@ mod tests {
 
         // Add leaf 0x1245 - this should cause a branch and create the 0x12 subtrie
         let (leaf3_path, value3) = ctx.create_test_leaf([0x1, 0x2, 0x4, 0x5], 3);
-        trie.update_leaf(leaf3_path, value3.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf3_path, value3.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify lower subtrie at 0x12 exists with correct structure
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -5349,7 +5327,7 @@ mod tests {
 
         // Add leaf 0x1334 - this should create another lower subtrie
         let (leaf4_path, value4) = ctx.create_test_leaf([0x1, 0x3, 0x3, 0x4], 4);
-        trie.update_leaf(leaf4_path, value4.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf4_path, value4.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify lower subtrie at 0x13 exists with correct values
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x3]))
@@ -5393,8 +5371,7 @@ mod tests {
         // First insert a leaf that ends exactly at the boundary (2 nibbles)
         let (first_leaf_path, first_value) = ctx.create_test_leaf([0x1, 0x2, 0x2, 0x4], 1);
 
-        trie.update_leaf(first_leaf_path, first_value.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(first_leaf_path, first_value.clone(), DefaultTrieNodeProvider).unwrap();
 
         // In an empty trie, the first leaf becomes the root, regardless of path length
         ctx.assert_upper_subtrie(&trie)
@@ -5404,8 +5381,7 @@ mod tests {
         // Now insert another leaf that shares the same 2-nibble prefix
         let (second_leaf_path, second_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 2);
 
-        trie.update_leaf(second_leaf_path, second_value.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(second_leaf_path, second_value.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Now both leaves should be in a lower subtrie at index [0x1, 0x2]
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -5468,8 +5444,7 @@ mod tests {
         let updated_path = Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]);
         let (_, updated_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4], 100);
 
-        trie.update_leaf(updated_path, updated_value.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(updated_path, updated_value.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify the subtrie structure is maintained and value is updated
         // The branch structure should remain the same and all values should be present
@@ -5483,8 +5458,7 @@ mod tests {
         // Add a new leaf that extends an existing branch
         let (new_leaf_path, new_leaf_value) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x6], 200);
 
-        trie.update_leaf(new_leaf_path, new_leaf_value.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(new_leaf_path, new_leaf_value.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify the branch at [0x1, 0x2, 0x3] now has an additional child
         ctx.assert_subtrie(&trie, Nibbles::from_nibbles([0x1, 0x2]))
@@ -5852,7 +5826,7 @@ mod tests {
 
         // Now add a leaf that will force the hash node to become a branch
         let (leaf_path, value) = ctx.create_test_leaf([0xA, 0x0], 1);
-        trie.update_leaf(leaf_path, value, false, provider).unwrap();
+        trie.update_leaf(leaf_path, value, provider).unwrap();
 
         // Verify the structure: extension should now terminate in a branch on the upper trie
         ctx.assert_upper_subtrie(&trie)
@@ -5888,8 +5862,8 @@ mod tests {
         let (leaf1_path, value1) = ctx.create_test_leaf([0xA, 0xB, 0xC, 0xD, 0xE, 0xF], 1);
         let (leaf2_path, value2) = ctx.create_test_leaf([0xA, 0xB, 0xD, 0xE, 0xF, 0x0], 2);
 
-        trie.update_leaf(leaf1_path, value1.clone(), false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1.clone(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify upper trie structure
         ctx.assert_upper_subtrie(&trie)
@@ -5945,9 +5919,9 @@ mod tests {
         let (leaf2_path, value2) = ctx.create_test_leaf([0x2, 0x3, 0x4, 0x5], 2);
         let (leaf3_path, value3) = ctx.create_test_leaf([0x2, 0x3, 0x5, 0x6], 3);
 
-        trie.update_leaf(leaf1_path, value1, false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2, false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf3_path, value3, false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf3_path, value3, DefaultTrieNodeProvider).unwrap();
 
         // Verify initial structure has branch at root
         ctx.assert_upper_subtrie(&trie).has_branch(&Nibbles::default(), &[0x1, 0x2]);
@@ -5961,12 +5935,9 @@ mod tests {
         // Clear and add new leaves
         let mut trie =
             ParallelSparseTrie::from_root(TrieNode::EmptyRoot, TrieMasks::none(), true).unwrap();
-        trie.update_leaf(new_leaf1_path, new_value1.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
-        trie.update_leaf(new_leaf2_path, new_value2.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
-        trie.update_leaf(new_leaf3_path, new_value3.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(new_leaf1_path, new_value1.clone(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(new_leaf2_path, new_value2.clone(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(new_leaf3_path, new_value3.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify new structure has extension
         ctx.assert_upper_subtrie(&trie)
@@ -6011,9 +5982,9 @@ mod tests {
         let (leaf2_path, value2) = ctx.create_test_leaf([0x2, 0x3, 0x4, 0x5], 2);
         let (leaf3_path, value3) = ctx.create_test_leaf([0x2, 0x3, 0x5, 0x6], 3);
 
-        trie.update_leaf(leaf1_path, value1, false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2.clone(), false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf3_path, value3.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2.clone(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf3_path, value3.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify upper trie structure
         ctx.assert_upper_subtrie(&trie)
@@ -6072,7 +6043,7 @@ mod tests {
 
         // Step 1: Add first leaf - initially stored as leaf in upper trie
         let (leaf1_path, value1) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4, 0x5], 1);
-        trie.update_leaf(leaf1_path, value1.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify leaf node in upper trie (optimized single-leaf case)
         ctx.assert_upper_subtrie(&trie)
@@ -6081,7 +6052,7 @@ mod tests {
 
         // Step 2: Add leaf at 0x12346 - creates branch at 0x1234
         let (leaf2_path, value2) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x4, 0x6], 2);
-        trie.update_leaf(leaf2_path, value2.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify extension now goes to 0x1234
         ctx.assert_upper_subtrie(&trie)
@@ -6099,7 +6070,7 @@ mod tests {
 
         // Step 3: Add leaf at 0x1235 - creates branch at 0x123
         let (leaf3_path, value3) = ctx.create_test_leaf([0x1, 0x2, 0x3, 0x5], 3);
-        trie.update_leaf(leaf3_path, value3.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf3_path, value3.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify extension now goes to 0x123
         ctx.assert_upper_subtrie(&trie)
@@ -6118,7 +6089,7 @@ mod tests {
 
         // Step 4: Add leaf at 0x124 - creates branch at 0x12 (subtrie root)
         let (leaf4_path, value4) = ctx.create_test_leaf([0x1, 0x2, 0x4], 4);
-        trie.update_leaf(leaf4_path, value4.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf4_path, value4.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Verify extension now goes to 0x12
         ctx.assert_upper_subtrie(&trie)
@@ -6164,8 +6135,8 @@ mod tests {
         let (leaf1_path, value1) = ctx.create_test_leaf(&path1_nibbles, 1);
         let (leaf2_path, value2) = ctx.create_test_leaf(&path2_nibbles, 2);
 
-        trie.update_leaf(leaf1_path, value1.clone(), false, DefaultTrieNodeProvider).unwrap();
-        trie.update_leaf(leaf2_path, value2.clone(), false, DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf1_path, value1.clone(), DefaultTrieNodeProvider).unwrap();
+        trie.update_leaf(leaf2_path, value2.clone(), DefaultTrieNodeProvider).unwrap();
 
         // The common prefix of 63 F's will create a very long extension
         let extension_key = vec![0xF; 63];
@@ -6265,7 +6236,7 @@ mod tests {
         );
         let leaf_value = hex!("f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c").to_vec();
 
-        let leaf_node = LeafNode::new(leaf_key, leaf_value, false);
+        let leaf_node = LeafNode::new(leaf_key, leaf_value);
         let leaf_masks = TrieMasks::none();
 
         trie.reveal_nodes(vec![
@@ -6293,8 +6264,7 @@ mod tests {
             218, 223, 145, 158, 225, 240, 227, 203, 155, 98, 211, 244, 176, 44,
         ];
 
-        trie.update_leaf(leaf_full_path, leaf_new_value.clone(), false, DefaultTrieNodeProvider)
-            .unwrap();
+        trie.update_leaf(leaf_full_path, leaf_new_value.clone(), DefaultTrieNodeProvider).unwrap();
 
         // Sanity checks before calculating the root
         assert_eq!(
@@ -6317,7 +6287,7 @@ mod tests {
         let path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
         let value = b"test_value".to_vec();
 
-        sparse.update_leaf(path, value.clone(), false, &provider).unwrap();
+        sparse.update_leaf(path, value.clone(), &provider).unwrap();
 
         // Check that the leaf exists
         let result = sparse.find_leaf(&path, None);
@@ -6337,7 +6307,7 @@ mod tests {
         let value = b"test_value".to_vec();
         let wrong_value = b"wrong_value".to_vec();
 
-        sparse.update_leaf(path, value, false, &provider).unwrap();
+        sparse.update_leaf(path, value, &provider).unwrap();
 
         // Check with wrong expected value
         let result = sparse.find_leaf(&path, Some(&wrong_value));
@@ -6372,7 +6342,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = ParallelSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
-        sparse.update_leaf(path, encode_account_value(0), false, &provider).unwrap();
+        sparse.update_leaf(path, encode_account_value(0), &provider).unwrap();
 
         let result = sparse.find_leaf(&path, None);
         assert_matches!(result, Ok(LeafLookup::Exists));
@@ -6384,7 +6354,7 @@ mod tests {
         let mut sparse = ParallelSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let value = encode_account_value(0);
-        sparse.update_leaf(path, value.clone(), false, &provider).unwrap();
+        sparse.update_leaf(path, value.clone(), &provider).unwrap();
 
         let result = sparse.find_leaf(&path, Some(&value));
         assert_matches!(result, Ok(LeafLookup::Exists));
@@ -6398,8 +6368,8 @@ mod tests {
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]); // Belongs to same branch
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at nibble 7
 
-        sparse.update_leaf(path1, encode_account_value(0), false, &provider).unwrap();
-        sparse.update_leaf(path2, encode_account_value(1), false, &provider).unwrap();
+        sparse.update_leaf(path1, encode_account_value(0), &provider).unwrap();
+        sparse.update_leaf(path2, encode_account_value(1), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent))
@@ -6414,7 +6384,7 @@ mod tests {
         // This path diverges from the extension key
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]);
 
-        sparse.update_leaf(path1, encode_account_value(0), false, &provider).unwrap();
+        sparse.update_leaf(path1, encode_account_value(0), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent))
@@ -6427,7 +6397,7 @@ mod tests {
         let existing_leaf_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4, 0x5, 0x6]);
 
-        sparse.update_leaf(existing_leaf_path, encode_account_value(0), false, &provider).unwrap();
+        sparse.update_leaf(existing_leaf_path, encode_account_value(0), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent))
@@ -6441,8 +6411,8 @@ mod tests {
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2]); // Path of the branch itself
 
-        sparse.update_leaf(path1, encode_account_value(0), false, &provider).unwrap();
-        sparse.update_leaf(path2, encode_account_value(1), false, &provider).unwrap();
+        sparse.update_leaf(path1, encode_account_value(0), &provider).unwrap();
+        sparse.update_leaf(path2, encode_account_value(1), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent));
@@ -6502,7 +6472,7 @@ mod tests {
                 (path_to_blind, SparseNode::Hash(blinded_hash)),
                 (
                     Nibbles::from_nibbles_unchecked([0x5]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8]), false),
+                    SparseNode::new_leaf(Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8])),
                 ),
             ]
             .into_iter(),

--- a/crates/trie/sparse/benches/rlp_node.rs
+++ b/crates/trie/sparse/benches/rlp_node.rs
@@ -21,8 +21,7 @@ fn update_rlp_node_level(c: &mut Criterion) {
             .unwrap()
             .current();
 
-        let is_private = false; // hardcoded to false for legacy benchmark
-                                // Create a sparse trie with `size` leaves
+        // Create a sparse trie with `size` leaves
 
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
@@ -31,7 +30,6 @@ fn update_rlp_node_level(c: &mut Criterion) {
                 .update_leaf(
                     Nibbles::unpack(key),
                     alloy_rlp::encode_fixed_size(value).to_vec(),
-                    false,
                     &provider,
                 )
                 .unwrap();
@@ -47,7 +45,6 @@ fn update_rlp_node_level(c: &mut Criterion) {
                     .update_leaf(
                         Nibbles::unpack(key),
                         alloy_rlp::encode_fixed_size(&rng.random::<U256>()).to_vec(),
-                        is_private,
                         &provider,
                     )
                     .unwrap();

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -19,7 +19,6 @@ use reth_trie_sparse::{provider::DefaultTrieNodeProvider, SerialSparseTrie, Spar
 use alloy_primitives::FlaggedStorage;
 
 fn calculate_root_from_leaves(c: &mut Criterion) {
-    let is_private = false; // hardcode to false for legacy test
     let mut group = c.benchmark_group("calculate root from leaves");
     group.sample_size(20);
 
@@ -39,7 +38,6 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
                     hb.add_leaf(
                         Nibbles::unpack(key),
                         &alloy_rlp::encode_fixed_size(value),
-                        is_private,
                     );
                 }
                 hb.root();
@@ -56,7 +54,6 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
                         .update_leaf(
                             Nibbles::unpack(key),
                             alloy_rlp::encode_fixed_size(value).to_vec(),
-                            is_private,
                             &provider,
                         )
                         .unwrap();
@@ -69,7 +66,6 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
 }
 
 fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
-    let is_private = false; // hardcode to false for legacy test
 
     let mut group = c.benchmark_group("calculate root from leaves repeated");
     group.sample_size(20);
@@ -116,7 +112,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                 hb.add_leaf(
                                     Nibbles::unpack(key),
                                     &alloy_rlp::encode_fixed_size(value),
-                                    is_private,
                                 );
                             }
                             hb.root();
@@ -175,7 +170,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                             hb.add_leaf(
                                                 Nibbles::unpack(hashed_slot),
                                                 alloy_rlp::encode_fixed_size(&value).as_ref(),
-                                                is_private,
                                             );
                                         }
                                     }
@@ -208,7 +202,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                     .update_leaf(
                                         Nibbles::unpack(key),
                                         alloy_rlp::encode_fixed_size(value).to_vec(),
-                                        is_private,
                                         &provider,
                                     )
                                     .unwrap();
@@ -223,7 +216,6 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
                                         .update_leaf(
                                             Nibbles::unpack(key),
                                             alloy_rlp::encode_fixed_size(value).to_vec(),
-                                            is_private,
                                             &provider,
                                         )
                                         .unwrap();

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -35,10 +35,7 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("hash builder", size), |b| {
             b.iter_with_setup(HashBuilder::default, |mut hb| {
                 for (key, value) in state.iter().sorted_by_key(|(key, _)| *key) {
-                    hb.add_leaf(
-                        Nibbles::unpack(key),
-                        &alloy_rlp::encode_fixed_size(value),
-                    );
+                    hb.add_leaf(Nibbles::unpack(key), &alloy_rlp::encode_fixed_size(value));
                 }
                 hb.root();
                 hb
@@ -66,7 +63,6 @@ fn calculate_root_from_leaves(c: &mut Criterion) {
 }
 
 fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
-
     let mut group = c.benchmark_group("calculate root from leaves repeated");
     group.sample_size(20);
 

--- a/crates/trie/sparse/benches/update.rs
+++ b/crates/trie/sparse/benches/update.rs
@@ -23,7 +23,7 @@ fn update_leaf(c: &mut Criterion) {
                     let mut trie = SparseTrie::<SerialSparseTrie>::revealed_empty();
                     // Pre-populate with data
                     for (path, value) in leaves.iter().cloned() {
-                        trie.update_leaf(path, value, false, &provider).unwrap();
+                        trie.update_leaf(path, value, &provider).unwrap();
                     }
 
                     let new_leaves = leaves
@@ -43,7 +43,7 @@ fn update_leaf(c: &mut Criterion) {
                 },
                 |(mut trie, new_leaves)| {
                     for (path, new_value) in new_leaves {
-                        trie.update_leaf(*path, new_value, false, &provider).unwrap();
+                        trie.update_leaf(*path, new_value, &provider).unwrap();
                     }
                     trie
                 },
@@ -67,7 +67,7 @@ fn remove_leaf(c: &mut Criterion) {
                     let mut trie = SparseTrie::<SerialSparseTrie>::revealed_empty();
                     // Pre-populate with data
                     for (path, value) in leaves.iter().cloned() {
-                        trie.update_leaf(path, value, false, &provider).unwrap();
+                        trie.update_leaf(path, value, &provider).unwrap();
                     }
 
                     let delete_leaves = leaves

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1150,14 +1150,8 @@ mod tests {
 
         let mut storage_hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([slot_path_1, slot_path_2]));
-        storage_hash_builder.add_leaf(
-            slot_path_1,
-            &alloy_rlp::encode_fixed_size(&value_1),
-        );
-        storage_hash_builder.add_leaf(
-            slot_path_2,
-            &alloy_rlp::encode_fixed_size(&value_2),
-        );
+        storage_hash_builder.add_leaf(slot_path_1, &alloy_rlp::encode_fixed_size(&value_1));
+        storage_hash_builder.add_leaf(slot_path_2, &alloy_rlp::encode_fixed_size(&value_2));
 
         let storage_root = storage_hash_builder.root();
         let storage_proof_nodes = storage_hash_builder.take_proof_nodes();
@@ -1286,8 +1280,7 @@ mod tests {
     #[test]
     fn test_filter_map_revealed_nodes() {
         let mut revealed_nodes = HashSet::from_iter([Nibbles::from_nibbles([0x0])]);
-        let leaf =
-            TrieNode::Leaf(LeafNode::new(Nibbles::default(), alloy_rlp::encode([])));
+        let leaf = TrieNode::Leaf(LeafNode::new(Nibbles::default(), alloy_rlp::encode([])));
         let leaf_encoded = alloy_rlp::encode(&leaf);
         let branch = TrieNode::Branch(BranchNode::new(
             vec![RlpNode::from_rlp(&leaf_encoded), RlpNode::from_rlp(&leaf_encoded)],

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -644,10 +644,8 @@ where
         if !self.revealed_account_paths.contains(&path) {
             self.revealed_account_paths.insert(path);
         }
-        let is_private = false; // account leaves are always public. Their storage leaves can be private.
-
         let provider = provider_factory.account_node_provider();
-        self.state.update_leaf(path, value, is_private, provider)?;
+        self.state.update_leaf(path, value, provider)?;
         Ok(())
     }
 
@@ -657,7 +655,6 @@ where
         address: B256,
         slot: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider_factory: impl TrieNodeProviderFactory,
     ) -> SparseStateTrieResult<()> {
         let provider = provider_factory.storage_node_provider(address);
@@ -665,7 +662,7 @@ where
             .tries
             .get_mut(&address)
             .ok_or(SparseTrieErrorKind::Blind)?
-            .update_leaf(slot, value, is_private, provider)?;
+            .update_leaf(slot, value, provider)?;
         self.storage.get_revealed_paths_mut(address).insert(slot);
         Ok(())
     }
@@ -976,7 +973,6 @@ mod tests {
 
     #[test]
     fn reveal_account_path_twice() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
@@ -984,12 +980,10 @@ mod tests {
         let leaf_1 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
             Nibbles::default(),
             leaf_value.clone(),
-            is_private,
         )));
         let leaf_2 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
             Nibbles::default(),
             leaf_value.clone(),
-            is_private,
         )));
 
         let multiproof = MultiProof {
@@ -1051,7 +1045,6 @@ mod tests {
 
     #[test]
     fn reveal_storage_path_twice() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
@@ -1059,12 +1052,10 @@ mod tests {
         let leaf_1 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
             Nibbles::default(),
             leaf_value.clone(),
-            is_private,
         )));
         let leaf_2 = alloy_rlp::encode(TrieNode::Leaf(LeafNode::new(
             Nibbles::default(),
             leaf_value.clone(),
-            is_private,
         )));
 
         let multiproof = MultiProof {
@@ -1157,19 +1148,15 @@ mod tests {
         let slot_path_3 = Nibbles::unpack(slot_3);
         let value_3 = U256::from(rng.random::<u64>());
 
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
-
         let mut storage_hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([slot_path_1, slot_path_2]));
         storage_hash_builder.add_leaf(
             slot_path_1,
             &alloy_rlp::encode_fixed_size(&value_1),
-            is_private,
         );
         storage_hash_builder.add_leaf(
             slot_path_2,
             &alloy_rlp::encode_fixed_size(&value_2),
-            is_private,
         );
 
         let storage_root = storage_hash_builder.root();
@@ -1188,11 +1175,10 @@ mod tests {
         let account_2 = Account::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
         let mut trie_account_2 = account_2.into_trie_account(EMPTY_ROOT_HASH);
 
-        let is_private = false; // account leaves are always public. Their storage leaves can be private.
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([address_path_1, address_path_2]));
-        hash_builder.add_leaf(address_path_1, &alloy_rlp::encode(trie_account_1), is_private);
-        hash_builder.add_leaf(address_path_2, &alloy_rlp::encode(trie_account_2), is_private);
+        hash_builder.add_leaf(address_path_1, &alloy_rlp::encode(trie_account_1));
+        hash_builder.add_leaf(address_path_2, &alloy_rlp::encode(trie_account_2));
 
         let root = hash_builder.root();
         let proof_nodes = hash_builder.take_proof_nodes();
@@ -1249,13 +1235,11 @@ mod tests {
             )
             .unwrap();
 
-        let is_private = false; // legacy test does not use private storage
         sparse
             .update_storage_leaf(
                 address_1,
                 slot_path_3,
                 alloy_rlp::encode(value_3),
-                is_private,
                 &provider_factory,
             )
             .unwrap();
@@ -1301,10 +1285,9 @@ mod tests {
 
     #[test]
     fn test_filter_map_revealed_nodes() {
-        let is_private = false; // hardcode to false for legacy test
         let mut revealed_nodes = HashSet::from_iter([Nibbles::from_nibbles([0x0])]);
         let leaf =
-            TrieNode::Leaf(LeafNode::new(Nibbles::default(), alloy_rlp::encode([]), is_private));
+            TrieNode::Leaf(LeafNode::new(Nibbles::default(), alloy_rlp::encode([])));
         let leaf_encoded = alloy_rlp::encode(&leaf);
         let branch = TrieNode::Branch(BranchNode::new(
             vec![RlpNode::from_rlp(&leaf_encoded), RlpNode::from_rlp(&leaf_encoded)],

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -111,7 +111,6 @@ pub trait SparseTrieInterface: Sized + Debug + Send + Sync {
         &mut self,
         full_path: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider: P,
     ) -> SparseTrieResult<()>;
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -227,11 +227,10 @@ impl<T: SparseTrieInterface> SparseTrie<T> {
         &mut self,
         path: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider: impl TrieNodeProvider,
     ) -> SparseTrieResult<()> {
         let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
-        revealed.update_leaf(path, value, is_private, provider)?;
+        revealed.update_leaf(path, value, provider)?;
         Ok(())
     }
 
@@ -532,7 +531,6 @@ impl SparseTrieInterface for SerialSparseTrie {
                             // Memoize the hash of a previously blinded node in a new leaf
                             // node.
                             hash: Some(*hash),
-                            is_private: leaf.is_private,
                         });
                     }
                     // Left node already exists.
@@ -551,7 +549,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                 Entry::Vacant(entry) => {
                     let mut full = *entry.key();
                     full.extend(&leaf.key);
-                    entry.insert(SparseNode::new_leaf(leaf.key, leaf.is_private));
+                    entry.insert(SparseNode::new_leaf(leaf.key));
                     self.values.insert(full, leaf.value);
                 }
             },
@@ -572,7 +570,6 @@ impl SparseTrieInterface for SerialSparseTrie {
         &mut self,
         full_path: Nibbles,
         value: Vec<u8>,
-        is_private: bool,
         provider: P,
     ) -> SparseTrieResult<()> {
         trace!(target: "trie::sparse", ?full_path, ?value, "update_leaf called");
@@ -588,15 +585,15 @@ impl SparseTrieInterface for SerialSparseTrie {
         while let Some(node) = self.nodes.get_mut(&current) {
             match node {
                 SparseNode::Empty => {
-                    *node = SparseNode::new_leaf(full_path, is_private);
+                    *node = SparseNode::new_leaf(full_path);
                     break
                 }
-                &mut SparseNode::Hash(hash) => {
-                    return Err(SparseTrieErrorKind::BlindedNode { path: current, hash }.into())
+                SparseNode::Hash(hash) => {
+                    return Err(
+                        SparseTrieErrorKind::BlindedNode { path: current, hash: *hash }.into()
+                    )
                 }
-                SparseNode::Leaf { key: current_key, is_private: existing_is_private, .. } => {
-                    // Store the existing is_private value before modifying the node
-                    let existing_is_private = *existing_is_private;
+                SparseNode::Leaf { key: current_key, .. } => {
                     current.extend(current_key);
 
                     // this leaf is being updated
@@ -622,11 +619,11 @@ impl SparseTrieInterface for SerialSparseTrie {
                     );
                     self.nodes.insert(
                         full_path.slice(..=common),
-                        SparseNode::new_leaf(full_path.slice(common + 1..), is_private),
+                        SparseNode::new_leaf(full_path.slice(common + 1..)),
                     );
                     self.nodes.insert(
                         current.slice(..=common),
-                        SparseNode::new_leaf(current.slice(common + 1..), existing_is_private),
+                        SparseNode::new_leaf(current.slice(common + 1..)),
                     );
 
                     break;
@@ -682,8 +679,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                         self.nodes.insert(current.slice(..common), branch);
 
                         // create new leaf
-                        let new_leaf =
-                            SparseNode::new_leaf(full_path.slice(common + 1..), is_private);
+                        let new_leaf = SparseNode::new_leaf(full_path.slice(common + 1..));
                         self.nodes.insert(full_path.slice(..=common), new_leaf);
 
                         // recreate extension to previous child if needed
@@ -700,8 +696,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                     current.push_unchecked(nibble);
                     if !state_mask.is_bit_set(nibble) {
                         state_mask.set_bit(nibble);
-                        let new_leaf =
-                            SparseNode::new_leaf(full_path.slice(current.len()..), is_private);
+                        let new_leaf = SparseNode::new_leaf(full_path.slice(current.len()..));
                         self.nodes.insert(current, new_leaf);
                         break;
                     }
@@ -782,12 +777,12 @@ impl SparseTrieInterface for SerialSparseTrie {
                         // followed by a leaf node in a complete trie, it's possible here because we
                         // could have downgraded the extension node's child into a leaf node from
                         // another node type.
-                        SparseNode::Leaf { key: leaf_key, is_private, .. } => {
+                        SparseNode::Leaf { key: leaf_key, .. } => {
                             self.nodes.remove(&child.path);
 
                             let mut new_key = *key;
                             new_key.extend(leaf_key);
-                            SparseNode::new_leaf(new_key, *is_private)
+                            SparseNode::new_leaf(new_key)
                         }
                         // For an extension node, we collapse them into one extension node,
                         // extending the key
@@ -854,22 +849,22 @@ impl SparseTrieInterface for SerialSparseTrie {
                         let mut delete_child = false;
                         let new_node = match child {
                             SparseNode::Empty => return Err(SparseTrieErrorKind::Blind.into()),
-                            &SparseNode::Hash(hash) => {
+                            SparseNode::Hash(hash) => {
                                 return Err(SparseTrieErrorKind::BlindedNode {
                                     path: child_path,
-                                    hash,
+                                    hash: *hash,
                                 }
                                 .into())
                             }
                             // If the only child is a leaf node, we downgrade the branch node into a
                             // leaf node, prepending the nibble to the key, and delete the old
                             // child.
-                            SparseNode::Leaf { key, is_private, .. } => {
+                            SparseNode::Leaf { key, .. } => {
                                 delete_child = true;
 
                                 let mut new_key = Nibbles::from_nibbles_unchecked([child_nibble]);
                                 new_key.extend(key);
-                                SparseNode::new_leaf(new_key, *is_private)
+                                SparseNode::new_leaf(new_key)
                             }
                             // If the only child node is an extension node, we downgrade the branch
                             // node into an even longer extension node, prepending the nibble to the
@@ -1013,9 +1008,9 @@ impl SparseTrieInterface for SerialSparseTrie {
                     // Empty node means there is a node at this path and it is "Empty"
                     return Ok(LeafLookup::NonExistent);
                 }
-                Some(&SparseNode::Hash(hash)) => {
+                Some(SparseNode::Hash(hash)) => {
                     // We hit a blinded node - cannot determine if leaf exists
-                    return Err(LeafLookupError::BlindedNode { path: current, hash });
+                    return Err(LeafLookupError::BlindedNode { path: current, hash: *hash });
                 }
                 Some(SparseNode::Leaf { key, .. }) => {
                     // We found a leaf node before reaching our target depth
@@ -1068,8 +1063,8 @@ impl SparseTrieInterface for SerialSparseTrie {
                     return Ok(LeafLookup::Exists);
                 }
             }
-            Some(&SparseNode::Hash(hash)) => {
-                return Err(LeafLookupError::BlindedNode { path: *full_path, hash });
+            Some(SparseNode::Hash(hash)) => {
+                return Err(LeafLookupError::BlindedNode { path: *full_path, hash: *hash });
             }
             _ => {
                 // No leaf at exactly the target path
@@ -1321,7 +1316,7 @@ impl SerialSparseTrie {
         while let Some((mut path, level)) = paths.pop() {
             match self.nodes.get(&path).unwrap() {
                 SparseNode::Empty | SparseNode::Hash(_) => {}
-                SparseNode::Leaf { key: _, hash, is_private: _ } => {
+                SparseNode::Leaf { key: _, hash } => {
                     if hash.is_some() && !prefix_set.contains(&path) {
                         continue;
                     }
@@ -1426,7 +1421,7 @@ impl SerialSparseTrie {
             let (rlp_node, node_type) = match node {
                 SparseNode::Empty => (RlpNode::word_rlp(&EMPTY_ROOT_HASH), SparseNodeType::Empty),
                 SparseNode::Hash(hash) => (RlpNode::word_rlp(hash), SparseNodeType::Hash),
-                SparseNode::Leaf { key, hash, is_private } => {
+                SparseNode::Leaf { key, hash } => {
                     let mut path = path;
                     path.extend(key);
                     if let Some(hash) = hash.filter(|_| !prefix_set_contains(&path)) {
@@ -1434,7 +1429,7 @@ impl SerialSparseTrie {
                     } else {
                         let value = self.values.get(&path).unwrap();
                         rlp_buf.clear();
-                        let rlp_node = LeafNodeRef { key, value, is_private }.rlp(rlp_buf);
+                        let rlp_node = LeafNodeRef { key, value }.rlp(rlp_buf);
                         *hash = rlp_node.as_hash();
                         (rlp_node, SparseNodeType::Leaf)
                     }
@@ -1746,8 +1741,6 @@ pub enum SparseNode {
         /// Pre-computed hash of the sparse node.
         /// Can be reused unless this trie path has been updated.
         hash: Option<B256>,
-        /// whether the leaf node is private
-        is_private: bool,
     },
     /// Sparse extension node with key.
     Extension {
@@ -1786,7 +1779,7 @@ impl SparseNode {
     pub fn from_node(node: TrieNode) -> Self {
         match node {
             TrieNode::EmptyRoot => Self::Empty,
-            TrieNode::Leaf(leaf) => Self::new_leaf(leaf.key, leaf.is_private),
+            TrieNode::Leaf(leaf) => Self::new_leaf(leaf.key),
             TrieNode::Extension(ext) => Self::new_ext(ext.key),
             TrieNode::Branch(branch) => Self::new_branch(branch.state_mask),
         }
@@ -1812,17 +1805,8 @@ impl SparseNode {
     }
 
     /// Create new [`SparseNode::Leaf`] from leaf key and value.
-    pub const fn new_leaf(key: Nibbles, is_private: bool) -> Self {
-        Self::Leaf { key, hash: None, is_private }
-    }
-
-    /// returns if the node holds private state
-    /// node is always public unless it is a leaf
-    pub fn is_private(&self) -> bool {
-        match self {
-            Self::Leaf { is_private, .. } => *is_private,
-            _ => false,
-        }
+    pub const fn new_leaf(key: Nibbles) -> Self {
+        Self::Leaf { key, hash: None }
     }
 
     /// Returns `true` if the node is a hash node.
@@ -1981,8 +1965,7 @@ mod find_leaf_tests {
         let path = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
         let value = b"test_value".to_vec();
 
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path, value.clone(), is_private, &provider).unwrap();
+        sparse.update_leaf(path, value.clone(), &provider).unwrap();
 
         // Check that the leaf exists
         let result = sparse.find_leaf(&path, None);
@@ -2002,8 +1985,7 @@ mod find_leaf_tests {
         let value = b"test_value".to_vec();
         let wrong_value = b"wrong_value".to_vec();
 
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path, value, is_private, &provider).unwrap();
+        sparse.update_leaf(path, value, &provider).unwrap();
 
         // Check with wrong expected value
         let result = sparse.find_leaf(&path, Some(&wrong_value));
@@ -2038,8 +2020,7 @@ mod find_leaf_tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path, VALUE_A(), is_private, &provider).unwrap();
+        sparse.update_leaf(path, VALUE_A(), &provider).unwrap();
 
         let result = sparse.find_leaf(&path, None);
         assert_matches!(result, Ok(LeafLookup::Exists));
@@ -2051,8 +2032,7 @@ mod find_leaf_tests {
         let mut sparse = SerialSparseTrie::default();
         let path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let value = VALUE_A();
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path, value.clone(), is_private, &provider).unwrap();
+        sparse.update_leaf(path, value.clone(), &provider).unwrap();
 
         let result = sparse.find_leaf(&path, Some(&value));
         assert_matches!(result, Ok(LeafLookup::Exists));
@@ -2066,9 +2046,8 @@ mod find_leaf_tests {
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]); // Belongs to same branch
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at nibble 7
 
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path1, VALUE_A(), is_private, &provider).unwrap();
-        sparse.update_leaf(path2, VALUE_B(), is_private, &provider).unwrap();
+        sparse.update_leaf(path1, VALUE_A(), &provider).unwrap();
+        sparse.update_leaf(path2, VALUE_B(), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent));
@@ -2083,8 +2062,7 @@ mod find_leaf_tests {
         // This path diverges from the extension key
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]);
 
-        let is_private = false; // hardcode to false for legacy test
-        sparse.update_leaf(path1, VALUE_A(), is_private, &provider).unwrap();
+        sparse.update_leaf(path1, VALUE_A(), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent));
@@ -2096,9 +2074,8 @@ mod find_leaf_tests {
         let mut sparse = SerialSparseTrie::default();
         let existing_leaf_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4, 0x5, 0x6]);
-        let is_private = false; // hardcode to false for legacy test
 
-        sparse.update_leaf(existing_leaf_path, VALUE_A(), is_private, &provider).unwrap();
+        sparse.update_leaf(existing_leaf_path, VALUE_A(), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent));
@@ -2111,10 +2088,9 @@ mod find_leaf_tests {
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Creates branch at 0x12
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2]); // Path of the branch itself
-        let is_private = false; // hardcode to false for legacy test
 
-        sparse.update_leaf(path1, VALUE_A(), is_private, &provider).unwrap();
-        sparse.update_leaf(path2, VALUE_B(), is_private, &provider).unwrap();
+        sparse.update_leaf(path1, VALUE_A(), &provider).unwrap();
+        sparse.update_leaf(path2, VALUE_B(), &provider).unwrap();
 
         let result = sparse.find_leaf(&search_path, None);
         assert_matches!(result, Ok(LeafLookup::NonExistent));
@@ -2166,7 +2142,6 @@ mod find_leaf_tests {
         let blinded_hash = B256::repeat_byte(0xAA);
         let path_to_blind = Nibbles::from_nibbles_unchecked([0x1]);
         let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]);
-        let is_private = false; // legacy test does not use private storage
 
         let mut nodes = HashMap::default();
 
@@ -2180,7 +2155,7 @@ mod find_leaf_tests {
         let path_revealed_leaf = Nibbles::from_nibbles_unchecked([0x5, 0x6, 0x7, 0x8]);
         nodes.insert(
             path_revealed,
-            SparseNode::new_leaf(Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8]), is_private),
+            SparseNode::new_leaf(Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8])),
         );
 
         let mut values = HashMap::default();
@@ -2214,13 +2189,11 @@ mod find_leaf_tests {
         let revealed_leaf_suffix = Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8]);
         let revealed_leaf_full_path = Nibbles::from_nibbles_unchecked([0x5, 0x6, 0x7, 0x8]);
         let revealed_value = VALUE_A();
-        let is_private = false; // legacy test does not use private storage
 
         // 1. Construct the RLP representation of the children for the root branch
         let rlp_node_child1 = RlpNode::word_rlp(&blinded_hash); // Blinded node
 
-        let leaf_node_child5 =
-            LeafNode::new(revealed_leaf_suffix, revealed_value.clone(), is_private);
+        let leaf_node_child5 = LeafNode::new(revealed_leaf_suffix, revealed_value.clone());
         let leaf_node_child5_rlp_buf = alloy_rlp::encode(&leaf_node_child5);
         let hash_of_child5 = keccak256(&leaf_node_child5_rlp_buf);
         let rlp_node_child5 = RlpNode::word_rlp(&hash_of_child5);
@@ -2321,7 +2294,6 @@ mod tests {
         proof_targets: impl IntoIterator<Item = Nibbles>,
     ) -> (B256, TrieUpdates, ProofNodes, HashMap<Nibbles, TrieMask>, HashMap<Nibbles, TrieMask>)
     {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let mut account_rlp = Vec::new();
 
         let mut hash_builder = HashBuilder::default()
@@ -2355,7 +2327,7 @@ mod tests {
                     let account = account.into_trie_account(EMPTY_ROOT_HASH);
                     account.encode(&mut account_rlp);
 
-                    hash_builder.add_leaf(Nibbles::unpack(key), &account_rlp, is_private);
+                    hash_builder.add_leaf(Nibbles::unpack(key), &account_rlp);
                     account_rlp.clear();
                 }
             }
@@ -2413,11 +2385,9 @@ mod tests {
                 ) => proof_key == sparse_key,
                 // Both nodes are leaves and have the same key
                 (
-                    TrieNode::Leaf(LeafNode {
-                        key: proof_key, is_private: proof_is_private, ..
-                    }),
-                    SparseNode::Leaf { key: sparse_key, is_private: sparse_is_private, .. },
-                ) => proof_key == sparse_key && proof_is_private == sparse_is_private,
+                    TrieNode::Leaf(LeafNode { key: proof_key, .. }),
+                    SparseNode::Leaf { key: sparse_key, .. },
+                ) => proof_key == sparse_key,
                 // Empty and hash nodes are specific to the sparse trie, skip them
                 (_, SparseNode::Empty | SparseNode::Hash(_)) => continue,
                 _ => false,
@@ -2437,7 +2407,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_one() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let key = Nibbles::unpack(B256::with_last_byte(42));
         let value = || Account::default();
         let value_encoded = || {
@@ -2456,7 +2425,7 @@ mod tests {
 
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
-        sparse.update_leaf(key, value_encoded(), is_private, &provider).unwrap();
+        sparse.update_leaf(key, value_encoded(), &provider).unwrap();
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
 
@@ -2467,7 +2436,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple_lower_nibbles() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         reth_tracing::init_test_tracing();
 
         let paths = (0..=16).map(|b| Nibbles::unpack(B256::with_last_byte(b))).collect::<Vec<_>>();
@@ -2489,7 +2457,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded(), is_private, &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -2501,7 +2469,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple_upper_nibbles() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let paths = (239..=255).map(|b| Nibbles::unpack(B256::repeat_byte(b))).collect::<Vec<_>>();
         let value = || Account::default();
         let value_encoded = || {
@@ -2521,7 +2488,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded(), is_private, &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -2533,7 +2500,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let paths = (0..=255)
             .map(|b| {
                 Nibbles::unpack(if b % 2 == 0 {
@@ -2561,7 +2527,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, value_encoded(), is_private, &provider).unwrap();
+            sparse.update_leaf(*path, value_encoded(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -2576,7 +2542,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_repeated() {
-        let is_private = false; // legacy test does not use private storage
         let paths = (0..=255).map(|b| Nibbles::unpack(B256::repeat_byte(b))).collect::<Vec<_>>();
         let old_value = Account { nonce: 1, ..Default::default() };
         let old_value_encoded = {
@@ -2602,7 +2567,7 @@ mod tests {
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
         for path in &paths {
-            sparse.update_leaf(*path, old_value_encoded.clone(), is_private, &provider).unwrap();
+            sparse.update_leaf(*path, old_value_encoded.clone(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.updates_ref();
@@ -2620,7 +2585,7 @@ mod tests {
             );
 
         for path in &paths {
-            sparse.update_leaf(*path, new_value_encoded.clone(), is_private, &provider).unwrap();
+            sparse.update_leaf(*path, new_value_encoded.clone(), &provider).unwrap();
         }
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
@@ -2632,8 +2597,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_remove_leaf() {
-        let is_private = false; // hardcoded to false all nodes except first
-
         reth_tracing::init_test_tracing();
 
         let provider = DefaultTrieNodeProvider;
@@ -2642,52 +2605,22 @@ mod tests {
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
 
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                value.clone(),
-                true,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]),
-                value,
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]), value, &provider)
             .unwrap();
 
         // Extension (Key = 5)
@@ -2717,29 +2650,29 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::default(), true)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::default(), is_private)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x1, 0x3]), is_private),
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x1, 0x3]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -2772,25 +2705,25 @@ mod tests {
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::default(), true)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                    SparseNode::new_leaf(Nibbles::default(), is_private)
+                    SparseNode::new_leaf(Nibbles::default())
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -2812,21 +2745,21 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3]), SparseNode::new_branch(0b1010.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x1]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0, 0x2]))
                 ),
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -2846,7 +2779,7 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3]),
@@ -2855,11 +2788,11 @@ mod tests {
                 (Nibbles::from_nibbles([0x5, 0x3, 0x3]), SparseNode::new_branch(0b0101.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x0]))
                 )
             ])
         );
@@ -2877,11 +2810,11 @@ mod tests {
                 (Nibbles::from_nibbles([0x5]), SparseNode::new_branch(0b1001.into())),
                 (
                     Nibbles::from_nibbles([0x5, 0x0]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x2, 0x3, 0x3]))
                 ),
                 (
                     Nibbles::from_nibbles([0x5, 0x3]),
-                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x0, 0x2]), is_private)
+                    SparseNode::new_leaf(Nibbles::from_nibbles([0x3, 0x0, 0x2]))
                 ),
             ])
         );
@@ -2893,7 +2826,7 @@ mod tests {
             sparse.nodes.clone().into_iter().collect::<BTreeMap<_, _>>(),
             BTreeMap::from_iter([(
                 Nibbles::default(),
-                SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), is_private)
+                SparseNode::new_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]))
             ),])
         );
 
@@ -2908,14 +2841,9 @@ mod tests {
 
     #[test]
     fn sparse_trie_remove_leaf_blinded() {
-        // legacy test does not use private storage
-        // not relevant to removing a blinded leaf
-        let is_private = false;
-
         let leaf = LeafNode::new(
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
-            is_private,
         );
         let branch = TrieNode::Branch(BranchNode::new(
             vec![
@@ -2958,14 +2886,9 @@ mod tests {
 
     #[test]
     fn sparse_trie_remove_leaf_non_existent() {
-        // legacy test does not use private storage
-        // not relevant to removing a non-existent leaf
-        let is_private = false;
-
         let leaf = LeafNode::new(
             Nibbles::default(),
             alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec(),
-            is_private,
         );
         let branch = TrieNode::Branch(BranchNode::new(
             vec![
@@ -3018,7 +2941,6 @@ mod tests {
                 let default_provider = DefaultTrieNodeProvider;
                 let provider_factory = create_test_provider_factory();
                 let mut sparse = SerialSparseTrie::default().with_updates(true);
-                let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
 
                 for (update, keys_to_delete) in updates {
                     // Insert state updates into the sparse trie and calculate the root
@@ -3026,9 +2948,7 @@ mod tests {
                         let account = account.into_trie_account(EMPTY_ROOT_HASH);
                         let mut account_rlp = Vec::new();
                         account.encode(&mut account_rlp);
-                        sparse
-                            .update_leaf(key, account_rlp, is_private, &default_provider)
-                            .unwrap();
+                        sparse.update_leaf(key, account_rlp, &default_provider).unwrap();
                     }
                     // We need to clone the sparse trie, so that all updated branch nodes are
                     // preserved, and not only those that were changed after the last call to
@@ -3160,8 +3080,6 @@ mod tests {
     /// replacing it.
     #[test]
     fn sparse_trie_reveal_node_1() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
-
         let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00]));
         let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01]));
         let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x02]));
@@ -3219,7 +3137,7 @@ mod tests {
         );
 
         // Insert the leaf for the second key
-        sparse.update_leaf(key2(), value_encoded(), is_private, &provider).unwrap();
+        sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
 
         // Check that the branch node was updated and another nibble was set
         assert_eq!(
@@ -3375,7 +3293,6 @@ mod tests {
     ///    overwritten with the extension node from the proof.
     #[test]
     fn sparse_trie_reveal_node_3() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
         let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x01]));
         let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x02]));
         let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01, 0x00]));
@@ -3413,7 +3330,7 @@ mod tests {
         );
 
         // Insert the leaf with a different prefix
-        sparse.update_leaf(key3(), value_encoded(), is_private, &provider).unwrap();
+        sparse.update_leaf(key3(), value_encoded(), &provider).unwrap();
 
         // Check that the extension node was turned into a branch node
         assert_matches!(
@@ -3450,7 +3367,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_get_changed_nodes_at_depth() {
-        let is_private = false; // hardcoded to false all nodes except first
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
 
@@ -3469,52 +3385,22 @@ mod tests {
         //                       ├── 0 -> Leaf (Key = 3302, Path = 53302) – Level 4
         //                       └── 2 -> Leaf (Key = 3320, Path = 53320) – Level 4
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]),
-                value,
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]), value, &provider)
             .unwrap();
 
         assert_eq!(
@@ -3580,7 +3466,6 @@ mod tests {
 
     #[test]
     fn hash_builder_branch_hash_mask() {
-        let is_private = false; // legacy test does not use private storage
         let key1 = || pad_nibbles_left(Nibbles::from_nibbles_unchecked([0x00]));
         let key2 = || pad_nibbles_left(Nibbles::from_nibbles_unchecked([0x01]));
         let value = || Account { bytecode_hash: Some(B256::repeat_byte(1)), ..Default::default() };
@@ -3599,8 +3484,8 @@ mod tests {
 
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
-        sparse.update_leaf(key1(), value_encoded(), is_private, &provider).unwrap();
-        sparse.update_leaf(key2(), value_encoded(), is_private, &provider).unwrap();
+        sparse.update_leaf(key1(), value_encoded(), &provider).unwrap();
+        sparse.update_leaf(key2(), value_encoded(), &provider).unwrap();
         let sparse_root = sparse.root();
         let sparse_updates = sparse.take_updates();
 
@@ -3610,7 +3495,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_wipe() {
-        let is_private = false; // hardcoded to false all nodes except first
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default().with_updates(true);
 
@@ -3629,52 +3513,22 @@ mod tests {
         //                       ├── 0 -> Leaf (Key = 3302, Path = 53302) – Level 4
         //                       └── 2 -> Leaf (Key = 3320, Path = 53320) – Level 4
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]),
-                value,
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]), value, &provider)
             .unwrap();
 
         sparse.wipe();
@@ -3689,44 +3543,22 @@ mod tests {
 
     #[test]
     fn sparse_trie_clear() {
-        let is_private = false; // hardcoded to false for legacy test
-
         // tests that if we fill a sparse trie with some nodes and then clear it, it has the same
         // contents as an empty sparse trie
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
         let value = alloy_rlp::encode_fixed_size(&U256::ZERO).to_vec();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
-                value,
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value, &provider)
             .unwrap();
 
         sparse.clear();
@@ -3737,8 +3569,6 @@ mod tests {
 
     #[test]
     fn sparse_trie_display() {
-        let is_private = false; // hardcoded to false all nodes except first
-
         let provider = DefaultTrieNodeProvider;
         let mut sparse = SerialSparseTrie::default();
 
@@ -3757,52 +3587,22 @@ mod tests {
         //                       ├── 0 -> Leaf (Key = 3302, Path = 53302) – Level 4
         //                       └── 2 -> Leaf (Key = 3320, Path = 53320) – Level 4
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]),
-                value.clone(),
-                true,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x1]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x0, 0x2, 0x3, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x2, 0x0, 0x1, 0x3]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x1, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]),
-                value.clone(),
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x0, 0x2]), value.clone(), &provider)
             .unwrap();
         sparse
-            .update_leaf(
-                Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]),
-                value,
-                is_private,
-                &provider,
-            )
+            .update_leaf(Nibbles::from_nibbles([0x5, 0x3, 0x3, 0x2, 0x0]), value, &provider)
             .unwrap();
 
         let normal_printed = format!("{sparse}");
@@ -3811,14 +3611,14 @@ Root -> Extension { key: Nibbles(0x5), hash: None, store_in_db_trie: None }
 5 -> Branch { state_mask: TrieMask(0000000000001101), hash: None, store_in_db_trie: None }
 50 -> Extension { key: Nibbles(0x23), hash: None, store_in_db_trie: None }
 5023 -> Branch { state_mask: TrieMask(0000000000001010), hash: None, store_in_db_trie: None }
-50231 -> Leaf { key: Nibbles(0x), hash: None, is_private: true }
-50233 -> Leaf { key: Nibbles(0x), hash: None, is_private: false }
-52013 -> Leaf { key: Nibbles(0x013), hash: None, is_private: false }
+50231 -> Leaf { key: Nibbles(0x), hash: None }
+50233 -> Leaf { key: Nibbles(0x), hash: None }
+52013 -> Leaf { key: Nibbles(0x013), hash: None }
 53 -> Branch { state_mask: TrieMask(0000000000001010), hash: None, store_in_db_trie: None }
-53102 -> Leaf { key: Nibbles(0x02), hash: None, is_private: false }
+53102 -> Leaf { key: Nibbles(0x02), hash: None }
 533 -> Branch { state_mask: TrieMask(0000000000000101), hash: None, store_in_db_trie: None }
-53302 -> Leaf { key: Nibbles(0x2), hash: None, is_private: false }
-53320 -> Leaf { key: Nibbles(0x0), hash: None, is_private: false }
+53302 -> Leaf { key: Nibbles(0x2), hash: None }
+53320 -> Leaf { key: Nibbles(0x0), hash: None }
 ";
         assert_eq!(normal_printed, expected);
 
@@ -3828,14 +3628,14 @@ Root -> Extension { key: Nibbles(0x5), hash: None, store_in_db_trie: None }
     5 -> Branch { state_mask: TrieMask(0000000000001101), hash: None, store_in_db_trie: None }
         50 -> Extension { key: Nibbles(0x23), hash: None, store_in_db_trie: None }
             5023 -> Branch { state_mask: TrieMask(0000000000001010), hash: None, store_in_db_trie: None }
-                50231 -> Leaf { key: Nibbles(0x), hash: None, is_private: true }
-                50233 -> Leaf { key: Nibbles(0x), hash: None, is_private: false }
-        52013 -> Leaf { key: Nibbles(0x013), hash: None, is_private: false }
+                50231 -> Leaf { key: Nibbles(0x), hash: None }
+                50233 -> Leaf { key: Nibbles(0x), hash: None }
+        52013 -> Leaf { key: Nibbles(0x013), hash: None }
         53 -> Branch { state_mask: TrieMask(0000000000001010), hash: None, store_in_db_trie: None }
-            53102 -> Leaf { key: Nibbles(0x02), hash: None, is_private: false }
+            53102 -> Leaf { key: Nibbles(0x02), hash: None }
             533 -> Branch { state_mask: TrieMask(0000000000000101), hash: None, store_in_db_trie: None }
-                53302 -> Leaf { key: Nibbles(0x2), hash: None, is_private: false }
-                53320 -> Leaf { key: Nibbles(0x0), hash: None, is_private: false }
+                53302 -> Leaf { key: Nibbles(0x2), hash: None }
+                53320 -> Leaf { key: Nibbles(0x0), hash: None }
 ";
 
         assert_eq!(alternate_printed, expected);

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -74,16 +74,11 @@ serde = [
     "alloy-eips/serde",
     "reth-trie-common/serde",
     "reth-primitives-traits/serde",
-    "alloy-primitives/serde",
-    "alloy-consensus/serde",
-    "alloy-trie/serde",
-    "alloy-eips/serde",
-    "reth-trie-common/serde",
+    "reth-ethereum-primitives/serde",
     "revm-database/serde",
     "reth-stages-types/serde",
     "revm-state/serde",
     "parking_lot/serde",
-    "reth-ethereum-primitives/serde",
 ]
 test-utils = [
     "triehash",

--- a/crates/trie/trie/benches/trie_root.rs
+++ b/crates/trie/trie/benches/trie_root.rs
@@ -71,8 +71,7 @@ mod implementations {
             value_buffer.clear();
             receipts[index].encode_2718(&mut value_buffer);
 
-            let is_private = false; // hardcode to false for legacy bench
-            hb.add_leaf(Nibbles::unpack(&index_buffer), &value_buffer, is_private);
+            hb.add_leaf(Nibbles::unpack(&index_buffer), &value_buffer);
         }
 
         hb.root()

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -280,9 +280,9 @@ where
                     // the database, so the walker will advance to the branch node after it. Because
                     // of this, we need to check that the current walker key has a prefix of the key
                     // that we seeked to.
-                    if can_skip_node
-                        && self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix))
-                        && self.walker.children_are_in_trie()
+                    if can_skip_node &&
+                        self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
+                        self.walker.children_are_in_trie()
                     {
                         trace!(
                             target: "trie::node_iter",

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -227,7 +227,7 @@ where
                 // Check if the walker's key is less than the key of the current hashed entry
                 if self.walker.key().is_some_and(|key| key < &Nibbles::unpack(hashed_key)) {
                     self.should_check_walker_key = false;
-                    continue
+                    continue;
                 }
 
                 // Set the next hashed entry as a leaf node and return
@@ -236,7 +236,7 @@ where
 
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_leaf_nodes_returned();
-                return Ok(Some(TrieElement::Leaf(hashed_key, value)))
+                return Ok(Some(TrieElement::Leaf(hashed_key, value)));
             }
 
             // Handle seeking and advancing based on the previous hashed key
@@ -280,9 +280,9 @@ where
                     // the database, so the walker will advance to the branch node after it. Because
                     // of this, we need to check that the current walker key has a prefix of the key
                     // that we seeked to.
-                    if can_skip_node &&
-                        self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
-                        self.walker.children_are_in_trie()
+                    if can_skip_node
+                        && self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix))
+                        && self.walker.children_are_in_trie()
                     {
                         trace!(
                             target: "trie::node_iter",
@@ -292,7 +292,7 @@ where
                         );
 
                         self.should_check_walker_key = false;
-                        continue
+                        continue;
                     }
 
                     self.current_hashed_entry = self.seek_hashed_entry(seek_key)?;
@@ -368,7 +368,6 @@ mod tests {
                     hash_builder.add_leaf(
                         Nibbles::unpack(key),
                         &alloy_rlp::encode(account.into_trie_account(EMPTY_ROOT_HASH)),
-                        false, // account nodes are always public
                     );
                 }
             }
@@ -387,7 +386,6 @@ mod tests {
             RlpNode::from_rlp(&alloy_rlp::encode(LeafNode::new(
                 key,
                 alloy_rlp::encode(TrieAccount::default()),
-                false, // account nodes are always public
             )))
         }
 

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -153,12 +153,7 @@ where
                     let account = account.into_trie_account(storage_multiproof.root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
 
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
-                    hash_builder.add_leaf(
-                        Nibbles::unpack(hashed_address),
-                        &account_rlp,
-                        is_private,
-                    );
+                    hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
 
                     // We might be adding leaves that are not necessarily our proof targets.
                     if leaf_is_proof_target {
@@ -308,7 +303,7 @@ where
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {
-            return Ok(StorageMultiProof::empty());
+            return Ok(StorageMultiProof::empty())
         }
 
         let target_nibbles = targets.into_iter().map(Nibbles::unpack).collect::<Vec<_>>();
@@ -333,7 +328,6 @@ where
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_slot),
                         alloy_rlp::encode_fixed_size(&value).as_ref(),
-                        value.is_private,
                     );
                 }
             }

--- a/crates/trie/trie/src/test_utils.rs
+++ b/crates/trie/trie/src/test_utils.rs
@@ -78,7 +78,7 @@ where
     for (hashed_address, account) in account_entries {
         let nibbles = Nibbles::unpack(hashed_address);
         let encoded_account = alloy_rlp::encode(account);
-        hash_builder.add_leaf(nibbles, &encoded_account, false);
+        hash_builder.add_leaf(nibbles, &encoded_account);
     }
 
     hash_builder.root()
@@ -102,7 +102,7 @@ pub fn storage_root_privacy_aware<
     for (hashed_key, flagged_storage) in storage_entries {
         let nibbles = Nibbles::unpack(hashed_key);
         let encoded_value = encode_fixed_size(&flagged_storage);
-        hash_builder.add_leaf(nibbles, &encoded_value, flagged_storage.is_private());
+        hash_builder.add_leaf(nibbles, &encoded_value);
     }
 
     hash_builder.root()
@@ -126,7 +126,7 @@ pub fn storage_root_prehashed_privacy_aware<
     for (key, flagged_storage) in storage_entries {
         let nibbles = Nibbles::unpack(key);
         let encoded_value = encode_fixed_size(&flagged_storage);
-        hash_builder.add_leaf(nibbles, &encoded_value, flagged_storage.is_private());
+        hash_builder.add_leaf(nibbles, &encoded_value);
     }
 
     hash_builder.root()

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -221,8 +221,6 @@ where
                     hashed_address,
                     account,
                     &mut hash_builder,
-                    // TODO(audit)
-                    false,
                     retain_updates,
                 )? {
                     // still in progress, need to pause again
@@ -254,7 +252,6 @@ where
                 }
                 TrieElement::Leaf(hashed_address, account) => {
                     tracker.inc_leaf();
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
                     storage_ctx.hashed_entries_walked += 1;
 
                     // calculate storage root, calculating the remaining threshold so we have
@@ -283,7 +280,6 @@ where
                         hashed_address,
                         account,
                         &mut hash_builder,
-                        is_private,
                         retain_updates,
                     )? {
                         // storage root hit threshold, need to pause
@@ -418,7 +414,6 @@ impl StateRootContext {
         hashed_address: B256,
         account: Account,
         hash_builder: &mut HashBuilder,
-        is_private: bool,
         retain_updates: bool,
     ) -> Result<Option<IntermediateStorageRootState>, StateRootError> {
         match storage_result {
@@ -437,7 +432,6 @@ impl StateRootContext {
                 hash_builder.add_leaf(
                     Nibbles::unpack(hashed_address),
                     &self.account_rlp,
-                    is_private,
                 );
                 Ok(None)
             }
@@ -676,7 +670,6 @@ where
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_slot),
                         alloy_rlp::encode_fixed_size(&value).as_ref(),
-                        value.is_private,
                     );
 
                     // Check if we need to return intermediate progress

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -429,10 +429,7 @@ impl StateRootContext {
                 self.account_rlp.clear();
                 let trie_account = account.into_trie_account(storage_root);
                 trie_account.encode(&mut self.account_rlp as &mut dyn BufMut);
-                hash_builder.add_leaf(
-                    Nibbles::unpack(hashed_address),
-                    &self.account_rlp,
-                );
+                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &self.account_rlp);
                 Ok(None)
             }
             StorageRootProgress::Progress(state, storage_slots_walked, updates) => {

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -176,14 +176,9 @@ where
                     storage.and_then(|s| s.storage.get(&hashed_slot)).filter(|v| !v.is_zero());
                 if let Some(value) = maybe_leaf_value {
                     let value = alloy_rlp::encode_fixed_size(value).to_vec();
-                    storage_trie
-                        .update_leaf(storage_nibbles, value, &provider)
-                        .map_err(|err| {
-                            SparseStateTrieErrorKind::SparseStorageTrie(
-                                hashed_address,
-                                err.into_kind(),
-                            )
-                        })?;
+                    storage_trie.update_leaf(storage_nibbles, value, &provider).map_err(|err| {
+                        SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())
+                    })?;
                 } else {
                     storage_trie.remove_leaf(&storage_nibbles, &provider).map_err(|err| {
                         SparseStateTrieErrorKind::SparseStorageTrie(hashed_address, err.into_kind())

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -175,10 +175,9 @@ where
                 let maybe_leaf_value =
                     storage.and_then(|s| s.storage.get(&hashed_slot)).filter(|v| !v.is_zero());
                 if let Some(value) = maybe_leaf_value {
-                    let is_private = value.is_private;
                     let value = alloy_rlp::encode_fixed_size(value).to_vec();
                     storage_trie
-                        .update_leaf(storage_nibbles, value, is_private, &provider)
+                        .update_leaf(storage_nibbles, value, &provider)
                         .map_err(|err| {
                             SparseStateTrieErrorKind::SparseStorageTrie(
                                 hashed_address,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+style_edition = "2021"
 reorder_imports = true
 imports_granularity = "Crate"
 use_small_heuristics = "Max"


### PR DESCRIPTION
Related to:
- https://github.com/SeismicSystems/seismic-alloy-core/pull/58
- https://github.com/SeismicSystems/seismic-alloy/pull/80
- https://github.com/SeismicSystems/seismic-reth/pull/328

## DO NOT MERGE

> We probably will want to only merge this after the audit is done, unless we decide we want to pull the trigger and want it audited.

Depends on:
- https://github.com/SeismicSystems/seismic-alloy-core/pull/58
- https://github.com/SeismicSystems/seismic-alloy/pull/80

These PRs implement a migration away from our seismic-trie fork and back to using stock alloy-trie, by changing the way we RLP encode FlaggedStorage slots.

See design in https://hackmd.io/ZOGfcUP2SyKmPeOuz0tmvg

## Diff with upstream

this branch vs main (upstream)
```
 crates/trie/common/src/proofs.rs                               | 41 ++++++++++++++++++++++++++++---------
 crates/trie/common/src/root.rs                                 |  9 ++++++---
 crates/trie/db/Cargo.toml                                      |  7 +++++++
 crates/trie/db/src/hashed_cursor.rs                            |  9 +++++----
 crates/trie/db/src/state.rs                                    | 23 ++++++++++++++++-----
 crates/trie/db/src/storage.rs                                  |  2 +-
 crates/trie/db/tests/fuzz_in_memory_nodes.proptest-regressions |  7 +++++++
 crates/trie/db/tests/fuzz_in_memory_nodes.rs                   |  6 +++---
 crates/trie/db/tests/post_state.rs                             | 61 ++++++++++++++++++++++++++++++++-----------------------
 crates/trie/db/tests/proof.rs                                  |  8 ++++++++
 crates/trie/db/tests/trie.proptest-regressions                 |  8 ++++++++
 crates/trie/db/tests/trie.rs                                   | 68 +++++++++++++++++++++++++++++++++++++++++++------------------
 crates/trie/db/tests/witness.rs                                | 23 +++++++++++++++------
 crates/trie/parallel/Cargo.toml                                |  2 ++
 crates/trie/parallel/benches/root.rs                           |  9 ++++++---
 crates/trie/parallel/src/lib.rs                                |  2 +-
 crates/trie/parallel/src/proof.rs                              |  8 ++++----
 crates/trie/parallel/src/root.rs                               |  9 +++++----
 crates/trie/sparse-parallel/src/trie.rs                        | 49 +++++++++++++++++++++++---------------------
 crates/trie/sparse/benches/rlp_node.rs                         |  1 +
 crates/trie/sparse/benches/root.rs                             |  6 +++++-
 crates/trie/sparse/src/state.rs                                |  5 ++---
 crates/trie/sparse/src/trie.rs                                 | 40 +++++++++++++++++++-----------------
 crates/trie/trie/Cargo.toml                                    |  8 ++------
 crates/trie/trie/benches/hash_post_state.rs                    |  5 +++--
 crates/trie/trie/src/hashed_cursor/mock.rs                     |  9 +++++----
 crates/trie/trie/src/hashed_cursor/mod.rs                      |  5 +++--
 crates/trie/trie/src/hashed_cursor/noop.rs                     |  5 +++--
 crates/trie/trie/src/hashed_cursor/post_state.rs               | 35 +++++++++++++++++++-------------
 crates/trie/trie/src/lib.rs                                    |  2 +-
 crates/trie/trie/src/node_iter.rs                              |  8 ++++----
 crates/trie/trie/src/test_utils.rs                             | 94 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
 crates/trie/trie/src/verify.rs                                 |  7 ++++---
 crates/trie/trie/src/witness.rs                                |  8 +++-----
 40 files changed, 462 insertions(+), 216 deletions(-)
```

seismic branch vs main branch
```
 crates/trie/common/Cargo.toml                                  |   4 +-
 crates/trie/common/src/account.rs                              |   8 +-
 crates/trie/common/src/added_removed_keys.rs                   |  14 +--
 crates/trie/common/src/hash_builder/state.rs                   |  49 +++++++++-
 crates/trie/common/src/hashed_state.rs                         |  56 +++++++----
 crates/trie/common/src/lib.rs                                  |   2 +-
 crates/trie/common/src/proofs.rs                               |  34 +++++--
 crates/trie/db/Cargo.toml                                      |   7 ++
 crates/trie/db/src/hashed_cursor.rs                            |   9 +-
 crates/trie/db/src/state.rs                                    |  27 +++++-
 crates/trie/db/src/storage.rs                                  |   2 +-
 crates/trie/db/tests/fuzz_in_memory_nodes.proptest-regressions |   7 ++
 crates/trie/db/tests/fuzz_in_memory_nodes.rs                   |   6 +-
 crates/trie/db/tests/post_state.rs                             |  61 +++++++-----
 crates/trie/db/tests/proof.rs                                  |   8 ++
 crates/trie/db/tests/trie.proptest-regressions                 |   8 ++
 crates/trie/db/tests/trie.rs                                   | 117 +++++++++++++++++------
 crates/trie/db/tests/witness.rs                                |  23 +++--
 crates/trie/parallel/Cargo.toml                                |   2 +
 crates/trie/parallel/benches/root.rs                           |   9 +-
 crates/trie/parallel/src/lib.rs                                |   2 +-
 crates/trie/parallel/src/proof.rs                              |  15 ++-
 crates/trie/parallel/src/root.rs                               |  16 +++-
 crates/trie/sparse-parallel/src/trie.rs                        | 241 ++++++++++++++++++++++++++--------------------
 crates/trie/sparse/benches/rlp_node.rs                         |   6 +-
 crates/trie/sparse/benches/root.rs                             |  20 +++-
 crates/trie/sparse/benches/update.rs                           |   6 +-
 crates/trie/sparse/src/state.rs                                |  41 ++++++--
 crates/trie/sparse/src/traits.rs                               |   1 +
 crates/trie/sparse/src/trie.rs                                 | 436 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----------------------
 crates/trie/trie/Cargo.toml                                    |   1 +
 crates/trie/trie/benches/hash_post_state.rs                    |   5 +-
 crates/trie/trie/benches/trie_root.rs                          |   3 +-
 crates/trie/trie/src/hashed_cursor/mock.rs                     |   9 +-
 crates/trie/trie/src/hashed_cursor/mod.rs                      |   5 +-
 crates/trie/trie/src/hashed_cursor/noop.rs                     |   5 +-
 crates/trie/trie/src/hashed_cursor/post_state.rs               |  35 ++++---
 crates/trie/trie/src/lib.rs                                    |   2 +-
 crates/trie/trie/src/node_iter.rs                              |   4 +-
 crates/trie/trie/src/proof/mod.rs                              |  10 +-
 crates/trie/trie/src/test_utils.rs                             |  94 +++++++++++++++++-
 crates/trie/trie/src/trie.rs                                   |  12 ++-
 crates/trie/trie/src/verify.rs                                 |   7 +-
 crates/trie/trie/src/witness.rs                                |  20 ++--
 44 files changed, 1037 insertions(+), 412 deletions(-)
```