### PR TITLE
refactor: inject purpose keys structurally through SeismicNode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,27 @@ Reth is a high-performance Ethereum execution client written in Rust, focusing o
    cargo +nightly fmt --all
    ```
 
-2. **Linting**: Run clippy with all features
+2. **Linting**: Run the Seismic CI clippy command (matches `.github/workflows/seismic.yml`)
    ```bash
-   RUSTFLAGS="-D warnings" cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked
+   cargo clippy \
+     -p reth-seismic-primitives \
+     -p reth-seismic-chainspec \
+     -p reth-seismic-evm \
+     -p reth-seismic-payload-builder \
+     -p reth-seismic-node \
+     -p reth-seismic-rpc \
+     -p reth-seismic-cli \
+     -p reth-seismic-txpool \
+     -p reth-seismic-forks \
+     -p seismic-reth \
+     --lib --tests --no-deps \
+     -- -D warnings \
+     -W clippy::unwrap_used \
+     -W clippy::expect_used \
+     -W clippy::indexing_slicing \
+     -W clippy::panic \
+     -W clippy::unreachable \
+     -W clippy::todo
    ```
 
 3. **Testing**: Use nextest for faster test execution
@@ -166,13 +184,36 @@ Based on PR patterns, avoid:
 
 ### CI Requirements
 
-Before submitting changes, ensure:
+Before committing or pushing code, run these checks locally to match what Seismic CI (`.github/workflows/seismic.yml`) enforces:
 
 1. **Format Check**: `cargo +nightly fmt --all --check`
-2. **Clippy**: No warnings with `RUSTFLAGS="-D warnings"`
-3. **Tests Pass**: All unit and integration tests
-4. **Documentation**: Update relevant docs and add doc comments with `cargo docs --document-private-items`
-5. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
+2. **Warnings Check**: `RUSTFLAGS="-D warnings" cargo check`
+3. **Clippy** (Seismic crates with strict lints):
+   ```bash
+   cargo clippy \
+     -p reth-seismic-primitives \
+     -p reth-seismic-chainspec \
+     -p reth-seismic-evm \
+     -p reth-seismic-payload-builder \
+     -p reth-seismic-node \
+     -p reth-seismic-rpc \
+     -p reth-seismic-cli \
+     -p reth-seismic-txpool \
+     -p reth-seismic-forks \
+     -p seismic-reth \
+     --lib --tests --no-deps \
+     -- -D warnings \
+     -W clippy::unwrap_used \
+     -W clippy::expect_used \
+     -W clippy::indexing_slicing \
+     -W clippy::panic \
+     -W clippy::unreachable \
+     -W clippy::todo
+   ```
+4. **Tests Pass**: `cargo nextest run --workspace` (unit and integration)
+5. **Build Check**: `cargo check --workspace`
+6. **Documentation**: Update relevant docs and add doc comments with `cargo docs --document-private-items`
+7. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
 
 
 ### Opening PRs against <https://github.com/paradigmxyz/reth>
@@ -294,8 +335,11 @@ Let's say you want to fix a bug where external IP resolution fails on startup:
 # Format code
 cargo +nightly fmt --all
 
-# Run lints
-RUSTFLAGS="-D warnings" cargo +nightly clippy --workspace --all-features --locked
+# Run Seismic CI clippy (see CI Requirements section for full command)
+cargo clippy -p reth-seismic-primitives -p reth-seismic-chainspec -p reth-seismic-evm -p reth-seismic-payload-builder -p reth-seismic-node -p reth-seismic-rpc -p reth-seismic-cli -p reth-seismic-txpool -p reth-seismic-forks -p seismic-reth --lib --tests --no-deps -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic -W clippy::unreachable -W clippy::todo
+
+# Run warnings check
+RUSTFLAGS="-D warnings" cargo check
 
 # Run tests
 cargo nextest run --workspace

--- a/bin/seismic-reth/src/main.rs
+++ b/bin/seismic-reth/src/main.rs
@@ -16,12 +16,16 @@ fn main() {
         // Boot enclave and fetch purpose keys BEFORE building node components
         let purpose_keys = boot_enclave_and_fetch_keys(&encl).await;
 
-        // Store purpose keys in global static storage before building the node.
+        // Store purpose keys in global static storage as a fallback for code
+        // paths that cannot yet receive keys structurally (e.g. CLI stage command).
         // Seismic RPC modules (seismic_ namespace + eth_ overrides) are registered
         // in SeismicAddOns::launch_add_ons, which reads keys via get_purpose_keys().
-        reth_seismic_node::purpose_keys::init_purpose_keys(purpose_keys);
+        reth_seismic_node::purpose_keys::init_purpose_keys(purpose_keys.clone());
 
-        let node = builder.node(SeismicNode::default()).launch_with_debug_capabilities().await?;
+        // Inject purpose keys structurally into SeismicNode so they flow
+        // through the node builder lifecycle without relying on the global.
+        let node =
+            builder.node(SeismicNode::new(purpose_keys)).launch_with_debug_capabilities().await?;
         node.node_exit_future.await
     }) {
         eprintln!("Error: {err:?}");

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -63,12 +63,38 @@ use crate::{purpose_keys::get_purpose_keys, seismic_evm_config};
 /// Storage implementation for Seismic.
 pub type SeismicStorage = EthStorage<SeismicTransactionSigned>;
 
-#[derive(Debug, Default, Clone)]
-#[non_exhaustive]
+#[derive(Debug, Clone)]
 /// Type configuration for a regular Seismic node.
-pub struct SeismicNode;
+///
+/// Purpose keys can be injected via [`SeismicNode::new`] so they flow through
+/// the node builder lifecycle instead of being read from a global side-channel.
+/// When constructed via [`Default`] (e.g. in tests), the executor builder will
+/// fall back to the global [`crate::purpose_keys::get_purpose_keys`].
+pub struct SeismicNode {
+    /// Structurally-injected purpose keys.  `None` means "use global fallback".
+    purpose_keys: Option<&'static seismic_enclave::GetPurposeKeysResponse>,
+}
+
+impl Default for SeismicNode {
+    fn default() -> Self {
+        Self { purpose_keys: None }
+    }
+}
 
 impl SeismicNode {
+    /// Create a new [`SeismicNode`] with structurally-injected purpose keys.
+    ///
+    /// The keys are leaked onto the heap so they live for `'static`, which is
+    /// required by the EVM configuration layer.
+    pub fn new(purpose_keys: seismic_enclave::GetPurposeKeysResponse) -> Self {
+        Self { purpose_keys: Some(crate::purpose_keys::leak_purpose_keys(purpose_keys)) }
+    }
+
+    /// Returns the injected purpose keys, if any.
+    pub fn purpose_keys(&self) -> Option<&'static seismic_enclave::GetPurposeKeysResponse> {
+        self.purpose_keys
+    }
+
     /// Returns the components for the given [`EnclaveArgs`].
     pub fn components<Node>(
         &self,
@@ -89,10 +115,11 @@ impl SeismicNode {
             >,
         >,
     {
+        let executor = SeismicExecutorBuilder { purpose_keys: self.purpose_keys };
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(SeismicPoolBuilder::default())
-            .executor(SeismicExecutorBuilder::default())
+            .executor(executor)
             .payload(BasicPayloadServiceBuilder::<SeismicPayloadBuilder>::default())
             .network(SeismicNetworkBuilder::default())
             .consensus(SeismicConsensusBuilder::default())
@@ -470,9 +497,14 @@ where
 }
 
 /// A regular seismic evm and executor builder.
-#[derive(Debug, Default, Clone, Copy)]
-#[non_exhaustive]
-pub struct SeismicExecutorBuilder;
+///
+/// When `purpose_keys` is `Some`, uses the injected keys directly.
+/// When `None`, falls back to the global [`crate::purpose_keys::get_purpose_keys`].
+#[derive(Debug, Default, Clone)]
+pub struct SeismicExecutorBuilder {
+    /// Structurally-injected purpose keys, or `None` for global fallback.
+    purpose_keys: Option<&'static seismic_enclave::GetPurposeKeysResponse>,
+}
 
 impl<Node> ExecutorBuilder<Node> for SeismicExecutorBuilder
 where
@@ -481,7 +513,8 @@ where
     type EVM = SeismicEvmConfig;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let purpose_keys = crate::purpose_keys::get_purpose_keys();
+        let purpose_keys =
+            self.purpose_keys.unwrap_or_else(|| crate::purpose_keys::get_purpose_keys());
         let evm_config = seismic_evm_config(ctx.chain_spec(), purpose_keys);
 
         Ok(evm_config)

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -70,15 +70,10 @@ pub type SeismicStorage = EthStorage<SeismicTransactionSigned>;
 /// the node builder lifecycle instead of being read from a global side-channel.
 /// When constructed via [`Default`] (e.g. in tests), the executor builder will
 /// fall back to the global [`crate::purpose_keys::get_purpose_keys`].
+#[derive(Default)]
 pub struct SeismicNode {
     /// Structurally-injected purpose keys.  `None` means "use global fallback".
     purpose_keys: Option<&'static seismic_enclave::GetPurposeKeysResponse>,
-}
-
-impl Default for SeismicNode {
-    fn default() -> Self {
-        Self { purpose_keys: None }
-    }
 }
 
 impl SeismicNode {
@@ -91,7 +86,7 @@ impl SeismicNode {
     }
 
     /// Returns the injected purpose keys, if any.
-    pub fn purpose_keys(&self) -> Option<&'static seismic_enclave::GetPurposeKeysResponse> {
+    pub const fn purpose_keys(&self) -> Option<&'static seismic_enclave::GetPurposeKeysResponse> {
         self.purpose_keys
     }
 

--- a/crates/seismic/node/src/purpose_keys.rs
+++ b/crates/seismic/node/src/purpose_keys.rs
@@ -2,6 +2,19 @@
 //!
 //! This module provides thread-safe access to purpose keys that are fetched once
 //! during node startup and then used throughout the application lifetime.
+//!
+//! ## Preferred path: structural injection
+//!
+//! Purpose keys should be injected into [`SeismicNode::new`](crate::node::SeismicNode::new),
+//! which stores them and threads them through the node builder lifecycle
+//! (executor builder, etc.). This avoids reliance on global state.
+//!
+//! ## Deprecated fallback: global `OnceLock`
+//!
+//! The global [`init_purpose_keys`] / [`get_purpose_keys`] functions are retained
+//! as a fallback for code paths that cannot yet receive keys structurally (e.g.
+//! the CLI `stage` command, or tests that construct `SeismicNode::default()`).
+//! New code should prefer the injection path.
 
 use seismic_enclave::GetPurposeKeysResponse;
 use std::sync::OnceLock;
@@ -27,4 +40,13 @@ pub fn init_purpose_keys(keys: GetPurposeKeysResponse) {
 #[allow(clippy::expect_used)] // Documented panic behavior
 pub fn get_purpose_keys() -> &'static GetPurposeKeysResponse {
     PURPOSE_KEYS.get().expect("Purpose keys not initialized")
+}
+
+/// Leak-box the given keys onto the heap and return a `&'static` reference.
+///
+/// This is used by [`SeismicNode::new`](crate::node::SeismicNode::new) so that
+/// the purpose keys have a `'static` lifetime without relying on the global
+/// `OnceLock`.
+pub fn leak_purpose_keys(keys: GetPurposeKeysResponse) -> &'static GetPurposeKeysResponse {
+    Box::leak(Box::new(keys))
 }


### PR DESCRIPTION
## Summary

- `SeismicNode` now accepts purpose keys via `SeismicNode::new(keys)`, threading them through the node builder lifecycle (executor builder → EVM config) without relying on the global `OnceLock`
- `SeismicExecutorBuilder` uses injected keys when available, falling back to `get_purpose_keys()` when constructed via `Default` (tests, CLI stage command)
- `main.rs` uses `SeismicNode::new(purpose_keys)` instead of `SeismicNode::default()`
- Global `init_purpose_keys()` / `get_purpose_keys()` retained as deprecated fallback for code paths that can't yet receive keys structurally

Addresses https://github.com/SeismicSystems/seismic-reth/pull/352#discussion_r3029445460

## Test plan

- [x] `cargo check -p reth-seismic-node -p seismic-reth` — compiles clean
- [x] `cargo nextest run -p reth-seismic-node -E 'kind(test)' --no-fail-fast` — all integration tests pass
- [x] `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)