### PR TITLE
chore: bump revm/evm to veridise-audit branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9614,7 +9614,6 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "schnellru",
- "seismic-revm",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=aef8ee6355075dc48c376b25c2580ef3a22372f5#aef8ee6355075dc48c376b25c2580ef3a22372f5"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=4a93957d9b02c83b182cd13ea875a49b3b39d283#4a93957d9b02c83b182cd13ea875a49b3b39d283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=aef8ee6355075dc48c376b25c2580ef3a22372f5#aef8ee6355075dc48c376b25c2580ef3a22372f5"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=4a93957d9b02c83b182cd13ea875a49b3b39d283#4a93957d9b02c83b182cd13ea875a49b3b39d283"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10605,7 +10605,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10616,7 +10616,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "auto_impl",
  "either",
@@ -10672,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "auto_impl",
  "either",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10762,7 +10762,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -11467,7 +11467,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=ed81a1d6a89a8ffbf816d52715a3260b040c98bb#ed81a1d6a89a8ffbf816d52715a3260b040c98bb"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=5ba06828ab6f0f8d0d62d745efd8a35862f8603c#5ba06828ab6f0f8d0d62d745efd8a35862f8603c"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -14063,8 +14063,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-tx-macros"
-version = "1.1.0"
-source = "git+https://github.com/alloy-rs/alloy?tag=v1.1.0#78b254e4d47fca0690a4141e0f42031da8b32a09"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,14 +365,13 @@ seismic-enclave = "0.1.0"
 seismic-revm = "1.0.0"
 alloy-seismic-evm = "0.20.1"
 
-seismic-alloy-rpc-types = {version = "0.0.1", default-features = false}
-seismic-alloy-consensus = {version = "0.0.1", default-features = false}
-seismic-alloy-provider = {version = "0.0.1", default-features = false}
-seismic-alloy-genesis = {version = "0.0.1", default-features = false}
-
-seismic-alloy-rpc-types-engine = {version = "0.0.1", default-features = false}
-seismic-alloy-network = {version = "0.0.1", default-features = false}
-seismic-alloy-flz = {version = "0.0.1", default-features = false}
+seismic-alloy-rpc-types = { version = "0.0.1", default-features = false }
+seismic-alloy-consensus = { version = "0.0.1", default-features = false }
+seismic-alloy-provider = { version = "0.0.1", default-features = false }
+seismic-alloy-genesis = { version = "0.0.1", default-features = false }
+seismic-alloy-rpc-types-engine = { version = "0.0.1", default-features = false }
+seismic-alloy-network = { version = "0.0.1", default-features = false }
+seismic-alloy-flz = { version = "0.0.1", default-features = false }
 
 alloy-json-abi = { version = "1.1.2", default-features = false } # only used by seismic rn
 
@@ -779,25 +778,22 @@ alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.
 alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }
 
-# This is needed because alloy-consensus depends on this crate for some proc macro, and the versions aren't locked together.
-# seismic-prelude -> alloy-consensus (=1.1.0 in alloy's Cargo.toml) -> alloy-tx-macros (floating version which didnt respect semver)
-alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
-
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "d8425918ced1d62043c3a64b382d6fa1d8c25518" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "ed81a1d6a89a8ffbf816d52715a3260b040c98bb" }
+# Temporarily pointing to veridise-audit-feb-2026 branch until we finish audits and merge it back into seismic
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5ba06828ab6f0f8d0d62d745efd8a35862f8603c" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "9e26c0a55f522ad7d8cf4716d9df9d79b8116d52" }
 
@@ -809,6 +805,7 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
 
 # alloy-evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "aef8ee6355075dc48c376b25c2580ef3a22372f5" }
+# Temporarily pointing to veridise-audit-feb-2026 branch until we finish audits and merge it back into seismic
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "4a93957d9b02c83b182cd13ea875a49b3b39d283" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "4a93957d9b02c83b182cd13ea875a49b3b39d283" }
 

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -12,9 +12,6 @@ description = "Types supporting implementation of 'eth' namespace RPC server API
 workspace = true
 
 [dependencies]
-# seismic
-seismic-revm.workspace = true
-
 # reth
 reth-chainspec.workspace = true
 reth-chain-state.workspace = true
@@ -71,5 +68,5 @@ itertools.workspace = true
 serde_json.workspace = true
 
 [features]
-timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds"]
+timestamp-in-seconds = ["revm/timestamp-in-seconds"]
 js-tracer = ["revm-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -5,7 +5,6 @@ use crate::EthApiError;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, EvmErrorFor, HaltReasonFor};
 use revm::context_interface::result::HaltReason;
-use seismic_revm::SeismicHaltReason;
 
 use super::RpcInvalidTransactionError;
 
@@ -111,16 +110,3 @@ impl FromEvmHalt<HaltReason> for EthApiError {
     }
 }
 
-impl FromEvmHalt<SeismicHaltReason> for EthApiError {
-    fn from_evm_halt(halt: SeismicHaltReason, gas_limit: u64) -> Self {
-        match halt {
-            SeismicHaltReason::Base(reason) => EthApiError::from_evm_halt(reason, gas_limit),
-            SeismicHaltReason::InvalidPrivateStorageAccess => {
-                EthApiError::EvmCustom("Invalid Private Storage Access".to_string())
-            }
-            SeismicHaltReason::InvalidPublicStorageAccess => {
-                EthApiError::EvmCustom("Invalid Public Storage Access".to_string())
-            }
-        }
-    }
-}

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -109,4 +109,3 @@ impl FromEvmHalt<HaltReason> for EthApiError {
         RpcInvalidTransactionError::halt(halt, gas_limit).into()
     }
 }
-

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -134,7 +134,7 @@ async fn integration_test() {
 
     // Flagged storage tests
     test_eth_call_rejects_sload_on_private_storage_inner().await;
-    test_eth_call_rejects_cload_on_public_storage_inner().await;
+    test_eth_call_allows_cload_on_public_storage_inner().await;
     test_eth_call_allows_cload_on_private_storage_inner().await;
     test_solidity_read_public_sload_succeeds_inner().await;
     test_solidity_read_private_succeeds_inner().await;
@@ -991,22 +991,20 @@ async fn test_eth_call_rejects_sload_on_private_storage_inner() {
     .await;
 
     println!("readPrivateSload eth_call result: {:?}", result);
-
-    println!("readPrivateSload eth_call result: {:?}", result);
     match &result {
         Ok(output) => panic!("SLOAD on private storage should fail, but got Ok: {:?}", output),
         Err(e) => {
             let err_msg = e.to_string().to_lowercase();
             assert!(
-                err_msg.contains("invalid private storage access"),
-                "Expected 'invalid private storage access', got: {}",
+                err_msg.contains("invalidprivatestorageaccess"),
+                "Expected 'InvalidPrivateStorageAccess' revert, got: {}",
                 err_msg
             );
         }
     }
 }
 
-async fn test_eth_call_rejects_cload_on_public_storage_inner() {
+async fn test_eth_call_allows_cload_on_public_storage_inner() {
     let reth_rpc_url = SeismicRethTestCommand::url();
     let chain_id = SeismicRethTestCommand::chain_id();
     let client = jsonrpsee::http_client::HttpClientBuilder::default().build(reth_rpc_url).unwrap();
@@ -1066,7 +1064,9 @@ async fn test_eth_call_rejects_cload_on_public_storage_inner() {
     .unwrap();
     thread::sleep(Duration::from_secs(WAIT_FOR_RECEIPT_SECONDS));
 
-    // Try CLOAD on public storage via seismic eth_call - should fail
+    // Try CLOAD on public storage via seismic eth_call - should succeed
+    // (CLOAD can read both private and public storage; SLOAD should be preferred
+    // for public storage since CLOAD charges constant gas)
     let block_hash = get_recent_block_hash(&client).await;
     let read_calldata: Bytes = hex::decode(FLAGGED_STORAGE_READ_PUBLIC_CLOAD).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
@@ -1088,13 +1088,7 @@ async fn test_eth_call_rejects_cload_on_public_storage_inner() {
     )
     .await;
 
-    assert!(result.is_err(), "CLOAD on public storage should fail");
-    let err_msg = result.unwrap_err().to_string().to_lowercase();
-    assert!(
-        err_msg.contains("invalid public storage access"),
-        "Expected 'invalid public storage access', got: {}",
-        err_msg
-    );
+    assert!(result.is_ok(), "CLOAD on public storage should succeed, got: {:?}", result.err());
 }
 
 async fn test_eth_call_allows_cload_on_private_storage_inner() {

--- a/crates/seismic/rpc/src/error.rs
+++ b/crates/seismic/rpc/src/error.rs
@@ -9,7 +9,6 @@ use reth_rpc_eth_types::{error::api::FromEvmHalt, EthApiError};
 use reth_rpc_server_types::result::internal_rpc_err;
 use revm::context_interface::result::EVMError;
 use revm_context::result::HaltReason;
-use seismic_revm::SeismicHaltReason;
 
 #[derive(Debug, thiserror::Error)]
 /// Seismic API error
@@ -20,12 +19,6 @@ pub enum SeismicEthApiError {
     /// Enclave error
     #[error("enclave error: {0}")]
     EnclaveError(String),
-    /// Attempting to access public storage with cload
-    #[error("invalid public storage access")]
-    InvalidPublicStorageAccess,
-    /// Attempting to access private storage with sload
-    #[error("invalid private storage access")]
-    InvalidPrivateStorageAccess,
 }
 
 impl AsEthApiError for SeismicEthApiError {
@@ -42,22 +35,6 @@ impl From<SeismicEthApiError> for jsonrpsee::types::error::ErrorObject<'static> 
         match error {
             SeismicEthApiError::Eth(e) => e.into(),
             SeismicEthApiError::EnclaveError(e) => internal_rpc_err(format!("enclave error: {e}")),
-            SeismicEthApiError::InvalidPrivateStorageAccess => {
-                internal_rpc_err("invalid private storage access")
-            }
-            SeismicEthApiError::InvalidPublicStorageAccess => {
-                internal_rpc_err("invalid public storage access")
-            }
-        }
-    }
-}
-
-impl FromEvmHalt<SeismicHaltReason> for SeismicEthApiError {
-    fn from_evm_halt(halt: SeismicHaltReason, gas_limit: u64) -> Self {
-        match halt {
-            SeismicHaltReason::InvalidPrivateStorageAccess => Self::InvalidPrivateStorageAccess,
-            SeismicHaltReason::InvalidPublicStorageAccess => Self::InvalidPublicStorageAccess,
-            SeismicHaltReason::Base(halt) => EthApiError::from_evm_halt(halt, gas_limit).into(),
         }
     }
 }


### PR DESCRIPTION
2 main changes from revm:
1. CLOAD is now allowed to read public storage (had to fix a test). See https://github.com/SeismicSystems/seismic-revm/pull/180
   - this is a pretty old PR now, its even on the seismic branch and not the audit branch. We were just pointing to a very old commit.
2. SeismicHaltReason no longer exists. Changed invalid public/private access to reverts instead of halts. See https://github.com/SeismicSystems/seismic-revm/pull/210 for more details