### PR TITLE
fix: use snapshot-consistent state in ChangedAccountsHook

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -549,7 +549,7 @@ reth_transaction_pool::maintain::LocalTransactionBackupConfig::with_local_txs_ba
             );
 
             // spawn the maintenance task with USDC balance augmentation
-            let balance_hook = reth_seismic_txpool::SeismicBalanceHook::new(client.clone());
+            let balance_hook = reth_seismic_txpool::SeismicBalanceHook;
             ctx.task_executor().spawn_critical(
                 "txpool maintenance task",
                 reth_transaction_pool::maintain::maintain_transaction_pool_future_with_hook(

--- a/crates/seismic/txpool/src/maintain.rs
+++ b/crates/seismic/txpool/src/maintain.rs
@@ -2,40 +2,24 @@
 //! USDC predeploy balances.
 
 use reth_execution_types::ChangedAccount;
-use reth_provider::StateProviderFactory;
+use reth_provider::StateProvider;
 use reth_transaction_pool::maintain::ChangedAccountsHook;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// A [`ChangedAccountsHook`] that reads each sender's USDC predeploy balance
 /// and sets `balance = max(native, usdc_scaled)` so the pool can make accurate
 /// demotion decisions for accounts paying gas in USDC.
-#[derive(Debug)]
-pub struct SeismicBalanceHook<C> {
-    client: C,
-}
+///
+/// The hook uses the [`StateProvider`] passed by the maintenance loop rather
+/// than opening its own snapshot, so the USDC balance is always read from the
+/// same block as the native balance and nonce.
+#[derive(Debug, Default)]
+pub struct SeismicBalanceHook;
 
-impl<C> SeismicBalanceHook<C> {
-    /// Creates a new hook backed by the given state provider factory.
-    pub const fn new(client: C) -> Self {
-        Self { client }
-    }
-}
-
-impl<C> ChangedAccountsHook for SeismicBalanceHook<C>
-where
-    C: StateProviderFactory + Send + Sync + 'static,
-{
-    fn transform(&self, accounts: &mut Vec<ChangedAccount>) {
-        let state = match self.client.latest() {
-            Ok(s) => s,
-            Err(err) => {
-                warn!(target: "seismic::txpool", %err, "failed to get latest state for USDC balance augmentation");
-                return;
-            }
-        };
-
+impl ChangedAccountsHook for SeismicBalanceHook {
+    fn transform(&self, state: &dyn StateProvider, accounts: &mut Vec<ChangedAccount>) {
         for acc in accounts.iter_mut() {
-            let usdc = crate::usdc::read_usdc_balance(&*state, &acc.address);
+            let usdc = crate::usdc::read_usdc_balance(state, &acc.address);
             let new_balance = std::cmp::max(acc.balance, usdc);
             if new_balance != acc.balance {
                 debug!(

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -22,7 +22,9 @@ use reth_fs_util::FsPathError;
 use reth_primitives_traits::{
     transaction::signed::SignedTransaction, NodePrimitives, SealedHeader,
 };
-use reth_storage_api::{errors::provider::ProviderError, BlockReaderIdExt, StateProviderFactory};
+use reth_storage_api::{
+    errors::provider::ProviderError, BlockReaderIdExt, StateProvider, StateProviderFactory,
+};
 use reth_tasks::TaskSpawner;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -99,12 +101,16 @@ pub trait ChangedAccountsHook: Send + Sync + 'static {
     /// Transforms the changed accounts list in place.  Implementations may read
     /// additional state (e.g. ERC-20 storage) and adjust the `balance` field of
     /// each [`ChangedAccount`].
-    fn transform(&self, accounts: &mut Vec<ChangedAccount>);
+    ///
+    /// The [`StateProvider`] is the same snapshot the maintenance loop used to
+    /// load native balance/nonce, so implementations always see a consistent
+    /// view of the chain.
+    fn transform(&self, state: &dyn StateProvider, accounts: &mut Vec<ChangedAccount>);
 }
 
 /// No-op implementation for chains that don't need balance augmentation.
 impl ChangedAccountsHook for () {
-    fn transform(&self, _accounts: &mut Vec<ChangedAccount>) {}
+    fn transform(&self, _state: &dyn StateProvider, _accounts: &mut Vec<ChangedAccount>) {}
 }
 
 /// Returns a spawnable future for maintaining the state of the transaction pool.
@@ -355,7 +361,9 @@ pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
                 // reloaded accounts successfully
                 // extend accounts we failed to load from database
                 dirty_addresses.extend(failed_to_load);
-                hook.transform(&mut accounts);
+                if let Ok(state) = client.history_by_block_hash(pool_info.last_seen_block_hash) {
+                    hook.transform(&*state, &mut accounts);
+                }
                 // update the pool with the loaded accounts
                 pool.update_accounts(accounts);
             }
@@ -435,7 +443,9 @@ pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
                 // also include all accounts from new chain
                 // we can use extend here because they are unique
                 changed_accounts.extend(new_changed_accounts.into_iter().map(|entry| entry.0));
-                hook.transform(&mut changed_accounts);
+                if let Ok(state) = client.history_by_block_hash(new_tip.hash()) {
+                    hook.transform(&*state, &mut changed_accounts);
+                }
 
                 // all transactions mined in the new chain
                 let new_mined_transactions: HashSet<_> = new_blocks.transaction_hashes().collect();
@@ -540,7 +550,9 @@ pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
                     dirty_addresses.remove(&acc.address);
                     changed_accounts.push(acc);
                 }
-                hook.transform(&mut changed_accounts);
+                if let Ok(tip_state) = client.history_by_block_hash(tip.hash()) {
+                    hook.transform(&*tip_state, &mut changed_accounts);
+                }
 
                 let mined_transactions = blocks.transaction_hashes().collect();
 


### PR DESCRIPTION
## Summary

- **Bug:** `SeismicBalanceHook` was calling `self.client.latest()` to read USDC balances, while the maintenance loop loaded native balance/nonce from a historical block snapshot (`history_by_block_hash`). This caused mixed-state reconciliation where nonce and native balance came from block B but USDC balance came from the chain tip, which could be a different block.
- **Impact:** False promotions (tx appears fundable using future USDC) and false demotions (tx appears unfunded using stale USDC) during reorgs and dirty-account reloads.
- **Fix:** Pass the same `StateProvider` the maintenance loop already opened into the `ChangedAccountsHook::transform` method. The Seismic hook no longer owns a client or opens its own state — it reads USDC storage from the snapshot it receives.

### Changes

- `ChangedAccountsHook::transform` now takes `&dyn StateProvider` as its first argument
- All 3 call sites in `maintain_transaction_pool_with_hook` open the correct historical state and pass it through
- `SeismicBalanceHook` becomes a unit struct — no generic, no client field, no `latest()` call
- No-op `()` impl updated to match the new signature

## Test plan

- [x] `cargo check -p reth-transaction-pool -p reth-seismic-txpool -p reth-seismic-node` passes
- [ ] Existing txpool tests pass
- [ ] Manual verification: submit tx from USDC-funded account, trigger reorg, confirm pool state is consistent