### PR TITLE
test: fix seismic integration failure lifecycle

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,3 +16,10 @@ slow-timeout = { period = "2m", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = "binary(e2e_testsuite)"
 slow-timeout = { period = "2m", terminate-after = 3 }
+
+# Seismic e2e integration test spawns a full reth node with hardcoded port 8545.
+# Retrying just causes port conflicts and wastes minutes.
+# For now just assuming the test is not flaky, but if it becomes flaky we can add a retry strategy that doesn't cause port conflicts.
+[[profile.default.overrides]]
+filter = "package(reth-seismic-node) & test(integration::integration_test)"
+retries = 0

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -59,8 +59,8 @@ pub mod test_utils {
                 .arg("-vvvv")
                 .arg("--disable-discovery")
                 // Use OS-assigned random ports for p2p (default 30303) and auth RPC (default 8551)
-                // to avoid "address already in use" errors on nextest retries. The test only talks to the
-                // HTTP RPC port (8545), so these ports don't matter.
+                // to avoid "address already in use" errors on nextest retries. The test only talks
+                // to the HTTP RPC port (8545), so these ports don't matter.
                 .arg("--port")
                 .arg("0")
                 .arg("--authrpc.port")

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -58,9 +58,19 @@ pub mod test_utils {
                 .arg("--enclave.mock-server")
                 .arg("-vvvv")
                 .arg("--disable-discovery")
+                // Use OS-assigned random ports for p2p (default 30303) and auth RPC (default 8551)
+                // to avoid "address already in use" errors on nextest retries. The test only talks to the
+                // HTTP RPC port (8545), so these ports don't matter.
+                .arg("--port")
+                .arg("0")
+                .arg("--authrpc.port")
+                .arg("0")
                 .current_dir(workspace_root)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
+                // Ensure the child process is killed when dropped (e.g. on test panic/timeout).
+                // Without this, a test failure leaves an orphaned reth process holding ports.
+                .kill_on_drop(true)
                 .spawn()
                 .expect("Failed to start the binary");
 
@@ -72,9 +82,6 @@ pub mod test_utils {
                 let mut stdout_line = String::new();
                 let mut stderr_line = String::new();
                 let mut sent = false;
-                std::panic::set_hook(Box::new(|info| {
-                    eprintln!("❌ PANIC DETECTED: {:?}", info);
-                }));
 
                 loop {
                     tokio::select! {
@@ -109,9 +116,9 @@ pub mod test_utils {
                         }
                     }
                 }
-                println!("✅ Exiting loop.");
-
-                child.kill().await.unwrap();
+                // kill_on_drop handles cleanup, but we explicitly kill here for a clean
+                // shutdown on the happy path (avoids waiting for drop).
+                let _ = child.kill().await;
                 println!("✅ Killed child process.");
             });
         }

--- a/testing/viem-tests/viem.test.ts
+++ b/testing/viem-tests/viem.test.ts
@@ -207,5 +207,5 @@ describe("Transaction Trace", async () => {
 });
 
 afterAll(async () => {
-    await exitProcess();
+    await exitProcess?.();
 });


### PR DESCRIPTION
There were a few issues when test fails:
1. started reth binary not killed
2. nextest restarts the test 4 times, but all 3 extra times just fail due to port conflict with non-cleaned leftover binary
3. also test would panic reporting failure

Changed nextest.toml config to only run this test once.

## More involved future improvements

I feel like the test harness with compiling at beginning of test (!) + running a reth binary is overkill. Claude seems to agree with me:
```
  What SeismicRethTestCommand does                                                                                                                       
                                                                                                                                                         
  It shells out to cargo run --bin seismic-reth at runtime (utils.rs:47), which means:                                                                   
                                                                                                                                                         
  1. Recompiles reth from scratch inside the test — a full cargo run that re-invokes the compiler                                                        
  2. Parses stdout waiting for "Starting consensus engine" to know it's ready                                                                          
  3. Communicates over HTTP RPC on a hardcoded port (127.0.0.1:8545) — no isolation, port conflicts possible                                             
  4. Uses mpsc channels + kill_on_drop for lifecycle management — brittle compared to in-process                                                         
                                                                                                                                                         
  What upstream reth does instead                                                                                                                        
                                                                                                                                                         
  Reth already has reth_e2e_test_utils which starts a full node in-process — no subprocess, no recompilation. The pattern from                           
  crates/ethereum/node/tests/e2e/eth.rs:                                                                                                                 
                                                                                                                                                         
  let (mut nodes, _tasks, wallet) = setup::<EthereumNode>(                                                                                               
      1, Arc::new(chain_spec), false, eth_payload_attributes,                                                                                            
  ).await?;                                                                                                                                              
  let mut node = nodes.pop().unwrap();
                                                                                                                                                         
  // inject tx, advance block, assert — all in-process                                                                                                   
  let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
  let tx_hash = node.rpc.inject_tx(raw_tx).await?;                                                                                                       
  let payload = node.advance_block().await?;                                                                                                           
                                                                                                                                                         
  This uses NodeBuilder::new(config).testing_node(executor) which creates an ephemeral TempDatabase, starts the node in the same process/tokio runtime,  
  and gives you direct programmatic access to all internals (pool, provider, network, RPC, payload builder).                                             
                                                                                                                                                         
  Benefits of switching to in-process                                                                                                                  

  - No double compilation — reth is compiled once as part of the test binary, not again at runtime via cargo run                                         
  - No port conflicts — RPC is in-process, no hardcoded 8545
  - Better isolation — each test gets its own TempDatabase                                                                                               
  - Direct access — you can call into node internals, not just HTTP RPC                                                                                  
  - Proper lifecycle — no process management, stdout parsing, or kill_on_drop                                                                            
                                                                                                                                                         
  So yes — the test should use setup::<SeismicNode>(...) (or equivalent) instead of SeismicRethTestCommand. The only reason this approach might have been
   used is if SeismicNode didn't yet implement the traits needed by the NodeBuilder test infrastructure, but that would be the right thing to fix.
```