### PR TITLE
fix: disable debug_executionWitness and debug_executionWitnessByBlockHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9439,6 +9439,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-signer-local",

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -45,7 +45,8 @@ use reth_seismic_payload_builder::SeismicBuilderConfig;
 use reth_seismic_primitives::{SeismicPrimitives, SeismicReceipt, SeismicTransactionSigned};
 use reth_seismic_rpc::{
     ext::{EthApiExt, EthApiOverrideServer, SeismicApi, SeismicApiServer},
-    SeismicEthApiBuilder, SeismicEthApiError, SeismicRethWithSignable,
+    DebugWitnessDisabled, DebugWitnessOverrideServer, SeismicEthApiBuilder, SeismicEthApiError,
+    SeismicRethWithSignable,
 };
 use reth_transaction_pool::{
     blobstore::{DiskFileBlobStore, DiskFileBlobStoreConfig},
@@ -370,6 +371,11 @@ where
 
                 // Register seismic_ namespace (getTeePublicKey)
                 modules.merge_configured(SeismicApi::new(purpose_keys).into_rpc())?;
+
+                // Disable `debug_executionWitness*` — the witness exposes preimages of
+                // every storage trie leaf the block touched, including shielded slot
+                // values, and cannot be redacted without breaking witness verifiability.
+                modules.merge_configured(DebugWitnessDisabled.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -375,7 +375,9 @@ where
                 // Disable `debug_executionWitness*` — the witness exposes preimages of
                 // every storage trie leaf the block touched, including shielded slot
                 // values, and cannot be redacted without breaking witness verifiability.
-                modules.merge_configured(DebugWitnessDisabled.into_rpc())?;
+                // Use `replace_configured` because the upstream debug namespace already
+                // registers these method names.
+                modules.replace_configured(DebugWitnessDisabled.into_rpc())?;
 
                 Ok(())
             })

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
+alloy-rpc-types-debug.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 alloy-json-rpc.workspace = true

--- a/crates/seismic/rpc/src/debug.rs
+++ b/crates/seismic/rpc/src/debug.rs
@@ -1,0 +1,87 @@
+//! Seismic overrides for the `debug_` RPC namespace.
+//!
+//! `debug_executionWitness` and `debug_executionWitnessByBlockHash` return the preimages
+//! of every storage trie leaf the block touched, including shielded slot values, and
+//! cannot be redacted without breaking witness verifiability. Both methods are disabled
+//! on seismic.
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_rpc_types_debug::ExecutionWitness;
+use jsonrpsee::{
+    core::{async_trait, RpcResult},
+    proc_macros::rpc,
+    types::{error::ErrorObject, ErrorObjectOwned},
+};
+
+/// Seismic override of the `debug_` RPC namespace.
+///
+/// Only includes the methods seismic needs to override; merging into the module container
+/// replaces just these handlers and leaves the rest of `debug_*` intact.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "debug"))]
+pub trait DebugWitnessOverride {
+    /// Disabled — see module docs.
+    #[method(name = "executionWitness")]
+    async fn debug_execution_witness(&self, block: BlockNumberOrTag)
+        -> RpcResult<ExecutionWitness>;
+
+    /// Disabled — see module docs.
+    #[method(name = "executionWitnessByBlockHash")]
+    async fn debug_execution_witness_by_block_hash(
+        &self,
+        hash: B256,
+    ) -> RpcResult<ExecutionWitness>;
+}
+
+/// Implementation that rejects every call with a fixed error.
+#[derive(Debug, Clone, Copy)]
+pub struct DebugWitnessDisabled;
+
+#[async_trait]
+impl DebugWitnessOverrideServer for DebugWitnessDisabled {
+    async fn debug_execution_witness(
+        &self,
+        _block: BlockNumberOrTag,
+    ) -> RpcResult<ExecutionWitness> {
+        Err(witness_disabled_error())
+    }
+
+    async fn debug_execution_witness_by_block_hash(
+        &self,
+        _hash: B256,
+    ) -> RpcResult<ExecutionWitness> {
+        Err(witness_disabled_error())
+    }
+}
+
+fn witness_disabled_error() -> ErrorObjectOwned {
+    ErrorObject::owned(-32000, "debug_executionWitness is disabled", None::<String>)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn execution_witness_returns_disabled_error() {
+        let api = DebugWitnessDisabled;
+        let err = api
+            .debug_execution_witness(BlockNumberOrTag::Latest)
+            .await
+            .expect_err("expected disabled error");
+        assert_eq!(err.code(), -32000);
+        assert_eq!(err.message(), "debug_executionWitness is disabled");
+    }
+
+    #[tokio::test]
+    async fn execution_witness_by_hash_returns_disabled_error() {
+        let api = DebugWitnessDisabled;
+        let err = api
+            .debug_execution_witness_by_block_hash(B256::ZERO)
+            .await
+            .expect_err("expected disabled error");
+        assert_eq!(err.code(), -32000);
+        assert_eq!(err.message(), "debug_executionWitness is disabled");
+    }
+}

--- a/crates/seismic/rpc/src/lib.rs
+++ b/crates/seismic/rpc/src/lib.rs
@@ -11,5 +11,8 @@
 mod eth;
 pub use eth::*;
 
+mod debug;
+pub use debug::*;
+
 mod error;
 pub use error::*;


### PR DESCRIPTION
These two endpoints can leak private data by exposing trie witness material for executed paths.