### PR TITLE
fix(chain-state): make revm-state optional like upstream

### DIFF
--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -27,7 +27,7 @@ alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["std"] }
 alloy-consensus.workspace = true
 revm-database.workspace = true
-revm-state = { workspace = true }
+revm-state = { workspace = true, optional = true }
 
 # async
 tokio = { workspace = true, default-features = false, features = ["sync", "macros"] }
@@ -68,7 +68,7 @@ serde = [
     "reth-primitives-traits/serde",
     "reth-trie/serde",
     "revm-database/serde",
-    # "revm-state?/serde",
+    "revm-state?/serde",
     "reth-storage-api/serde",
 ]
 test-utils = [
@@ -76,6 +76,7 @@ test-utils = [
     "alloy-signer",
     "alloy-signer-local",
     "rand",
+    "revm-state",
     "reth-chainspec/test-utils",
     "reth-primitives-traits/test-utils",
     "reth-trie/test-utils",

--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -8,8 +8,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use revm_state as _;
-
 mod in_memory;
 pub use in_memory::*;
 

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -72,8 +72,9 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
     let is_private = false; // hardcode to false for legacy test
 
     let mut group = c.benchmark_group("calculate root from leaves repeated");
+    group.sample_size(20);
 
-    for init_size in [1_000, 10_000, 100_000, 1_000_000] {
+    for init_size in [1_000, 10_000, 100_000, 1_000_00] {
         // Too slow.
         #[expect(unexpected_cfgs)]
         if cfg!(codspeed) && init_size > 10_000 {

--- a/crates/trie/sparse/benches/root.rs
+++ b/crates/trie/sparse/benches/root.rs
@@ -72,9 +72,8 @@ fn calculate_root_from_leaves_repeated(c: &mut Criterion) {
     let is_private = false; // hardcode to false for legacy test
 
     let mut group = c.benchmark_group("calculate root from leaves repeated");
-    group.sample_size(20);
 
-    for init_size in [1_000, 10_000, 100_000] {
+    for init_size in [1_000, 10_000, 100_000, 1_000_000] {
         // Too slow.
         #[expect(unexpected_cfgs)]
         if cfg!(codspeed) && init_size > 10_000 {


### PR DESCRIPTION
Small refactor to minimize diff with upstream. Think this was changed by mistake.

new diff in this PR:
```
~/devel/seismic-workspace/seismic-reth [refactor--minimize-chain-state-crate-diff-with-upstream] $ git diff main --stat crates/chain-state
 crates/chain-state/src/in_memory.rs      | 6 ++++--
 crates/chain-state/src/lib.rs            | 2 +-
 crates/chain-state/src/memory_overlay.rs | 6 ++++--
 3 files changed, 9 insertions(+), 5 deletions(-)
```

Current seismic branch diff with main:
```
~/devel/seismic-workspace/seismic-reth [seismic] $ git diff main --stat crates/chain-state
 crates/chain-state/Cargo.toml            | 5 ++---
 crates/chain-state/src/in_memory.rs      | 6 ++++--
 crates/chain-state/src/lib.rs            | 4 +++-
 crates/chain-state/src/memory_overlay.rs | 6 ++++--
 4 files changed, 13 insertions(+), 8 deletions(-)
```


## Claude Analysis
```
  The diff has 3 related changes:

  1. revm-state changed from optional to non-optional (line 30)
  2. "revm-state?/serde" commented out in the serde feature (line 71)
  3. "revm-state" removed from test-utils feature (line 79)

  Why it was done:

  In upstream reth, revm-state is an optional dependency only pulled in by the test-utils feature — it's used solely in test_utils.rs (use
  revm_state::AccountInfo). The ? syntax in "revm-state?/serde" means "enable serde on revm-state only if it's already enabled."

  On the seismic branch, someone added use revm_state as _; to lib.rs (not behind #[cfg(feature = "test-utils")]). This is a dummy import that exists only
  to suppress the unused_crate_dependencies lint (the #![cfg_attr(not(test), warn(unused_crate_dependencies))] at the top). But because this import is
  unconditional, it requires revm-state to always be present — hence making it non-optional.

  Once it's non-optional:
  - The ? conditional syntax in "revm-state?/serde" becomes pointless (it's always present), so it was commented out — though it should have been changed to "revm-state/serde" rather than commented out (this is likely a bug: serde won't propagate to revm-state now).
  - Listing "revm-state" in test-utils is redundant since it's always included, so it was removed.

  Was this necessary?

  No, this change appears unnecessary and introduces a minor bug. The cleaner approach would have been to either:
  1. Not add the use revm_state as _; line at all (it's not needed since the crate genuinely uses it in test-utils), or
  2. Gate the dummy import behind #[cfg(feature = "test-utils")]

  And the commented-out "revm-state?/serde" line should be "revm-state/serde" (without ?) to correctly propagate the serde feature.
```