### PR TITLE
fix(rpc)!: sanitize `from` in eth_estimateGas to prevent leaks via caller spoofing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=4607075bb120f9727137887f67280506d806c59a#4607075bb120f9727137887f67280506d806c59a"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f#86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=4607075bb120f9727137887f67280506d806c59a#4607075bb120f9727137887f67280506d806c59a"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f#86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5514,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10036,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "bitvec",
  "phf",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10109,7 +10109,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "auto_impl",
  "either",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "auto_impl",
  "either",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10226,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10764,7 +10764,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=41325fbc629ff18f69bf22d3b36dfa7937dbfb56#41325fbc629ff18f69bf22d3b36dfa7937dbfb56"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=584184c5c3df59d2876ca498b1b976505e5536e8#584184c5c3df59d2876ca498b1b976505e5536e8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10790,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-genesis"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=41325fbc629ff18f69bf22d3b36dfa7937dbfb56#41325fbc629ff18f69bf22d3b36dfa7937dbfb56"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=584184c5c3df59d2876ca498b1b976505e5536e8#584184c5c3df59d2876ca498b1b976505e5536e8"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=41325fbc629ff18f69bf22d3b36dfa7937dbfb56#41325fbc629ff18f69bf22d3b36dfa7937dbfb56"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=584184c5c3df59d2876ca498b1b976505e5536e8#584184c5c3df59d2876ca498b1b976505e5536e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -10830,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=41325fbc629ff18f69bf22d3b36dfa7937dbfb56#41325fbc629ff18f69bf22d3b36dfa7937dbfb56"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=584184c5c3df59d2876ca498b1b976505e5536e8#584184c5c3df59d2876ca498b1b976505e5536e8"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=41325fbc629ff18f69bf22d3b36dfa7937dbfb56#41325fbc629ff18f69bf22d3b36dfa7937dbfb56"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=584184c5c3df59d2876ca498b1b976505e5536e8#584184c5c3df59d2876ca498b1b976505e5536e8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10915,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=863c1fe6c66502e75217c5dcd20f8238a0282b51#863c1fe6c66502e75217c5dcd20f8238a0282b51"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=dc05eece19f14516ab9f996611fa7c63e1d1a8ae#dc05eece19f14516ab9f996611fa7c63e1d1a8ae"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -768,28 +768,28 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "e75adca2bed85c68ebecf1b130decd08693f2f0b" }
 
 # Seismic alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "41325fbc629ff18f69bf22d3b36dfa7937dbfb56" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "41325fbc629ff18f69bf22d3b36dfa7937dbfb56" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "41325fbc629ff18f69bf22d3b36dfa7937dbfb56" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "41325fbc629ff18f69bf22d3b36dfa7937dbfb56" }
-seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "41325fbc629ff18f69bf22d3b36dfa7937dbfb56" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "584184c5c3df59d2876ca498b1b976505e5536e8" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "584184c5c3df59d2876ca498b1b976505e5536e8" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "584184c5c3df59d2876ca498b1b976505e5536e8" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "584184c5c3df59d2876ca498b1b976505e5536e8" }
+seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "584184c5c3df59d2876ca498b1b976505e5536e8" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "4607075bb120f9727137887f67280506d806c59a" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "4607075bb120f9727137887f67280506d806c59a" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "86a0ecf8e7148eb04cb8a4371c0f1f97004ec84f" }

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -490,8 +490,8 @@ pub(super) mod serde_bincode_compat {
 mod compact {
     use super::*;
     use reth_codecs::{
-        __private::{modular_bitfield::prelude::*, Buf},
         Compact,
+        __private::{modular_bitfield::prelude::*, Buf},
     };
 
     impl Receipt {

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -490,8 +490,8 @@ pub(super) mod serde_bincode_compat {
 mod compact {
     use super::*;
     use reth_codecs::{
-        Compact,
         __private::{modular_bitfield::prelude::*, Buf},
+        Compact,
     };
 
     impl Receipt {

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1032,8 +1032,7 @@ async fn test_eth_estimate_gas_rejects_code_override() -> eyre::Result<()> {
 
     let result = EthApiOverrideClient::<Block>::estimate_gas(
         &client,
-        SeismicCallRequest::TransactionRequest(
-        SeismicTransactionRequest {
+        SeismicCallRequest::TransactionRequest(SeismicTransactionRequest {
             inner: TransactionRequest {
                 from: Some(wallet.inner.address()),
                 to: Some(TxKind::Call(victim_addr)),

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -270,16 +270,63 @@ async fn rpc_test_gas_and_call_variants(
     )
     .await;
 
-    // test eth_estimateGas
+    // test eth_estimateGas with signed bytes (unsigned requests have `from` sanitized)
     let gas = EthApiOverrideClient::<Block>::estimate_gas(
         client,
-        simulate_tx_request.clone(),
+        get_signed_seismic_tx_bytes(
+            &wallet.inner,
+            get_nonce(client, wallet.inner.address()).await,
+            TxKind::Call(contract_addr),
+            chain_id,
+            ContractTestContext::get_is_odd_input_plaintext(),
+            recent_block_hash,
+        )
+        .await
+        .into(),
         None,
         None,
     )
     .await
     .unwrap();
     assert!(gas > U256::ZERO);
+
+    // test eth_estimateGas sanitizes unsigned seismic requests (clears `from` and
+    // seismic_elements to prevent caller spoofing, same as eth_call)
+    let unsigned_seismic_result = EthApiOverrideClient::<Block>::estimate_gas(
+        client,
+        SeismicCallRequest::TransactionRequest(simulate_tx_request.clone()),
+        None,
+        None,
+    )
+    .await;
+    // Sanitized request simulates ciphertext as address(0) — expected to fail
+    assert!(
+        unsigned_seismic_result.is_err(),
+        "unsigned seismic estimateGas should fail after sanitization"
+    );
+
+    // test eth_estimateGas works for plain unsigned requests (standard Ethereum behavior)
+    let plain_unsigned_result = EthApiOverrideClient::<Block>::estimate_gas(
+        client,
+        SeismicCallRequest::TransactionRequest(SeismicTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(wallet.inner.address()),
+                to: Some(TxKind::Call(contract_addr)),
+                input: TransactionInput {
+                    data: Some(ContractTestContext::get_is_odd_input_plaintext()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            seismic_elements: None,
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    println!("eth_estimateGas for plain unsigned is_odd() gas: {:?}", plain_unsigned_result);
+    assert!(plain_unsigned_result > U256::ZERO);
 
     // TODO: should remove this functionality from seismic tx (audit)
     let _access_list =

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1032,6 +1032,7 @@ async fn test_eth_estimate_gas_rejects_code_override() -> eyre::Result<()> {
 
     let result = EthApiOverrideClient::<Block>::estimate_gas(
         &client,
+        SeismicCallRequest::TransactionRequest(
         SeismicTransactionRequest {
             inner: TransactionRequest {
                 from: Some(wallet.inner.address()),
@@ -1041,7 +1042,7 @@ async fn test_eth_estimate_gas_rejects_code_override() -> eyre::Result<()> {
                 ..Default::default()
             },
             seismic_elements: None,
-        },
+        }),
         None,
         Some(state_overrides),
     )

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -123,7 +123,7 @@ pub trait EthApiOverride<B: RpcObject> {
     #[method(name = "estimateGas")]
     async fn estimate_gas(
         &self,
-        request: SeismicTransactionRequest,
+        request: SeismicCallRequest,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256>;
@@ -307,16 +307,21 @@ where
 
     async fn estimate_gas(
         &self,
-        request: SeismicTransactionRequest,
+        request: SeismicCallRequest,
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256> {
         debug!(target: "reth-seismic-rpc::eth", ?request, ?block_number, ?state_override, "serving seismic eth_estimateGas extension");
 
-        // Decrypt if this is a seismic transaction
-        let is_seismic = request.seismic_elements.is_some();
-        let decrypted_req =
-            signed_read_to_plaintext_tx((request, is_seismic), &self.purpose_keys.tx_io_sk)?;
+        // Same sanitization as eth_call: unsigned requests have `from`,
+        // gas/value fields, and seismic_elements cleared to prevent caller
+        // spoofing that could leak private state. Signed requests (TypedData/Bytes)
+        // authenticate the sender cryptographically and are processed normally.
+        let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
+        let decrypted_req = signed_read_to_plaintext_tx(
+            (seismic_tx_request, signed_read),
+            &self.purpose_keys.tx_io_sk,
+        )?;
 
         // call inner
         Ok(EthCall::estimate_gas_at(


### PR DESCRIPTION
Response to this audit issue:
<https://github.com/SeismicSystems/mirror--seismic-reth/issues/4>

Reliant on [this seismic-alloy pr](https://github.com/SeismicSystems/seismic-alloy/pull/98).
**DO NOT MERGE** before updating the seismic-alloy deps in `Cargo.toml` upon
merging that pr.
