### PR TITLE
refactor(chainspec): use stock alloy_genesis::Genesis in ChainSpec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,7 +7128,6 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
- "seismic-alloy-genesis",
  "serde_json",
 ]
 
@@ -7136,11 +7135,11 @@ dependencies = [
 name = "reth-cli"
 version = "1.7.0"
 dependencies = [
+ "alloy-genesis",
  "clap",
  "eyre",
  "reth-cli-runner",
  "reth-db",
- "seismic-alloy-genesis",
  "serde_json",
  "shellexpand",
 ]
@@ -7216,6 +7215,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "secp256k1 0.30.0",
+ "seismic-alloy-genesis",
  "serde",
  "serde_json",
  "tar",
@@ -7430,6 +7430,7 @@ name = "reth-db-common"
 version = "1.7.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
  "eyre",
@@ -8929,7 +8930,6 @@ dependencies = [
  "reth-optimism-forks",
  "reth-optimism-primitives",
  "reth-primitives-traits",
- "seismic-alloy-genesis",
  "serde",
  "serde_json",
  "tar-no-std",
@@ -9700,7 +9700,6 @@ dependencies = [
  "reth-seismic-forks",
  "reth-seismic-primitives",
  "seismic-alloy-consensus",
- "seismic-alloy-genesis",
  "seismic-alloy-rpc-types",
  "serde_json",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9410,7 +9410,6 @@ dependencies = [
  "reth-node-ethereum",
  "reth-rpc-api",
  "reth-tracing",
- "seismic-alloy-genesis",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -11,9 +11,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-# seismic
-seismic-alloy-genesis.workspace = true
-
 # reth
 reth-ethereum-forks.workspace = true
 reth-network-peers.workspace = true
@@ -27,6 +24,8 @@ alloy-eips = { workspace = true, features = ["serde"] }
 alloy-genesis.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-consensus.workspace = true
+
+# seismic
 alloy-seismic-evm.workspace = true
 
 # misc
@@ -67,6 +66,4 @@ arbitrary = [
     "alloy-primitives/arbitrary",
     "alloy-trie/arbitrary",
 ]
-test-utils = [
-    "reth-primitives-traits/test-utils",
-]
+test-utils = ["reth-primitives-traits/test-utils"]

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -3,13 +3,12 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::Header;
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
+use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use core::fmt::{Debug, Display};
 use reth_ethereum_forks::EthereumHardforks;
 use reth_network_peers::NodeRecord;
 use reth_primitives_traits::{AlloyBlockHeader, BlockHeader};
-
-use seismic_alloy_genesis::Genesis;
 
 /// Trait representing type configuring a chain spec.
 #[auto_impl::auto_impl(&, Arc)]

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -17,6 +17,7 @@ use alloy_consensus::{
 use alloy_eips::{
     eip1559::INITIAL_BASE_FEE, eip7685::EMPTY_REQUESTS_HASH, eip7892::BlobScheduleBlobParams,
 };
+use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};
 use alloy_seismic_evm::hardfork::{SeismicHardfork, SeismicHardforks};
 use alloy_trie::root::state_root_ref_unhashed;
@@ -31,7 +32,6 @@ use reth_network_peers::{
     NodeRecord,
 };
 use reth_primitives_traits::{sync::LazyLock, SealedHeader};
-use seismic_alloy_genesis::Genesis;
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
 pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
@@ -1068,14 +1068,12 @@ mod tests {
     use alloy_consensus::constants::ETH_TO_WEI;
     use alloy_eips::{eip4844::BLOB_TX_MIN_BLOB_GASPRICE, eip7840::BlobParams};
     use alloy_evm::block::calc::{base_block_reward, block_reward};
-    use alloy_genesis::ChainConfig;
+    use alloy_genesis::{ChainConfig, GenesisAccount};
     use alloy_primitives::{b256, hex};
     use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
     use core::ops::Deref;
     use reth_ethereum_forks::{ForkCondition, ForkHash, ForkId, Head};
     use std::{collections::HashMap, str::FromStr};
-
-    use seismic_alloy_genesis::GenesisAccount;
 
     fn ts(timestamp_seconds: u64) -> u64 {
         if cfg!(feature = "timestamp-in-seconds") {

--- a/crates/cli/cli/Cargo.toml
+++ b/crates/cli/cli/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-# seismic
-seismic-alloy-genesis.workspace = true
+# ethereum
+alloy-genesis.workspace = true
 
 # reth
 reth-cli-runner.workspace = true

--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -65,8 +65,8 @@ pub trait ChainSpecParser: Clone + Send + Sync + 'static {
     }
 }
 
-/// A helper to parse a [`Genesis`](seismic_alloy_genesis::Genesis) as argument or from disk.
-pub fn parse_genesis(s: &str) -> eyre::Result<seismic_alloy_genesis::Genesis> {
+/// A helper to parse a [`Genesis`](alloy_genesis::Genesis) as argument or from disk.
+pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
     // try to read json from path first
     let raw = match fs::read_to_string(PathBuf::from(shellexpand::full(s)?.into_owned())) {
         Ok(raw) => raw,

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 [lints]
 
 [dependencies]
+# seismic
+seismic-alloy-genesis.workspace = true
+
 # reth
 reth-chainspec.workspace = true
 reth-cli.workspace = true

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -108,7 +108,14 @@ impl<C: ChainSpecParser> Command<C> {
                 reset_prune_checkpoint(tx, PruneSegment::ContractLogs)?;
                 reset_stage_checkpoint(tx, StageId::Execution)?;
 
-                let alloc = &self.env.chain.genesis().alloc;
+                let alloc: std::collections::BTreeMap<_, seismic_alloy_genesis::GenesisAccount> =
+                    self.env
+                        .chain
+                        .genesis()
+                        .alloc
+                        .iter()
+                        .map(|(addr, account)| (*addr, account.clone().into()))
+                        .collect();
                 insert_genesis_state(&provider_rw, alloc.iter())?;
             }
             StageEnum::AccountHashing => {
@@ -147,7 +154,15 @@ impl<C: ChainSpecParser> Command<C> {
                 reset_stage_checkpoint(tx, StageId::IndexAccountHistory)?;
                 reset_stage_checkpoint(tx, StageId::IndexStorageHistory)?;
 
-                insert_genesis_history(&provider_rw, self.env.chain.genesis().alloc.iter())?;
+                let alloc: std::collections::BTreeMap<_, seismic_alloy_genesis::GenesisAccount> =
+                    self.env
+                        .chain
+                        .genesis()
+                        .alloc
+                        .iter()
+                        .map(|(addr, account)| (*addr, account.clone().into()))
+                        .collect();
+                insert_genesis_history(&provider_rw, alloc.iter())?;
             }
             StageEnum::TxLookup => {
                 tx.clear::<tables::TransactionHashNumbers>()?;

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -113,6 +113,5 @@ fn custom_chain() -> Arc<ChainSpec> {
 }
 "#;
     let genesis: Genesis = serde_json::from_str(custom_genesis).unwrap();
-    let genesis = seismic_alloy_genesis::Genesis::from(genesis);
     Arc::new(genesis.into())
 }

--- a/crates/exex/exex/src/backfill/test_utils.rs
+++ b/crates/exex/exex/src/backfill/test_utils.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use alloy_consensus::{constants::ETH_TO_WEI, BlockHeader, Header, TxEip2930};
+use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{b256, Address, TxKind, U256};
 use reth_chainspec::{ChainSpec, ChainSpecBuilder, EthereumHardfork, MAINNET, MIN_TRANSACTION_GAS};
 use reth_ethereum_primitives::{Block, BlockBody, Receipt, Transaction};
@@ -18,7 +19,6 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_testing_utils::generators::sign_tx_with_key_pair;
 use secp256k1::Keypair;
-use alloy_genesis::{Genesis, GenesisAccount};
 
 pub(crate) fn to_execution_outcome(
     block_number: u64,

--- a/crates/exex/exex/src/backfill/test_utils.rs
+++ b/crates/exex/exex/src/backfill/test_utils.rs
@@ -18,7 +18,7 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_testing_utils::generators::sign_tx_with_key_pair;
 use secp256k1::Keypair;
-use seismic_alloy_genesis::{Genesis, GenesisAccount};
+use alloy_genesis::{Genesis, GenesisAccount};
 
 pub(crate) fn to_execution_outcome(
     block_number: u64,

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -12,9 +12,6 @@ description = "EVM chain spec implementation for optimism."
 workspace = true
 
 [dependencies]
-# seismic
-seismic-alloy-genesis.workspace = true
-
 # reth
 reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -112,7 +112,7 @@ impl OpChainSpecBuilder {
 
     /// Set the genesis block.
     pub fn genesis(mut self, genesis: Genesis) -> Self {
-        self.inner = self.inner.genesis(genesis.into());
+        self.inner = self.inner.genesis(genesis);
         self
     }
 
@@ -276,7 +276,7 @@ impl EthChainSpec for OpChainSpec {
         self.inner.genesis_header()
     }
 
-    fn genesis(&self) -> &seismic_alloy_genesis::Genesis {
+    fn genesis(&self) -> &Genesis {
         self.inner.genesis()
     }
 
@@ -418,14 +418,13 @@ impl From<Genesis> for OpChainSpec {
         ordered_hardforks.append(&mut block_hardforks);
 
         let hardforks = ChainHardforks::new(ordered_hardforks);
-        let genesis_header =
-            SealedHeader::seal_slow(make_op_genesis_header(&genesis.clone().into(), &hardforks));
+        let genesis_header = SealedHeader::seal_slow(make_op_genesis_header(&genesis, &hardforks));
 
         Self {
             inner: ChainSpec {
                 chain: genesis.config.chain_id.into(),
                 genesis_header,
-                genesis: genesis.into(),
+                genesis,
                 hardforks,
                 // We assume no OP network merges, and set the paris block and total difficulty to
                 // zero
@@ -492,11 +491,8 @@ impl OpGenesisInfo {
 }
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
-pub fn make_op_genesis_header(
-    genesis: &seismic_alloy_genesis::Genesis,
-    hardforks: &ChainHardforks,
-) -> Header {
-    let mut header = reth_chainspec::make_genesis_header(&genesis.clone().into(), hardforks);
+pub fn make_op_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
+    let mut header = reth_chainspec::make_genesis_header(genesis, hardforks);
 
     // If Isthmus is active, overwrite the withdrawals root with the storage root of predeploy
     // `L2ToL1MessagePasser.sol`
@@ -508,7 +504,7 @@ pub fn make_op_genesis_header(
                         if v.is_zero() {
                             None
                         } else {
-                            Some((*k, *v))
+                            Some((*k, U256::from_be_bytes(v.0)))
                         }
                     })));
             }

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # seimsic
 seismic-alloy-consensus = { workspace = true, features = ["k256", "serde"] }
 seismic-alloy-genesis.workspace = true
+alloy-genesis.workspace = true
 
 # reth
 reth-codecs = { workspace = true, optional = true }
@@ -57,7 +58,6 @@ rayon = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 
 [dev-dependencies]
-alloy-genesis.workspace = true
 reth-codecs.workspace = true
 reth-chainspec = { workspace = true, features = ["arbitrary"] }
 

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -1,10 +1,11 @@
 use alloy_consensus::constants::KECCAK_EMPTY;
+use alloy_genesis::GenesisAccount;
 use alloy_primitives::{keccak256, Bytes, B256, U256};
 use alloy_trie::TrieAccount;
 use derive_more::Deref;
 use revm_bytecode::{Bytecode as RevmBytecode, BytecodeDecodeError};
 use revm_state::AccountInfo;
-use seismic_alloy_genesis::GenesisAccount;
+use seismic_alloy_genesis::GenesisAccount as SeismicGenesisAccount;
 
 #[cfg(any(test, feature = "reth-codec"))]
 /// Identifiers used in [`Compact`](reth_codecs::Compact) encoding of [`Bytecode`].
@@ -196,6 +197,16 @@ impl reth_codecs::Compact for Bytecode {
 
 impl From<&GenesisAccount> for Account {
     fn from(value: &GenesisAccount) -> Self {
+        Self {
+            nonce: value.nonce.unwrap_or_default(),
+            balance: value.balance,
+            bytecode_hash: value.code.as_ref().map(keccak256),
+        }
+    }
+}
+
+impl From<&SeismicGenesisAccount> for Account {
+    fn from(value: &SeismicGenesisAccount) -> Self {
         Self {
             nonce: value.nonce.unwrap_or_default(),
             balance: value.balance,

--- a/crates/rpc/rpc-e2e-tests/Cargo.toml
+++ b/crates/rpc/rpc-e2e-tests/Cargo.toml
@@ -37,7 +37,6 @@ reth-tracing.workspace = true
 reth-chainspec.workspace = true
 reth-node-ethereum.workspace = true
 alloy-genesis.workspace = true
-seismic-alloy-genesis.workspace = true
 
 [[test]]
 name = "e2e_testsuite"

--- a/crates/rpc/rpc-e2e-tests/tests/e2e-testsuite/main.rs
+++ b/crates/rpc/rpc-e2e-tests/tests/e2e-testsuite/main.rs
@@ -1,5 +1,6 @@
 //! RPC compatibility tests using execution-apis test data
 
+use alloy_genesis::Genesis;
 use eyre::Result;
 use reth_chainspec::ChainSpec;
 use reth_e2e_test_utils::testsuite::{
@@ -9,7 +10,6 @@ use reth_e2e_test_utils::testsuite::{
 };
 use reth_node_ethereum::{EthEngineTypes, EthereumNode};
 use reth_rpc_e2e_tests::rpc_compat::{InitializeFromExecutionApis, RunRpcCompatTests};
-use seismic_alloy_genesis::Genesis;
 use std::{env, path::PathBuf, sync::Arc};
 use tracing::{debug, info};
 

--- a/crates/seismic/chainspec/Cargo.toml
+++ b/crates/seismic/chainspec/Cargo.toml
@@ -33,8 +33,6 @@ alloy-hardforks.workspace = true
 # op
 seismic-alloy-rpc-types.workspace = true
 seismic-alloy-consensus.workspace = true
-seismic-alloy-genesis.workspace = true
-
 # io
 serde_json.workspace = true
 

--- a/crates/seismic/chainspec/src/lib.rs
+++ b/crates/seismic/chainspec/src/lib.rs
@@ -12,12 +12,11 @@ use std::sync::Arc;
 
 use alloy_chains::Chain;
 use alloy_consensus::constants::DEV_GENESIS_HASH;
+use alloy_genesis::Genesis;
 use alloy_primitives::{b256, B256, U256};
 use reth_chainspec::{make_genesis_header, ChainSpec};
 use reth_primitives_traits::{sync::LazyLock, SealedHeader};
 use reth_seismic_forks::{SEISMIC_DEV_HARDFORKS, SEISMIC_MAINNET_HARDFORKS};
-
-use seismic_alloy_genesis::Genesis;
 
 /// Genesis hash for the Seismic mainnet
 /// Calculated by rlp encoding the genesis header and hashing it

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -301,6 +301,7 @@ mod tests {
     use alloy_consensus::{Header, Receipt};
     use alloy_eips::eip7685::Requests;
     use alloy_evm::Evm;
+    use alloy_genesis::Genesis;
     use alloy_primitives::{bytes, map::HashMap, Address, LogData, B256};
     use reth_chainspec::ChainSpec;
     use reth_evm::execute::ProviderError;
@@ -319,7 +320,6 @@ mod tests {
         primitives::Log,
         state::AccountInfo,
     };
-    use seismic_alloy_genesis::Genesis;
     use seismic_enclave::{
         get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
         get_unsecure_sample_secp256k1_sk, GetPurposeKeysResponse,

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -44,6 +44,7 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-genesis.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -135,7 +135,10 @@ where
 
     debug!("Writing genesis block.");
 
-    let alloc = &genesis.alloc;
+    // Convert alloy_genesis accounts to seismic accounts for DB storage (adds FlaggedStorage).
+    // This is lossless: all genesis storage is marked as public.
+    let alloc: std::collections::BTreeMap<Address, GenesisAccount> =
+        genesis.alloc.iter().map(|(addr, account)| (*addr, account.clone().into())).collect();
 
     // use transaction to insert genesis header
     let provider_rw = factory.database_provider_rw()?;
@@ -674,6 +677,7 @@ mod tests {
     use alloy_consensus::constants::{
         HOLESKY_GENESIS_HASH, MAINNET_GENESIS_HASH, SEPOLIA_GENESIS_HASH,
     };
+    use alloy_genesis::{Genesis, GenesisAccount};
     use reth_chainspec::{Chain, ChainSpec, HOLESKY, MAINNET, SEPOLIA};
     use reth_db::DatabaseEnv;
     use reth_db_api::{
@@ -687,7 +691,6 @@ mod tests {
         test_utils::{create_test_provider_factory_with_chain_spec, MockNodeTypesWithDB},
         ProviderFactory,
     };
-    use seismic_alloy_genesis::Genesis;
     use std::{collections::BTreeMap, sync::Arc};
 
     fn collect_table_entries<DB, T>(
@@ -765,11 +768,7 @@ mod tests {
                     (
                         address_with_storage,
                         GenesisAccount {
-                            storage: Some(
-                                seismic_alloy_genesis::convert_fixedbytes_map_to_flagged_storage(
-                                    BTreeMap::from([(storage_key, B256::random())]),
-                                ),
-                            ),
+                            storage: Some(BTreeMap::from([(storage_key, B256::random())])),
                             ..Default::default()
                         },
                     ),

--- a/crates/storage/provider/src/test_utils/mod.rs
+++ b/crates/storage/provider/src/test_utils/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     providers::{ProviderNodeTypes, StaticFileProvider},
     HashingWriter, ProviderFactory, TrieWriter,
 };
-use alloy_primitives::B256;
+use alloy_primitives::{FlaggedStorage, B256, U256};
 use reth_chainspec::{ChainSpec, MAINNET};
 use reth_db::{
     test_utils::{create_test_rw_db, create_test_static_files_dir, TempDatabase},
@@ -82,7 +82,7 @@ pub fn insert_genesis<N: ProviderNodeTypes<ChainSpec = ChainSpec>>(
                 addr,
                 storage.into_iter().map(|(key, value)| StorageEntry {
                     key,
-                    value: value.into(),
+                    value: FlaggedStorage::public(U256::from_be_bytes(value.0)),
                     ..Default::default()
                 }),
             )


### PR DESCRIPTION
Replace seismic_alloy_genesis::Genesis with upstream alloy_genesis::Genesis in ChainSpec.genesis. This reduces our fork diff in core upstream crates (chainspec, optimism, cli) by keeping the genesis type stock.

Why: seismic_alloy_genesis::Genesis uses FlaggedStorage for storage values (carrying an is_private flag), but our genesis JSON files don't use private storage — all storage values are plain hex strings, which alloy_genesis handles identically. Using the stock type removes seismic-specific imports from upstream crates that don't need them.

What changed:
- ChainSpec.genesis and EthChainSpec::genesis() now return &alloy_genesis::Genesis
- parse_genesis() in CLI now returns alloy_genesis::Genesis (zero diff from upstream)
- DB layer still uses seismic_alloy_genesis::GenesisAccount for its codec
(FlaggedStorage encoding). The conversion boundary is in init_genesis() where
alloy_genesis::GenesisAccount is converted to seismic_alloy_genesis::GenesisAccount
via the existing lossless From impl (marks all storage as public).
- Same conversion added in stage/drop.rs for the stage reset path.
- Account::from now has impls for both genesis account types.
- Optimism chainspec updated to use alloy_genesis types directly.

Future compatibility: If private genesis storage is ever needed, only the DB boundary code (init.rs) and seismic chainspec construction would need to change. ChainSpec stays stock.

## Diff Explained

Our diff wrt upstream (main branch) has increased overall, but the conceptual diff has been reduced and is better organized.

Conceptual wins:
- ChainSpec.genesis is now stock — this is the most important one. It's the type that flows through the entire codebase. Every upstream crate that touches chain.genesis() now sees
a stock type.
- cli/cli/src/chainspec.rs — zero diff, fully stock
- optimism/chainspec/ — closer to stock, fewer seismic concepts bleeding in

Conceptual losses:
- init.rs now has an explicit conversion boundary (alloy_genesis → seismic_alloy_genesis) that didn't exist before. But this is the right place for it — it's the DB boundary where
B256 becomes FlaggedStorage. Previously the conversion was hidden in the genesis deserialization (JSON → seismic type), scattered across every callsite that parsed a genesis file.
- drop.rs has the same conversion — annoying but same pattern, same boundary
- account.rs has two From impls — duplication, but both are trivial 3-liners

The concentrated boundary: All the seismic-specific complexity now lives in two spots:
1. The DB boundary (init.rs, drop.rs) — "stock genesis goes in, FlaggedStorage comes out for DB"
2. SeismicHardforks impl in chainspec/spec.rs — forced by orphan rule