### PR TITLE
test(net): fix test_discv5_fork_id_default timestamp unit mismatch

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -762,15 +762,21 @@ mod tests {
 
     #[test]
     fn test_discv5_fork_id_default() {
-        #[cfg(feature = "timestamp-in-seconds")]
-        const GENESIS_TIME: u64 = 151_515;
-        #[cfg(not(feature = "timestamp-in-seconds"))]
         const GENESIS_TIME: u64 = 151_515_000;
+        // ForkCondition::Timestamp stores seconds (upstream alloy-hardforks convention),
+        // while header/head timestamps store ms (Seismic uses 300-400ms block times).
+        // This unit mismatch is the source of the `timestamp-in-seconds` feature flag
+        // and scattered `/ 1000` conversions across the codebase.
+        // TODO(samlaf): think we could convert ForkCondition to also use ms, and then only keep the
+        // feature-flag for ef-tests.
+        const GENESIS_TIME_SECONDS: u64 = 151_515;
 
         let genesis = Genesis::default().with_timestamp(GENESIS_TIME);
 
-        let active_fork = (EthereumHardfork::Shanghai, ForkCondition::Timestamp(GENESIS_TIME));
-        let future_fork = (EthereumHardfork::Cancun, ForkCondition::Timestamp(GENESIS_TIME + 1));
+        let active_fork =
+            (EthereumHardfork::Shanghai, ForkCondition::Timestamp(GENESIS_TIME_SECONDS));
+        let future_fork =
+            (EthereumHardfork::Cancun, ForkCondition::Timestamp(GENESIS_TIME_SECONDS + 1));
 
         let chain_spec = ChainSpecBuilder::default()
             .chain(Chain::dev())
@@ -781,7 +787,7 @@ mod tests {
 
         // get the fork id to advertise on discv5
         let genesis_fork_hash = ForkHash::from(chain_spec.genesis_hash());
-        let fork_id = ForkId { hash: genesis_fork_hash, next: GENESIS_TIME + 1 };
+        let fork_id = ForkId { hash: genesis_fork_hash, next: GENESIS_TIME_SECONDS + 1 };
         // check the fork id is set to active fork and _not_ yet future fork
         assert_eq!(
             fork_id,


### PR DESCRIPTION
This test was passing before because reth-optimism-chainspec's dev-dependency [enabled](https://github.com/SeismicSystems/seismic-reth/blob/9382370ab423b142fb5572155258049e98919e04/crates/optimism/chainspec/Cargo.toml#L54) `timestamp-in-seconds` on reth-chainspec.                                                              
                
Cargo feature unification meant this flag leaked to the entire workspace during `cargo test --workspace` which we were using in CI, so the network test silently ran in seconds mode. However the test failed when ran directly via `cargo nextest run -p reth-network test_discv5_fork_id_default`. Discovered this when removing the optimism dependency in https://github.com/SeismicSystems/seismic-reth/pull/359.                                                                    
                
Fix: use separate constants — GENESIS_TIME (ms) for genesis/head timestamps, GENESIS_TIME_SECONDS (s) for ForkCondition and ForkId.

## Future improvements
                                                                                                                              
Longer term, we should unify to ms everywhere — including ForkCondition::Timestamp — and only keep the timestamp-in-seconds feature flag for ef-tests (whose fixtures have seconds baked into RLP-encoded blocks). This would eliminate the unit mismatch and the ~26 scattered cfg!/conversion sites across 4 repos.

Here is Claude's plan:
```
Combine A's "ms everywhere" approach with a retained feature flag scoped to ef-tests only. Production code uses ms for everything — `header.timestamp`, `Head.timestamp`, and `ForkCondition::Timestamp` are all ms. This means the conversion code in `spec.rs` (`* 1000`, `/ 1000`, `genesis_timestamp_seconds()`) is deleted, not made unconditional. The `cfg!` checks only survive in the few code paths ef-tests exercise (TIMESTAMP/TIMESTAMPMS opcodes in seismic-revm, fork activation in seismic-reth chainspec).

**Pros:**
- Production code has one unit everywhere: ms. No conversions in fork activation, fork ID, or fork filter
- Eliminates ~20 Cargo.toml propagation entries from production
- ef-tests continue to pass using the seconds path (flag ON: fork conditions in seconds, header timestamps in seconds, no conversions)
- Unit tests throughout the codebase use ms consistently
- The `cfg!` checks that remain are only exercised by ef-tests

**Cons:**
- Feature flag still exists (in seismic-revm's block_info.rs and seismic-reth's chainspec)
- Two code paths still compiled, just one is only used by ef-tests
- RPCs still return ms (breaks standard tooling without the proxy)
- `ForkId.next` contains ms in production, diverging from Ethereum p2p convention (acceptable — Seismic has its own network)

**Scope:**

| Repo | Work |
|------|------|
| seismic-reth | Remove flag from `bin/seismic-reth/Cargo.toml` and ~18 production crate Cargo.toml entries. Delete conversion code in production paths (`* 1000`, `/ 1000`, `genesis_timestamp_seconds()`). Update Seismic chainspecs to store ms in `ForkCondition::Timestamp`. Keep `cfg!` in `chainspec/src/spec.rs` for ef-tests. Update ~10 unit tests. Keep flag in `testing/ef-tests/Cargo.toml`. |
| seismic-revm | Keep `cfg!` in `block_info.rs` (TIMESTAMP/TIMESTAMPMS opcodes, needed for ef-tests). Remove flag from production Cargo.toml propagation. |
| seismic-evm | Remove `cfg!` checks entirely (ef-tests use `EthEvmConfig`, not `SeismicEvmConfig`). Remove from Cargo.toml. |
| seismic-foundry | ~1 test update, Cargo.toml cleanup. |

**Verdict:** Best balance. Cleanest production code (no conversions), ef-tests still work.
```