### PR TITLE
test(seismic): re-enable E2E p2p module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9875,6 +9875,7 @@ dependencies = [
  "revm",
  "secp256k1 0.30.0",
  "seismic-alloy-consensus",
+ "seismic-alloy-genesis",
  "seismic-alloy-network",
  "seismic-alloy-provider",
  "seismic-alloy-rpc-types",

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -76,6 +76,9 @@ tokio = { workspace = true }
 jsonrpsee = { workspace = true }
 tempfile = { workspace = true }
 once_cell.workspace = true
+reth-e2e-test-utils = { workspace = true, optional = true }
+reth-tasks = { workspace = true, optional = true }
+seismic-alloy-genesis = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-seismic-node = { workspace = true, features = ["test-utils"] }
@@ -128,7 +131,9 @@ js-tracer = [
     "reth-node-builder/js-tracer",
 ]
 test-utils = [
-    # "reth-tasks",
+    "reth-tasks",
+    "reth-e2e-test-utils",
+    "seismic-alloy-genesis",
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",
     "reth-consensus/test-utils",

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -133,7 +133,6 @@ js-tracer = [
 test-utils = [
     "reth-tasks",
     "reth-e2e-test-utils",
-    "seismic-alloy-genesis",
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",
     "reth-consensus/test-utils",

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -1,124 +1,108 @@
-//! test utils for the e2e tests
+//! Test utilities for Seismic E2E tests.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Test utilities - panics are acceptable
 
+/// E2E test helpers: node setup, chain advancement, payload attributes.
 #[cfg(feature = "test-utils")]
-use crate::node::SeismicNode;
-#[cfg(feature = "test-utils")]
-use crate::purpose_keys::init_purpose_keys;
-#[cfg(feature = "test-utils")]
-use alloy_primitives::{Address, B256};
-#[cfg(feature = "test-utils")]
-use alloy_rpc_types_engine::PayloadAttributes;
-#[cfg(feature = "test-utils")]
-use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
-#[cfg(feature = "test-utils")]
-use reth_node_api::NodeTypesWithDBAdapter;
-#[cfg(feature = "test-utils")]
-use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
-#[cfg(feature = "test-utils")]
-use reth_provider::providers::BlockchainProvider;
-#[cfg(feature = "test-utils")]
-use reth_seismic_chainspec::SEISMIC_DEV;
-#[cfg(feature = "test-utils")]
-use reth_seismic_primitives::SeismicPrimitives;
-#[cfg(feature = "test-utils")]
-use reth_tasks::TaskManager;
-#[cfg(feature = "test-utils")]
-use seismic_enclave::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
-};
-#[cfg(feature = "test-utils")]
-use std::sync::{Arc, Once};
-#[cfg(feature = "test-utils")]
-use tokio::sync::Mutex;
-
-#[cfg(feature = "test-utils")]
-use reth_e2e_test_utils::TmpDB;
-
-/// Seismic returns times in milliseconds
-#[cfg(feature = "test-utils")]
-pub const SEISMIC_TIMESTAMP_MULTIPLIER: u64 = 1000;
-
-#[cfg(feature = "test-utils")]
-static INIT_KEYS: Once = Once::new();
-
-/// Initializes mock purpose keys for tests. Safe to call multiple times.
-#[cfg(feature = "test-utils")]
-pub fn ensure_mock_purpose_keys() {
-    INIT_KEYS.call_once(|| {
-        init_purpose_keys(GetPurposeKeysResponse {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            snapshot_key_bytes: [0u8; 32],
-            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
-        });
-    });
-}
-
-/// Seismic Node Helper type
-#[cfg(feature = "test-utils")]
-pub type SeismicTestNode =
-    NodeHelperType<SeismicNode, BlockchainProvider<NodeTypesWithDBAdapter<SeismicNode, TmpDB>>>;
-
-/// Creates the initial setup with `num_nodes` of the seismic node config, started and connected.
-#[cfg(feature = "test-utils")]
-pub async fn setup(num_nodes: usize) -> eyre::Result<(Vec<SeismicTestNode>, TaskManager, Wallet)> {
-    reth_e2e_test_utils::setup_engine(
-        num_nodes,
-        SEISMIC_DEV.clone(),
-        false,
-        Default::default(),
-        seismic_payload_attributes,
-    )
-    .await
-}
-
-/// Advance the chain with sequential payloads returning them in the end.
-#[cfg(feature = "test-utils")]
-pub async fn advance_chain(
-    length: usize,
-    node: &mut SeismicTestNode,
-    wallet: Arc<Mutex<Wallet>>,
-) -> eyre::Result<Vec<EthBuiltPayload<SeismicPrimitives>>> {
-    node.advance(length as u64, |_| {
-        let wallet = wallet.clone();
-        Box::pin(async move {
-            let mut wallet = wallet.lock().await;
-            let nonce = wallet.inner_nonce;
-            wallet.inner_nonce += 1;
-            let tx = alloy_rpc_types_eth::TransactionRequest {
-                nonce: Some(nonce),
-                value: Some(alloy_primitives::U256::from(100)),
-                to: Some(alloy_primitives::TxKind::Call(Address::random())),
-                gas: Some(21000),
-                max_fee_per_gas: Some(20e9 as u128),
-                max_priority_fee_per_gas: Some(20e9 as u128),
-                chain_id: Some(wallet.chain_id),
-                ..Default::default()
-            };
-            let signed = TransactionTestContext::sign_tx(wallet.inner.clone(), tx).await;
-            alloy_eips::eip2718::Encodable2718::encoded_2718(&signed).into()
-        })
-    })
-    .await
-}
-
-/// Helper function to create a new eth payload attributes for seismic
-#[cfg(feature = "test-utils")]
-pub fn seismic_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = PayloadAttributes {
-        timestamp: timestamp * SEISMIC_TIMESTAMP_MULTIPLIER,
-        prev_randao: B256::ZERO,
-        suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
-        parent_beacon_block_root: Some(B256::ZERO),
+pub mod e2e {
+    use crate::{node::SeismicNode, purpose_keys::init_purpose_keys};
+    use alloy_primitives::{Address, B256};
+    use alloy_rpc_types_engine::PayloadAttributes;
+    use reth_e2e_test_utils::{
+        transaction::TransactionTestContext, wallet::Wallet, NodeHelperType, TmpDB,
     };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    use reth_node_api::NodeTypesWithDBAdapter;
+    use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+    use reth_provider::providers::BlockchainProvider;
+    use reth_seismic_chainspec::SEISMIC_DEV;
+    use reth_seismic_primitives::SeismicPrimitives;
+    use reth_tasks::TaskManager;
+    use seismic_enclave::{
+        get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
+        get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
+    };
+    use std::sync::{Arc, Once};
+    use tokio::sync::Mutex;
+
+    /// Seismic returns times in milliseconds
+    pub const SEISMIC_TIMESTAMP_MULTIPLIER: u64 = 1000;
+
+    static INIT_KEYS: Once = Once::new();
+
+    /// Initializes mock purpose keys for tests. Safe to call multiple times.
+    pub fn ensure_mock_purpose_keys() {
+        INIT_KEYS.call_once(|| {
+            init_purpose_keys(GetPurposeKeysResponse {
+                tx_io_sk: get_unsecure_sample_secp256k1_sk(),
+                tx_io_pk: get_unsecure_sample_secp256k1_pk(),
+                snapshot_key_bytes: [0u8; 32],
+                rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
+            });
+        });
+    }
+
+    /// Seismic Node Helper type
+    pub type SeismicTestNode =
+        NodeHelperType<SeismicNode, BlockchainProvider<NodeTypesWithDBAdapter<SeismicNode, TmpDB>>>;
+
+    /// Creates the initial setup with `num_nodes` of the seismic node config, started and
+    /// connected.
+    pub async fn setup(
+        num_nodes: usize,
+    ) -> eyre::Result<(Vec<SeismicTestNode>, TaskManager, Wallet)> {
+        reth_e2e_test_utils::setup_engine(
+            num_nodes,
+            SEISMIC_DEV.clone(),
+            false,
+            Default::default(),
+            seismic_payload_attributes,
+        )
+        .await
+    }
+
+    /// Advance the chain with sequential payloads returning them in the end.
+    pub async fn advance_chain(
+        length: usize,
+        node: &mut SeismicTestNode,
+        wallet: Arc<Mutex<Wallet>>,
+    ) -> eyre::Result<Vec<EthBuiltPayload<SeismicPrimitives>>> {
+        node.advance(length as u64, |_| {
+            let wallet = wallet.clone();
+            Box::pin(async move {
+                let mut wallet = wallet.lock().await;
+                let nonce = wallet.inner_nonce;
+                wallet.inner_nonce += 1;
+                let tx = alloy_rpc_types_eth::TransactionRequest {
+                    nonce: Some(nonce),
+                    value: Some(alloy_primitives::U256::from(100)),
+                    to: Some(alloy_primitives::TxKind::Call(Address::random())),
+                    gas: Some(21000),
+                    max_fee_per_gas: Some(20e9 as u128),
+                    max_priority_fee_per_gas: Some(20e9 as u128),
+                    chain_id: Some(wallet.chain_id),
+                    ..Default::default()
+                };
+                let signed = TransactionTestContext::sign_tx(wallet.inner.clone(), tx).await;
+                alloy_eips::eip2718::Encodable2718::encoded_2718(&signed).into()
+            })
+        })
+        .await
+    }
+
+    /// Helper function to create a new eth payload attributes for seismic
+    pub fn seismic_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
+        let attributes = PayloadAttributes {
+            timestamp: timestamp * SEISMIC_TIMESTAMP_MULTIPLIER,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        };
+        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    }
 }
 
-/// Test utils for the seismic rpc api
+/// RPC test utilities: test command runner, nonce helpers, re-exported test helpers.
 pub mod test_utils {
     use alloy_primitives::Address;
     use alloy_rpc_types::{Block, Header, Transaction, TransactionReceipt};
@@ -143,7 +127,6 @@ pub mod test_utils {
         sign_seismic_tx, sign_tx,
     };
 
-    // use reth_seismic_evm::engine::SeismicEngineValidator;
     /// Seismic reth test command
     #[derive(Debug)]
     pub struct SeismicRethTestCommand();

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -5,11 +5,11 @@
 #[cfg(feature = "test-utils")]
 use crate::node::SeismicNode;
 #[cfg(feature = "test-utils")]
+use crate::purpose_keys::init_purpose_keys;
+#[cfg(feature = "test-utils")]
 use alloy_primitives::{Address, B256};
 #[cfg(feature = "test-utils")]
 use alloy_rpc_types_engine::PayloadAttributes;
-#[cfg(feature = "test-utils")]
-use reth_chainspec::{ChainSpecBuilder, MAINNET};
 #[cfg(feature = "test-utils")]
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
 #[cfg(feature = "test-utils")]
@@ -19,18 +19,43 @@ use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
 #[cfg(feature = "test-utils")]
 use reth_provider::providers::BlockchainProvider;
 #[cfg(feature = "test-utils")]
+use reth_seismic_chainspec::SEISMIC_DEV;
+#[cfg(feature = "test-utils")]
 use reth_seismic_primitives::SeismicPrimitives;
 #[cfg(feature = "test-utils")]
 use reth_tasks::TaskManager;
 #[cfg(feature = "test-utils")]
-use seismic_alloy_genesis::Genesis;
+use seismic_enclave::{
+    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
+    get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
+};
 #[cfg(feature = "test-utils")]
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 #[cfg(feature = "test-utils")]
 use tokio::sync::Mutex;
 
 #[cfg(feature = "test-utils")]
 use reth_e2e_test_utils::TmpDB;
+
+/// Seismic returns times in milliseconds
+#[cfg(feature = "test-utils")]
+pub const SEISMIC_TIMESTAMP_MULTIPLIER: u64 = 1000;
+
+#[cfg(feature = "test-utils")]
+static INIT_KEYS: Once = Once::new();
+
+/// Initializes mock purpose keys for tests. Safe to call multiple times.
+#[cfg(feature = "test-utils")]
+pub fn ensure_mock_purpose_keys() {
+    INIT_KEYS.call_once(|| {
+        init_purpose_keys(GetPurposeKeysResponse {
+            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
+            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
+            snapshot_key_bytes: [0u8; 32],
+            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
+        });
+    });
+}
 
 /// Seismic Node Helper type
 #[cfg(feature = "test-utils")]
@@ -40,17 +65,9 @@ pub type SeismicTestNode =
 /// Creates the initial setup with `num_nodes` of the seismic node config, started and connected.
 #[cfg(feature = "test-utils")]
 pub async fn setup(num_nodes: usize) -> eyre::Result<(Vec<SeismicTestNode>, TaskManager, Wallet)> {
-    let genesis: Genesis =
-        serde_json::from_str(include_str!("../tests/assets/genesis.json")).unwrap();
     reth_e2e_test_utils::setup_engine(
         num_nodes,
-        Arc::new(
-            ChainSpecBuilder::default()
-                .chain(MAINNET.chain)
-                .genesis(genesis)
-                .cancun_activated()
-                .build(),
-        ),
+        SEISMIC_DEV.clone(),
         false,
         Default::default(),
         seismic_payload_attributes,
@@ -92,7 +109,7 @@ pub async fn advance_chain(
 #[cfg(feature = "test-utils")]
 pub fn seismic_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
     let attributes = PayloadAttributes {
-        timestamp,
+        timestamp: timestamp * SEISMIC_TIMESTAMP_MULTIPLIER,
         prev_randao: B256::ZERO,
         suggested_fee_recipient: Address::ZERO,
         withdrawals: Some(vec![]),

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -69,10 +69,20 @@ pub async fn advance_chain(
         let wallet = wallet.clone();
         Box::pin(async move {
             let mut wallet = wallet.lock().await;
-            let tx_fut =
-                TransactionTestContext::transfer_tx_bytes(wallet.chain_id, wallet.inner.clone());
+            let nonce = wallet.inner_nonce;
             wallet.inner_nonce += 1;
-            tx_fut.await
+            let tx = alloy_rpc_types_eth::TransactionRequest {
+                nonce: Some(nonce),
+                value: Some(alloy_primitives::U256::from(100)),
+                to: Some(alloy_primitives::TxKind::Call(Address::random())),
+                gas: Some(21000),
+                max_fee_per_gas: Some(20e9 as u128),
+                max_priority_fee_per_gas: Some(20e9 as u128),
+                chain_id: Some(wallet.chain_id),
+                ..Default::default()
+            };
+            let signed = TransactionTestContext::sign_tx(wallet.inner.clone(), tx).await;
+            alloy_eips::eip2718::Encodable2718::encoded_2718(&signed).into()
         })
     })
     .await

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -2,6 +2,95 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Test utilities - panics are acceptable
 
+#[cfg(feature = "test-utils")]
+use crate::node::SeismicNode;
+#[cfg(feature = "test-utils")]
+use alloy_primitives::{Address, B256};
+#[cfg(feature = "test-utils")]
+use alloy_rpc_types_engine::PayloadAttributes;
+#[cfg(feature = "test-utils")]
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+#[cfg(feature = "test-utils")]
+use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet, NodeHelperType};
+#[cfg(feature = "test-utils")]
+use reth_node_api::NodeTypesWithDBAdapter;
+#[cfg(feature = "test-utils")]
+use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+#[cfg(feature = "test-utils")]
+use reth_provider::providers::BlockchainProvider;
+#[cfg(feature = "test-utils")]
+use reth_seismic_primitives::SeismicPrimitives;
+#[cfg(feature = "test-utils")]
+use reth_tasks::TaskManager;
+#[cfg(feature = "test-utils")]
+use seismic_alloy_genesis::Genesis;
+#[cfg(feature = "test-utils")]
+use std::sync::Arc;
+#[cfg(feature = "test-utils")]
+use tokio::sync::Mutex;
+
+#[cfg(feature = "test-utils")]
+use reth_e2e_test_utils::TmpDB;
+
+/// Seismic Node Helper type
+#[cfg(feature = "test-utils")]
+pub type SeismicTestNode =
+    NodeHelperType<SeismicNode, BlockchainProvider<NodeTypesWithDBAdapter<SeismicNode, TmpDB>>>;
+
+/// Creates the initial setup with `num_nodes` of the seismic node config, started and connected.
+#[cfg(feature = "test-utils")]
+pub async fn setup(num_nodes: usize) -> eyre::Result<(Vec<SeismicTestNode>, TaskManager, Wallet)> {
+    let genesis: Genesis =
+        serde_json::from_str(include_str!("../tests/assets/genesis.json")).unwrap();
+    reth_e2e_test_utils::setup_engine(
+        num_nodes,
+        Arc::new(
+            ChainSpecBuilder::default()
+                .chain(MAINNET.chain)
+                .genesis(genesis)
+                .cancun_activated()
+                .build(),
+        ),
+        false,
+        Default::default(),
+        seismic_payload_attributes,
+    )
+    .await
+}
+
+/// Advance the chain with sequential payloads returning them in the end.
+#[cfg(feature = "test-utils")]
+pub async fn advance_chain(
+    length: usize,
+    node: &mut SeismicTestNode,
+    wallet: Arc<Mutex<Wallet>>,
+) -> eyre::Result<Vec<EthBuiltPayload<SeismicPrimitives>>> {
+    node.advance(length as u64, |_| {
+        let wallet = wallet.clone();
+        Box::pin(async move {
+            let mut wallet = wallet.lock().await;
+            let tx_fut =
+                TransactionTestContext::transfer_tx_bytes(wallet.chain_id, wallet.inner.clone());
+            wallet.inner_nonce += 1;
+            tx_fut.await
+        })
+    })
+    .await
+}
+
+/// Helper function to create a new eth payload attributes for seismic
+#[cfg(feature = "test-utils")]
+pub fn seismic_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
+    let attributes = PayloadAttributes {
+        timestamp,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+    };
+    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+}
+
 /// Test utils for the seismic rpc api
 pub mod test_utils {
     use alloy_primitives::Address;

--- a/crates/seismic/node/tests/e2e/main.rs
+++ b/crates/seismic/node/tests/e2e/main.rs
@@ -1,8 +1,8 @@
-#![allow(missing_docs, clippy::unwrap_used, clippy::expect_used)]
+#![allow(missing_docs, clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
 mod hardfork_config;
 mod integration;
-// mod p2p;
+mod p2p;
 // mod testsuite;
 
 const fn main() {}

--- a/crates/seismic/node/tests/e2e/p2p.rs
+++ b/crates/seismic/node/tests/e2e/p2p.rs
@@ -1,11 +1,31 @@
 use futures::StreamExt;
-use reth_seismic_node::utils::{advance_chain, setup};
-use std::sync::Arc;
+use reth_seismic_node::{
+    purpose_keys::init_purpose_keys,
+    utils::{advance_chain, setup},
+};
+use seismic_enclave::{
+    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
+    get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
+};
+use std::sync::{Arc, Once};
 use tokio::sync::Mutex;
+
+static INIT_KEYS: Once = Once::new();
+fn ensure_mock_purpose_keys() {
+    INIT_KEYS.call_once(|| {
+        init_purpose_keys(GetPurposeKeysResponse {
+            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
+            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
+            snapshot_key_bytes: [0u8; 32],
+            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
+        });
+    });
+}
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
 
     let (mut nodes, _tasks, wallet) = setup(3).await?;
     let wallet = Arc::new(Mutex::new(wallet));

--- a/crates/seismic/node/tests/e2e/p2p.rs
+++ b/crates/seismic/node/tests/e2e/p2p.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use reth_seismic_node::utils::{advance_chain, ensure_mock_purpose_keys, setup};
+use reth_seismic_node::utils::e2e::{advance_chain, ensure_mock_purpose_keys, setup};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/crates/seismic/node/tests/e2e/p2p.rs
+++ b/crates/seismic/node/tests/e2e/p2p.rs
@@ -1,26 +1,7 @@
 use futures::StreamExt;
-use reth_seismic_node::{
-    purpose_keys::init_purpose_keys,
-    utils::{advance_chain, setup},
-};
-use seismic_enclave::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
-};
-use std::sync::{Arc, Once};
+use reth_seismic_node::utils::{advance_chain, ensure_mock_purpose_keys, setup};
+use std::sync::Arc;
 use tokio::sync::Mutex;
-
-static INIT_KEYS: Once = Once::new();
-fn ensure_mock_purpose_keys() {
-    INIT_KEYS.call_once(|| {
-        init_purpose_keys(GetPurposeKeysResponse {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            snapshot_key_bytes: [0u8; 32],
-            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
-        });
-    });
-}
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {

--- a/crates/seismic/node/tests/e2e/testsuite.rs
+++ b/crates/seismic/node/tests/e2e/testsuite.rs
@@ -1,42 +1,9 @@
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, B256, U256};
-use alloy_rpc_types_engine::PayloadAttributes;
+use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use eyre::Result;
-use reth_e2e_test_utils::{setup_engine, transaction::TransactionTestContext};
-use reth_payload_builder::EthPayloadBuilderAttributes;
-use reth_seismic_chainspec::SEISMIC_DEV;
-use reth_seismic_node::{node::SeismicNode, purpose_keys::init_purpose_keys};
-use seismic_enclave::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,
-};
-use std::sync::Once;
-
-static INIT_KEYS: Once = Once::new();
-fn ensure_mock_purpose_keys() {
-    INIT_KEYS.call_once(|| {
-        init_purpose_keys(GetPurposeKeysResponse {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            snapshot_key_bytes: [0u8; 32],
-            rng_keypair: get_unsecure_sample_schnorrkel_keypair(),
-        });
-    });
-}
-
-const SEISMIC_TIMESTAMP_MULTIPLIER: u64 = 1000; // Seismic returns times in milliseconds
-
-fn seismic_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = PayloadAttributes {
-        timestamp: timestamp * SEISMIC_TIMESTAMP_MULTIPLIER,
-        prev_randao: B256::ZERO,
-        suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
-        parent_beacon_block_root: Some(B256::ZERO),
-    };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
-}
+use reth_e2e_test_utils::transaction::TransactionTestContext;
+use reth_seismic_node::utils::ensure_mock_purpose_keys;
 
 // Produces a single block on a Seismic node using the internal engine channel
 // (not the JSON-RPC engine API, which loses Prague-era fields in V3 payloads).
@@ -45,14 +12,7 @@ async fn test_seismic_produce_blocks() -> Result<()> {
     reth_tracing::init_test_tracing();
     ensure_mock_purpose_keys();
 
-    let (mut nodes, _tasks, wallet) = setup_engine::<SeismicNode>(
-        1,
-        SEISMIC_DEV.clone(),
-        false,
-        Default::default(),
-        seismic_payload_attributes,
-    )
-    .await?;
+    let (mut nodes, _tasks, wallet) = reth_seismic_node::utils::setup(1).await?;
     let mut node = nodes.pop().unwrap();
 
     let tx = TransactionRequest {

--- a/crates/seismic/node/tests/e2e/testsuite.rs
+++ b/crates/seismic/node/tests/e2e/testsuite.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use eyre::Result;
 use reth_e2e_test_utils::transaction::TransactionTestContext;
-use reth_seismic_node::utils::ensure_mock_purpose_keys;
+use reth_seismic_node::utils::e2e::ensure_mock_purpose_keys;
 
 // Produces a single block on a Seismic node using the internal engine channel
 // (not the JSON-RPC engine API, which loses Prague-era fields in V3 payloads).
@@ -12,7 +12,7 @@ async fn test_seismic_produce_blocks() -> Result<()> {
     reth_tracing::init_test_tracing();
     ensure_mock_purpose_keys();
 
-    let (mut nodes, _tasks, wallet) = reth_seismic_node::utils::setup(1).await?;
+    let (mut nodes, _tasks, wallet) = reth_seismic_node::utils::e2e::setup(1).await?;
     let mut node = nodes.pop().unwrap();
 
     let tx = TransactionRequest {


### PR DESCRIPTION
## Summary
- Re-enable the `mod p2p` E2E test module that was previously commented out
- Fix `utils::setup()` to use `SEISMIC_DEV` chain spec instead of a vanilla Ethereum Cancun spec, so p2p tests actually run with Seismic fork rules
- Deduplicate test helpers: move `ensure_mock_purpose_keys()`, `SEISMIC_TIMESTAMP_MULTIPLIER`, and `seismic_payload_attributes()` into shared `utils.rs`
- Fix `seismic_payload_attributes()` to apply the millisecond timestamp multiplier
- Remove unused `seismic-alloy-genesis` dependency from test-utils feature

## Test plan
- [x] `cargo +nightly fmt --all` clean
- [x] `cargo clippy -p reth-seismic-node --tests --no-deps` passes (seismic-strict)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)