### PR TITLE
chore: add lefthook configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,31 @@
+pre-commit:
+  commands:
+    fmt:
+      run: cargo +nightly fmt --all
+      stage_fixed: true
+
+pre-push:
+  commands:
+    clippy:
+      run: >
+        cargo clippy
+        -p reth-seismic-primitives
+        -p reth-seismic-chainspec
+        -p reth-seismic-evm
+        -p reth-seismic-payload-builder
+        -p reth-seismic-node
+        -p reth-seismic-rpc
+        -p reth-seismic-cli
+        -p reth-seismic-txpool
+        -p reth-seismic-forks
+        -p seismic-reth
+        --lib --tests --no-deps
+        -- -D warnings
+        -W clippy::unwrap_used
+        -W clippy::expect_used
+        -W clippy::indexing_slicing
+        -W clippy::panic
+        -W clippy::unreachable
+        -W clippy::todo
+    typos:
+      run: typos


### PR DESCRIPTION
## Summary
- Adds `lefthook.yml` with git hooks matching CI checks in `seismic.yml`:
  - **pre-commit**: `cargo +nightly fmt --all` (auto-formats code)
  - **pre-push**: strict clippy on seismic crates (same flags as CI), `typos` spell check

## Setup
After merging, each developer needs to run `lefthook install` once in their local clone.