### PR TITLE
chore: decouple optimism crates from workspace build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,18 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-op-hardforks"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07953246c78130f119855393ba0235d22539c60b6a627f737cdf0ae692f042f6"
-dependencies = [
- "alloy-chains",
- "alloy-hardforks",
- "auto_impl",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.4.1"
 source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7#994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7"
@@ -5447,7 +5435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "serde",
  "simd-adler32",
 ]
 
@@ -7412,7 +7399,6 @@ dependencies = [
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-seismic-primitives",
@@ -7693,7 +7679,6 @@ dependencies = [
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
- "reth-optimism-chainspec",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
@@ -8909,71 +8894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-optimism-chainspec"
-version = "1.7.0"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-hardforks",
- "alloy-primitives",
- "derive_more 2.1.1",
- "miniz_oxide",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "paste",
- "reth-chainspec",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-optimism-forks",
- "reth-optimism-primitives",
- "reth-primitives-traits",
- "seismic-alloy-genesis",
- "serde",
- "serde_json",
- "tar-no-std",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-optimism-forks"
-version = "1.7.0"
-dependencies = [
- "alloy-op-hardforks",
- "alloy-primitives",
- "once_cell",
- "reth-ethereum-forks",
-]
-
-[[package]]
-name = "reth-optimism-primitives"
-version = "1.7.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "bincode 1.3.3",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
- "rand 0.8.5",
- "rand 0.9.2",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
- "rstest",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "serde_with",
-]
-
-[[package]]
 name = "reth-payload-builder"
 version = "1.7.0"
 dependencies = [
@@ -9468,7 +9388,6 @@ dependencies = [
  "op-revm",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
  "revm-context",
@@ -12076,17 +11995,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tar-no-std"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
-dependencies = [
- "bitflags 2.10.0",
- "log",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "crates/node/events/",
     "crates/node/metrics",
     "crates/node/types",
+    # seismic: these crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
     # "crates/optimism/bin",
     # "crates/optimism/chainspec",
     # "crates/optimism/cli",
@@ -376,7 +377,6 @@ seismic-alloy-flz = { version = "0.0.1", default-features = false }
 alloy-json-abi = { version = "1.1.2", default-features = false } # only used by seismic rn
 
 # reth
-op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }
 reth-basic-payload-builder = { path = "crates/payload/basic" }
@@ -424,7 +424,6 @@ reth-ethereum = { path = "crates/ethereum/reth" }
 reth-etl = { path = "crates/etl" }
 reth-evm = { path = "crates/evm/evm", default-features = false }
 reth-evm-ethereum = { path = "crates/ethereum/evm", default-features = false }
-reth-optimism-evm = { path = "crates/optimism/evm", default-features = false }
 reth-execution-errors = { path = "crates/evm/execution-errors", default-features = false }
 reth-execution-types = { path = "crates/evm/execution-types", default-features = false }
 reth-exex = { path = "crates/exex/exex" }
@@ -452,18 +451,7 @@ reth-node-ethereum = { path = "crates/ethereum/node" }
 reth-node-ethstats = { path = "crates/node/ethstats" }
 reth-node-events = { path = "crates/node/events" }
 reth-node-metrics = { path = "crates/node/metrics" }
-reth-optimism-node = { path = "crates/optimism/node" }
 reth-node-types = { path = "crates/node/types" }
-reth-op = { path = "crates/optimism/reth", default-features = false }
-reth-optimism-chainspec = { path = "crates/optimism/chainspec", default-features = false }
-reth-optimism-cli = { path = "crates/optimism/cli" }
-reth-optimism-consensus = { path = "crates/optimism/consensus", default-features = false }
-reth-optimism-forks = { path = "crates/optimism/hardforks", default-features = false }
-reth-optimism-payload-builder = { path = "crates/optimism/payload" }
-reth-optimism-primitives = { path = "crates/optimism/primitives", default-features = false }
-reth-optimism-rpc = { path = "crates/optimism/rpc" }
-reth-optimism-storage = { path = "crates/optimism/storage" }
-reth-optimism-txpool = { path = "crates/optimism/txpool" }
 reth-payload-builder = { path = "crates/payload/builder" }
 reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
@@ -484,7 +472,6 @@ reth-rpc-engine-api = { path = "crates/rpc/rpc-engine-api" }
 reth-rpc-eth-api = { path = "crates/rpc/rpc-eth-api" }
 reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = false }
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
-reth-optimism-flashblocks = { path = "crates/optimism/flashblocks" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
 reth-stages = { path = "crates/stages/stages" }

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -39,7 +39,9 @@ eyre.workspace = true
 tracing.workspace = true
 
 op-alloy-rpc-types-engine = { workspace = true, optional = true }
-reth-optimism-chainspec = { workspace = true, optional = true }
+# seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+# The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+# reth-optimism-chainspec = { workspace = true, optional = true }
 
 [lints]
 workspace = true
@@ -48,6 +50,8 @@ workspace = true
 timestamp-in-seconds = []
 op = [
     "dep:op-alloy-rpc-types-engine",
-    "dep:reth-optimism-chainspec",
+    # seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+    # The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+    # "dep:reth-optimism-chainspec",
     "reth-payload-primitives/op",
 ]

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -762,15 +762,21 @@ mod tests {
 
     #[test]
     fn test_discv5_fork_id_default() {
-        #[cfg(feature = "timestamp-in-seconds")]
-        const GENESIS_TIME: u64 = 151_515;
-        #[cfg(not(feature = "timestamp-in-seconds"))]
         const GENESIS_TIME: u64 = 151_515_000;
+        // ForkCondition::Timestamp stores seconds (upstream alloy-hardforks convention),
+        // while header/head timestamps store ms (Seismic uses 300-400ms block times).
+        // This unit mismatch is the source of the `timestamp-in-seconds` feature flag
+        // and scattered `/ 1000` conversions across the codebase.
+        // TODO(samlaf): think we could convert ForkCondition to also use ms, and then only keep the
+        // feature-flag for ef-tests.
+        const GENESIS_TIME_SECONDS: u64 = 151_515;
 
         let genesis = Genesis::default().with_timestamp(GENESIS_TIME);
 
-        let active_fork = (EthereumHardfork::Shanghai, ForkCondition::Timestamp(GENESIS_TIME));
-        let future_fork = (EthereumHardfork::Cancun, ForkCondition::Timestamp(GENESIS_TIME + 1));
+        let active_fork =
+            (EthereumHardfork::Shanghai, ForkCondition::Timestamp(GENESIS_TIME_SECONDS));
+        let future_fork =
+            (EthereumHardfork::Cancun, ForkCondition::Timestamp(GENESIS_TIME_SECONDS + 1));
 
         let chain_spec = ChainSpecBuilder::default()
             .chain(Chain::dev())
@@ -781,7 +787,7 @@ mod tests {
 
         // get the fork id to advertise on discv5
         let genesis_fork_hash = ForkHash::from(chain_spec.genesis_hash());
-        let fork_id = ForkId { hash: genesis_fork_hash, next: GENESIS_TIME + 1 };
+        let fork_id = ForkId { hash: genesis_fork_hash, next: GENESIS_TIME_SECONDS + 1 };
         // check the fork id is set to active fork and _not_ yet future fork
         assert_eq!(
             fork_id,

--- a/crates/optimism/chainspec/Cargo.toml
+++ b/crates/optimism/chainspec/Cargo.toml
@@ -12,9 +12,6 @@ description = "EVM chain spec implementation for optimism."
 workspace = true
 
 [dependencies]
-# seismic
-seismic-alloy-genesis.workspace = true
-
 # reth
 reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
@@ -50,12 +47,11 @@ thiserror = { workspace = true, optional = true }
 op-alloy-consensus.workspace = true
 
 [dev-dependencies]
-# timestamp-in-seconds to make some tests we don't care about pass
-reth-chainspec = { workspace = true, features = ["test-utils", "timestamp-in-seconds"] }
+reth-chainspec = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = ["std"]
-superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "dep:serde"]
+superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "thiserror", "dep:serde"]
 std = [
     "alloy-chains/std",
     "alloy-genesis/std",

--- a/crates/optimism/chainspec/src/base.rs
+++ b/crates/optimism/chainspec/src/base.rs
@@ -23,7 +23,7 @@ pub static BASE_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
                 make_op_genesis_header(&genesis, &hardforks),
                 b256!("0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
             ),
-            genesis: genesis.into(),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/base_sepolia.rs
+++ b/crates/optimism/chainspec/src/base_sepolia.rs
@@ -23,7 +23,7 @@ pub static BASE_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
                 make_op_genesis_header(&genesis, &hardforks),
                 b256!("0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"),
             ),
-            genesis: genesis.into(),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/dev.rs
+++ b/crates/optimism/chainspec/src/dev.rs
@@ -23,7 +23,7 @@ pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
         inner: ChainSpec {
             chain: Chain::dev(),
             genesis_header,
-            genesis: genesis.into(),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -112,7 +112,7 @@ impl OpChainSpecBuilder {
 
     /// Set the genesis block.
     pub fn genesis(mut self, genesis: Genesis) -> Self {
-        self.inner = self.inner.genesis(genesis.into());
+        self.inner = self.inner.genesis(genesis);
         self
     }
 
@@ -276,7 +276,7 @@ impl EthChainSpec for OpChainSpec {
         self.inner.genesis_header()
     }
 
-    fn genesis(&self) -> &seismic_alloy_genesis::Genesis {
+    fn genesis(&self) -> &Genesis {
         self.inner.genesis()
     }
 
@@ -418,14 +418,13 @@ impl From<Genesis> for OpChainSpec {
         ordered_hardforks.append(&mut block_hardforks);
 
         let hardforks = ChainHardforks::new(ordered_hardforks);
-        let genesis_header =
-            SealedHeader::seal_slow(make_op_genesis_header(&genesis.clone().into(), &hardforks));
+        let genesis_header = SealedHeader::seal_slow(make_op_genesis_header(&genesis, &hardforks));
 
         Self {
             inner: ChainSpec {
                 chain: genesis.config.chain_id.into(),
                 genesis_header,
-                genesis: genesis.into(),
+                genesis,
                 hardforks,
                 // We assume no OP network merges, and set the paris block and total difficulty to
                 // zero
@@ -492,11 +491,8 @@ impl OpGenesisInfo {
 }
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
-pub fn make_op_genesis_header(
-    genesis: &seismic_alloy_genesis::Genesis,
-    hardforks: &ChainHardforks,
-) -> Header {
-    let mut header = reth_chainspec::make_genesis_header(&genesis.clone().into(), hardforks);
+pub fn make_op_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
+    let mut header = reth_chainspec::make_genesis_header(genesis, hardforks);
 
     // If Isthmus is active, overwrite the withdrawals root with the storage root of predeploy
     // `L2ToL1MessagePasser.sol`
@@ -508,7 +504,7 @@ pub fn make_op_genesis_header(
                         if v.is_zero() {
                             None
                         } else {
-                            Some((*k, *v))
+                            Some((*k, (*v).into()))
                         }
                     })));
             }

--- a/crates/optimism/chainspec/src/op.rs
+++ b/crates/optimism/chainspec/src/op.rs
@@ -23,7 +23,7 @@ pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
                 make_op_genesis_header(&genesis, &hardforks),
                 b256!("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b"),
             ),
-            genesis: genesis.into(),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/chainspec/src/op_sepolia.rs
+++ b/crates/optimism/chainspec/src/op_sepolia.rs
@@ -21,7 +21,7 @@ pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
                 make_op_genesis_header(&genesis, &hardforks),
                 b256!("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
             ),
-            genesis: genesis.into(),
+            genesis,
             paris_block_and_final_difficulty: Some((0, U256::from(0))),
             hardforks,
             base_fee_params: BaseFeeParamsKind::Variable(

--- a/crates/optimism/evm/src/execute.rs
+++ b/crates/optimism/evm/src/execute.rs
@@ -17,7 +17,6 @@ mod tests {
     use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
     use reth_primitives_traits::{Account, RecoveredBlock};
     use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
-    use revm::state::FlaggedStorage;
     use std::{collections::HashMap, str::FromStr};
 
     fn create_op_state_provider() -> StateProviderTest {
@@ -28,22 +27,18 @@ mod tests {
 
         let mut l1_block_storage = HashMap::default();
         // base fee
-        l1_block_storage
-            .insert(StorageKey::with_last_byte(1), FlaggedStorage::public(1000000000));
+        l1_block_storage.insert(StorageKey::with_last_byte(1), StorageValue::from(1000000000));
         // l1 fee overhead
-        l1_block_storage.insert(StorageKey::with_last_byte(5), FlaggedStorage::public(188));
+        l1_block_storage.insert(StorageKey::with_last_byte(5), StorageValue::from(188));
         // l1 fee scalar
-        l1_block_storage
-            .insert(StorageKey::with_last_byte(6), FlaggedStorage::public(684000));
+        l1_block_storage.insert(StorageKey::with_last_byte(6), StorageValue::from(684000));
         // l1 free scalars post ecotone
         l1_block_storage.insert(
             StorageKey::with_last_byte(3),
-            FlaggedStorage::public(
-                StorageValue::from_str(
-                    "0x0000000000000000000000000000000000001db0000d27300000000000000005",
-                )
-                .unwrap(),
-            ),
+            StorageValue::from_str(
+                "0x0000000000000000000000000000000000001db0000d27300000000000000005",
+            )
+            .unwrap(),
         );
 
         db.insert_account(L1_BLOCK_CONTRACT, l1_block_contract_account, None, l1_block_storage);

--- a/crates/optimism/primitives/Cargo.toml
+++ b/crates/optimism/primitives/Cargo.toml
@@ -50,7 +50,7 @@ rand_08.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
 
 [features]
-default = ["std", "serde-bincode-compat", "alloy-compat", "arbitrary", "reth-codec"]
+default = ["std"]
 std = [
     "reth-primitives-traits/std",
     "reth-codecs?/std",

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -30,7 +30,9 @@ alloy-json-rpc.workspace = true
 op-alloy-consensus = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
-reth-optimism-primitives = { workspace = true, optional = true }
+# seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+# The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+# reth-optimism-primitives = { workspace = true, optional = true }
 op-revm = { workspace = true, optional = true }
 
 # revm
@@ -48,7 +50,9 @@ op = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
     "dep:op-alloy-network",
-    "dep:reth-optimism-primitives",
+    # seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+    # The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+    # "dep:reth-optimism-primitives",
     "dep:reth-storage-api",
     "dep:op-revm",
     "reth-evm/op",

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -31,7 +31,9 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 
 # optimism
-reth-optimism-primitives = { workspace = true, optional = true }
+# seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+# The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+# reth-optimism-primitives = { workspace = true, optional = true }
 
 # codecs
 modular-bitfield.workspace = true
@@ -86,11 +88,13 @@ arbitrary = [
     "reth-prune-types/arbitrary",
     "reth-stages-types/arbitrary",
     "alloy-consensus/arbitrary",
-    "reth-optimism-primitives?/arbitrary",
+    # seismic: remove this dep to avoid pulling them optimism crates that don't compile implicitly by cargo/lsp/etc.
+    # The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
+    # "reth-optimism-primitives?/arbitrary",
     "reth-ethereum-primitives/arbitrary",
 ]
 op = [
-    "dep:reth-optimism-primitives",
+    # "dep:reth-optimism-primitives",
     "reth-codecs/op",
     "reth-primitives-traits/op",
 ]


### PR DESCRIPTION
Revert crates/optimism/ to match upstream (zero diff) and remove optimism workspace dependency entries from root Cargo.toml. Comment out the three optional reth-optimism-* deps in db-api, rpc-convert, and engine/local that were causing cargo to resolve and compile the optimism crates (which fail due to our FlaggedStorage/Genesis changes).

cargo clippy --workspace now passes cleanly.

This will be easier to maintain going forward. Instead of having to fix stuff that we implicitly break in op code, we just disable op code entirely from being compiled/linted.

## Timestamp-ms note

The`test_discv5_fork_id_default` test was passing in CI before because reth-optimism-chainspec's dev-dependency [enabled](https://github.com/SeismicSystems/seismic-reth/blob/9382370ab423b142fb5572155258049e98919e04/crates/optimism/chainspec/Cargo.toml#L54) timestamp-in-seconds on reth-chainspec. This PR removed that though.

Cargo feature unification meant this flag leaked to the entire workspace during cargo test --workspace which we were using in CI, so the network test silently ran in seconds mode. However note that the test failed when ran directly via cargo nextest run -p reth-network test_discv5_fork_id_default. So this fix is more principled. Also the timestamp-in-seconds flag was not even a feature of the network crate.

Fix: use separate constants — GENESIS_TIME (ms) for genesis/head timestamps, GENESIS_TIME_SECONDS (s) for ForkCondition and ForkId.

### Future improvements
                                                                                                                              
Longer term, we should unify to ms everywhere — including ForkCondition::Timestamp — and only keep the timestamp-in-seconds feature flag for ef-tests (whose fixtures have seconds baked into RLP-encoded blocks). This would eliminate the unit mismatch and the ~26 scattered cfg!/conversion sites across 4 repos.

Here is Claude's plan:
```
Combine A's "ms everywhere" approach with a retained feature flag scoped to ef-tests only. Production code uses ms for everything — `header.timestamp`, `Head.timestamp`, and `ForkCondition::Timestamp` are all ms. This means the conversion code in `spec.rs` (`* 1000`, `/ 1000`, `genesis_timestamp_seconds()`) is deleted, not made unconditional. The `cfg!` checks only survive in the few code paths ef-tests exercise (TIMESTAMP/TIMESTAMPMS opcodes in seismic-revm, fork activation in seismic-reth chainspec).

**Pros:**
- Production code has one unit everywhere: ms. No conversions in fork activation, fork ID, or fork filter
- Eliminates ~20 Cargo.toml propagation entries from production
- ef-tests continue to pass using the seconds path (flag ON: fork conditions in seconds, header timestamps in seconds, no conversions)
- Unit tests throughout the codebase use ms consistently
- The `cfg!` checks that remain are only exercised by ef-tests

**Cons:**
- Feature flag still exists (in seismic-revm's block_info.rs and seismic-reth's chainspec)
- Two code paths still compiled, just one is only used by ef-tests
- RPCs still return ms (breaks standard tooling without the proxy)
- `ForkId.next` contains ms in production, diverging from Ethereum p2p convention (acceptable — Seismic has its own network)

**Scope:**

| Repo | Work |
|------|------|
| seismic-reth | Remove flag from `bin/seismic-reth/Cargo.toml` and ~18 production crate Cargo.toml entries. Delete conversion code in production paths (`* 1000`, `/ 1000`, `genesis_timestamp_seconds()`). Update Seismic chainspecs to store ms in `ForkCondition::Timestamp`. Keep `cfg!` in `chainspec/src/spec.rs` for ef-tests. Update ~10 unit tests. Keep flag in `testing/ef-tests/Cargo.toml`. |
| seismic-revm | Keep `cfg!` in `block_info.rs` (TIMESTAMP/TIMESTAMPMS opcodes, needed for ef-tests). Remove flag from production Cargo.toml propagation. |
| seismic-evm | Remove `cfg!` checks entirely (ef-tests use `EthEvmConfig`, not `SeismicEvmConfig`). Remove from Cargo.toml. |
| seismic-foundry | ~1 test update, Cargo.toml cleanup. |

**Verdict:** Best balance. Cleanest production code (no conversions), ef-tests still work.
```