### PR TITLE
refactor: deduplicate USDC constants

### DIFF
--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -55,6 +55,7 @@ seismic-enclave.workspace = true
 seismic-alloy-consensus.workspace = true
 seismic-alloy-network.workspace = true
 seismic-alloy-rpc-types = { workspace = true, features = ["serde", "k256"] }
+reth-seismic-txpool.workspace = true
 seismic-revm.workspace = true
 
 # async
@@ -87,7 +88,6 @@ reth-e2e-test-utils.workspace = true
 reth-engine-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-seismic-evm.workspace = true
-reth-seismic-txpool.workspace = true
 reth-rpc-engine-api.workspace = true
 alloy-rpc-types-engine.workspace = true
 

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -44,6 +44,7 @@ use reth_tasks::{
     TaskSpawner,
 };
 use seismic_alloy_network::SeismicReth;
+use reth_seismic_txpool::usdc::{usdc_balance_storage_key, USDC_CONTRACT, USDC_DECIMAL_SCALE};
 use seismic_revm::SeismicTransaction;
 use std::{fmt, marker::PhantomData, sync::Arc};
 
@@ -336,10 +337,6 @@ where
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        use reth_seismic_txpool::usdc::{
-            usdc_balance_storage_key, USDC_CONTRACT, USDC_DECIMAL_SCALE,
-        };
-
         let storage_key = usdc_balance_storage_key(&address);
 
         self.spawn_blocking_io_fut(move |this| async move {

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -336,29 +336,11 @@ where
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        use alloy_primitives::keccak256;
+        use reth_seismic_txpool::usdc::{
+            usdc_balance_storage_key, USDC_CONTRACT, USDC_DECIMAL_SCALE,
+        };
 
-        /// USDC predeploy address on Seismic.
-        const USDC_CONTRACT: Address =
-            alloy_primitives::address!("0x790701048922E265105fd6a4467a2901c2201C43");
-
-        /// Scale factor to convert USDC (6 decimals) to 18 decimals: 10^12.
-        const USDC_DECIMAL_SCALE: U256 = U256::from_limbs([1_000_000_000_000u64, 0, 0, 0]);
-
-        /// Storage slot of the `_balances` mapping in the USDC predeploy.
-        const BALANCES_SLOT: u8 = 3;
-
-        // Compute storage key: keccak256(abi.encode(address, uint256(BALANCES_SLOT))).
-        // The address is left-padded to 32 bytes; the slot occupies the last byte of the
-        // second word.
-        let mut buf = [0u8; 64];
-        #[allow(clippy::indexing_slicing)]
-        buf[12..32].copy_from_slice(address.as_slice());
-        #[allow(clippy::indexing_slicing)]
-        {
-            buf[63] = BALANCES_SLOT;
-        }
-        let storage_key = keccak256(buf);
+        let storage_key = usdc_balance_storage_key(&address);
 
         self.spawn_blocking_io_fut(move |this| async move {
             let state = this.state_at_block_id_or_latest(block_id).await?;

--- a/crates/seismic/txpool/src/usdc.rs
+++ b/crates/seismic/txpool/src/usdc.rs
@@ -22,7 +22,7 @@ const BALANCES_MAPPING_SLOT: U256 = U256::from_limbs([3, 0, 0, 0]);
 /// For a Solidity `mapping(address => uint256)` at slot `s`, the value for key
 /// `k` is stored at `keccak256(abi.encode(k, s))` — i.e. `k` left-padded to 32
 /// bytes concatenated with `s` as a 32-byte big-endian integer.
-fn usdc_balance_storage_key(address: &Address) -> B256 {
+pub fn usdc_balance_storage_key(address: &Address) -> B256 {
     let mut buf = [0u8; 64];
     // address is 20 bytes, right-aligned in the first 32-byte word
     buf[12..32].copy_from_slice(address.as_slice());


### PR DESCRIPTION
## Summary
- Removes duplicate `USDC_CONTRACT`, `USDC_DECIMAL_SCALE`, and balances storage key computation from the RPC `balance()` method
- Imports them from `reth_seismic_txpool::usdc` instead (single source of truth)
- Makes `usdc_balance_storage_key` public so it can be reused

## Test plan
- [x] `cargo check -p reth-seismic-rpc` passes
- Existing tests in `usdc.rs` cover storage key correctness