### PR TITLE
fix(rpc): surface StorageOverrideNotPermitted from seismic-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e644240d0aa5cc1ddc29ed74454e5f127ac98266#e644240d0aa5cc1ddc29ed74454e5f127ac98266"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=0a751067fa55afc762e64c919c4443eea72546ca#0a751067fa55afc762e64c919c4443eea72546ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e644240d0aa5cc1ddc29ed74454e5f127ac98266#e644240d0aa5cc1ddc29ed74454e5f127ac98266"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=0a751067fa55afc762e64c919c4443eea72546ca#0a751067fa55afc762e64c919c4443eea72546ca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=c33f3076495d153eefbde07dd81c3a575f3d19b8#c33f3076495d153eefbde07dd81c3a575f3d19b8"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e644240d0aa5cc1ddc29ed74454e5f127ac98266#e644240d0aa5cc1ddc29ed74454e5f127ac98266"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=c33f3076495d153eefbde07dd81c3a575f3d19b8#c33f3076495d153eefbde07dd81c3a575f3d19b8"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e644240d0aa5cc1ddc29ed74454e5f127ac98266#e644240d0aa5cc1ddc29ed74454e5f127ac98266"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,5 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c1ce53389ad2bf9bd04c15f4924abe77677395b6" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "c33f3076495d153eefbde07dd81c3a575f3d19b8" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "c33f3076495d153eefbde07dd81c3a575f3d19b8" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e644240d0aa5cc1ddc29ed74454e5f127ac98266" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e644240d0aa5cc1ddc29ed74454e5f127ac98266" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,5 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c1ce53389ad2bf9bd04c15f4924abe77677395b6" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e644240d0aa5cc1ddc29ed74454e5f127ac98266" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e644240d0aa5cc1ddc29ed74454e5f127ac98266" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "0a751067fa55afc762e64c919c4443eea72546ca" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "0a751067fa55afc762e64c919c4443eea72546ca" }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -118,6 +118,9 @@ pub enum EthApiError {
     /// Code overrides are not permitted (Seismic privacy)
     #[error("code overrides are not permitted on Seismic (account: {0:?})")]
     CodeOverrideNotPermitted(Address),
+    /// Storage overrides are not permitted (Seismic privacy)
+    #[error("storage overrides are not permitted on Seismic (account: {0:?})")]
+    StorageOverrideNotPermitted(Address),
     /// Other internal error
     #[error(transparent)]
     Internal(RethError),
@@ -258,6 +261,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::Signing(_) |
             EthApiError::BothStateAndStateDiffInOverride(_) |
             EthApiError::CodeOverrideNotPermitted(_) |
+            EthApiError::StorageOverrideNotPermitted(_) |
             EthApiError::InvalidTracerConfig |
             EthApiError::TransactionConversionError |
             EthApiError::InvalidRewardPercentiles |
@@ -355,6 +359,9 @@ where
             }
             StateOverrideError::CodeOverrideNotPermitted(address) => {
                 Self::CodeOverrideNotPermitted(address)
+            }
+            StateOverrideError::StorageOverrideNotPermitted(address) => {
+                Self::StorageOverrideNotPermitted(address)
             }
             StateOverrideError::Database(err) => err.into(),
         }

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1390,3 +1390,149 @@ async fn test_usdc_only_susdc_transfer_e2e() -> eyre::Result<()> {
     assert!(receipt.status());
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_call_rejects_storage_override() -> eyre::Result<()> {
+    let (_node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let victim_addr = Address::from_hex("0x0000000000000000000000000000000000001234").unwrap();
+
+    let storage: alloy_primitives::map::B256HashMap<B256> =
+        [(B256::ZERO, B256::from(U256::from(1)))].into_iter().collect();
+
+    let mut state_overrides = StateOverride::default();
+    state_overrides
+        .insert(victim_addr, AccountOverride { state_diff: Some(storage), ..Default::default() });
+
+    let result = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(wallet.inner.address()),
+                to: Some(TxKind::Call(victim_addr)),
+                gas: Some(1_000_000),
+                chain_id: Some(chain_id),
+                ..Default::default()
+            },
+            seismic_elements: None,
+        }
+        .into(),
+        None,
+        Some(state_overrides),
+        None,
+    )
+    .await;
+
+    match &result {
+        Ok(output) => panic!(
+            "eth_call with storage override should be rejected, but got Ok: 0x{}",
+            hex::encode(output)
+        ),
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.to_lowercase().contains("storage overrides are not permitted"),
+                "Expected storage override rejection error, got: {}",
+                err_msg
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_estimate_gas_rejects_storage_override() -> eyre::Result<()> {
+    let (_node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let victim_addr = Address::from_hex("0x0000000000000000000000000000000000001234").unwrap();
+
+    let storage: alloy_primitives::map::B256HashMap<B256> =
+        [(B256::ZERO, B256::from(U256::from(1)))].into_iter().collect();
+
+    let mut state_overrides = StateOverride::default();
+    state_overrides
+        .insert(victim_addr, AccountOverride { state_diff: Some(storage), ..Default::default() });
+
+    let result = EthApiOverrideClient::<Block>::estimate_gas(
+        &client,
+        SeismicCallRequest::TransactionRequest(SeismicTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(wallet.inner.address()),
+                to: Some(TxKind::Call(victim_addr)),
+                gas: Some(1_000_000),
+                chain_id: Some(chain_id),
+                ..Default::default()
+            },
+            seismic_elements: None,
+        }),
+        None,
+        Some(state_overrides),
+    )
+    .await;
+
+    match &result {
+        Ok(gas) => {
+            panic!("eth_estimateGas with storage override should be rejected, but got Ok: {}", gas)
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.to_lowercase().contains("storage overrides are not permitted"),
+                "Expected storage override rejection error, got: {}",
+                err_msg
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_simulate_v1_rejects_storage_override() -> eyre::Result<()> {
+    let (_node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let victim_addr = Address::from_hex("0x0000000000000000000000000000000000001234").unwrap();
+
+    let storage: alloy_primitives::map::B256HashMap<B256> =
+        [(B256::ZERO, B256::from(U256::from(1)))].into_iter().collect();
+
+    let mut state_overrides = StateOverride::default();
+    state_overrides
+        .insert(victim_addr, AccountOverride { state_diff: Some(storage), ..Default::default() });
+
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let tx_bytes = get_signed_deploy_tx_bytes(
+        wallet.inner.clone(),
+        nonce,
+        chain_id,
+        ContractTestContext::get_deploy_input_plaintext(),
+    )
+    .await;
+
+    let block_with_storage_override = SimBlock {
+        block_overrides: None,
+        state_overrides: Some(state_overrides),
+        calls: vec![SeismicCallRequest::Bytes(tx_bytes)],
+    };
+
+    let simulate_payload = SimulatePayload::<SeismicCallRequest> {
+        block_state_calls: vec![block_with_storage_override],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: false,
+    };
+
+    let result = EthApiOverrideClient::<Block>::simulate_v1(&client, simulate_payload, None).await;
+
+    match &result {
+        Ok(_) => panic!("eth_simulateV1 with storage override should be rejected"),
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.to_lowercase().contains("storage overrides are not permitted"),
+                "Expected storage override rejection error, got: {}",
+                err_msg
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Companion to [seismic-evm#52](https://github.com/SeismicSystems/seismic-evm/pull/52), which rejects `state` / `stateDiff` overrides at the `apply_account_override` chokepoint to close an audit finding where signed reads could be evaluated against attacker-controlled storage.

- Adds `EthApiError::StorageOverrideNotPermitted(Address)` next to the existing `CodeOverrideNotPermitted` variant.
- Includes it in the `invalid_params_rpc_err` arm so it surfaces as `-32602` (matching the code-override behavior).
- Maps the underlying `StateOverrideError::StorageOverrideNotPermitted` through `From<StateOverrideError> for EthApiError`.
- Bumps `alloy-evm` / `alloy-seismic-evm` to the seismic-evm branch tip (`e644240`) so the new variant resolves.

## Merge order

**Do not merge this PR until:**
1. [seismic-evm#52](https://github.com/SeismicSystems/seismic-evm/pull/52) is merged to `seismic`.
2. The `alloy-evm` / `alloy-seismic-evm` rev in `Cargo.toml` (lines 794-795) is re-bumped to the **post-merge commit on `seismic`** — the current pin points at the branch commit, which will differ from the merge commit (squash / merge / rebase).

## Test plan

- [ ] After dep re-bump: `cargo check -p reth-rpc-eth-types` builds clean for the error module changes. (Note: the base `veridise-audit-april-2026` has pre-existing `Url: serde` errors unrelated to this PR — verified by building the baseline without these changes.)
- [ ] Signed `eth_call` with a `stateDiff` override returns `-32602 invalid params` with the storage-override message.