### PR TITLE
fix: decouple rpc_compat test from SEISMIC_DEV chainspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,6 +9262,7 @@ dependencies = [
 name = "reth-seismic-node"
 version = "1.7.0"
 dependencies = [
+ "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
@@ -9311,6 +9312,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-seismic-chainspec",
  "reth-seismic-evm",
+ "reth-seismic-forks",
  "reth-seismic-node",
  "reth-seismic-payload-builder",
  "reth-seismic-primitives",

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -98,7 +98,9 @@ reth-seismic-evm.workspace = true
 reth-seismic-chainspec.workspace = true
 alloy-network = { workspace = true }
 alloy-signer-local = { workspace = true }
+alloy-chains.workspace = true
 alloy-genesis = { workspace = true }
+reth-seismic-forks.workspace = true
 seismic-alloy-network = { workspace = true }
 seismic-alloy-provider = { workspace = true }
 alloy-dyn-abi.workspace = true

--- a/crates/seismic/node/tests/e2e/rpc_compat.rs
+++ b/crates/seismic/node/tests/e2e/rpc_compat.rs
@@ -3,19 +3,23 @@
 //! These tests import a chain produced by a Summit testnet (real consensus, chain ID 5124)
 //! and verify RPC responses against captured `.io` test files.
 
+use alloy_chains::Chain;
+use alloy_genesis::Genesis;
+use alloy_primitives::U256;
 use eyre::Result;
+use reth_chainspec::{make_genesis_header, ChainSpec};
 use reth_e2e_test_utils::testsuite::{
     actions::{MakeCanonical, UpdateBlockInfo},
     setup::{NetworkSetup, Setup},
     TestBuilder,
 };
+use reth_primitives_traits::SealedHeader;
 use reth_rpc_e2e_tests::rpc_compat::{InitializeFromExecutionApis, RunRpcCompatTests};
-use reth_seismic_chainspec::SEISMIC_DEV;
 use reth_seismic_evm::SeismicEvmConfig;
 use reth_seismic_node::{
     engine::SeismicEngineTypes, node::SeismicNode, purpose_keys::get_purpose_keys,
 };
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -30,12 +34,37 @@ async fn test_seismic_rpc_compat() -> Result<()> {
 
     let chain_rlp_path = test_data_path.join("chain.rlp");
     let fcu_json_path = test_data_path.join("headfcu.json");
+    let genesis_path = test_data_path.join("genesis.json");
 
     assert!(chain_rlp_path.exists(), "chain.rlp not found");
     assert!(fcu_json_path.exists(), "headfcu.json not found");
+    assert!(genesis_path.exists(), "genesis.json not found");
+
+    // Load genesis from testdata so this test is decoupled from SEISMIC_DEV.
+    let genesis_json =
+        std::fs::read_to_string(&genesis_path).expect("failed to read genesis.json from testdata");
+    let mut genesis: Genesis = serde_json::from_str(&genesis_json).expect("invalid genesis JSON");
+
+    // Genesis JSON timestamps are in seconds, but when timestamp-in-seconds feature is disabled,
+    // we store timestamps internally as milliseconds.
+    #[cfg(not(feature = "timestamp-in-seconds"))]
+    {
+        genesis.timestamp *= 1000;
+    }
+
+    let hardforks = reth_seismic_forks::SEISMIC_DEV_HARDFORKS.clone();
+    let chain_spec: Arc<ChainSpec> = ChainSpec {
+        chain: Chain::from_id(genesis.config.chain_id),
+        genesis_header: SealedHeader::seal_slow(make_genesis_header(&genesis, &hardforks)),
+        genesis,
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks,
+        ..Default::default()
+    }
+    .into();
 
     let setup = Setup::<SeismicEngineTypes>::default()
-        .with_chain_spec(SEISMIC_DEV.clone())
+        .with_chain_spec(chain_spec.clone())
         .with_network(NetworkSetup::single_node());
 
     let test = TestBuilder::new()
@@ -50,7 +79,7 @@ async fn test_seismic_rpc_compat() -> Result<()> {
             test_data_path.to_string_lossy(),
         ));
 
-    let evm_config = SeismicEvmConfig::new(SEISMIC_DEV.clone(), get_purpose_keys());
+    let evm_config = SeismicEvmConfig::new(chain_spec, get_purpose_keys());
     test.run_with_evm::<SeismicNode>(evm_config).await?;
 
     Ok(())

--- a/crates/seismic/node/tests/e2e/testdata/rpc-compat/genesis.json
+++ b/crates/seismic/node/tests/e2e/testdata/rpc-compat/genesis.json
@@ -77,63 +77,6 @@
     },
     "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
       "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x1a642f0e3c3af545e7acbd38b07251b3990914f1": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x5050a4f4b3f9338c3472dcc01a87c76a144b3c9c": {
-      "balance": "0x14D1120D7B160000"
-    },
-    "0x3325a78425f17a7e487eb5666b2bfd93abb06c70": {
-      "balance": "0x14D1120D7B160000"
-    },
-    "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x976ea74026e726554db657fa54763abd0c3a0aa9": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x14dc79964da2c08b23698b3d3cc7ca32193d9955": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xa0ee7a142d267c1f36714e4a8f75612f20a79720": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xbcd4042de499d14e55001ccbb24a551f3b954096": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x71be63f3384f5fb98995898a86b02fb2426c5788": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xfabb0ac9d68b0b445fb7357272ff202c5651694a": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xcd3b766ccdd6ae721141f452c550ca635964ce71": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x2546bcd3c84621e976d8185a91a922ae77ecec30": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xbda5747bfd65f08deb54cb465eb87d40e51b197e": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0xdd2fd4581271e230360230f9337d5c0430bf44c0": {
-      "balance": "0xD3C21BCECCEDA1000000"
-    },
-    "0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199": {
-      "balance": "0xD3C21BCECCEDA1000000"
     }
   },
   "coinbase": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
## Summary

The rpc_compat test previously used the hardcoded `SEISMIC_DEV` chainspec to initialize the node, but the test chain data (`chain.rlp`) was generated from a specific genesis at a specific point in time. If `SEISMIC_DEV` diverges from that genesis, the test breaks — not from a regression, but from a genesis mismatch.

This PR loads `genesis.json` from the testdata directory instead, so the node is always initialized with the same genesis that produced the chain data.

## Changes

- **`rpc_compat.rs`**: Load and parse `genesis.json` from testdata, build a `ChainSpec` from it using `SEISMIC_DEV_HARDFORKS`, use that for both `Setup` and `SeismicEvmConfig`
- **`genesis.json`**: Remove 19 extra Hardhat-default accounts that weren't present in the genesis used to generate `chain.rlp` (caused state root mismatch)
- **`Cargo.toml`**: Add `alloy-chains` and `reth-seismic-forks` as dev-dependencies

## Test plan

- [x] `cargo test -p reth-seismic-node --test e2e -- test_seismic_rpc_compat` passes