### PR TITLE
fix: reject sentinel transactions from eth_sendRawTransactionSync

### DIFF
--- a/crates/seismic/node/tests/e2e/ops.rs
+++ b/crates/seismic/node/tests/e2e/ops.rs
@@ -814,3 +814,59 @@ async fn test_ops_sentinel_does_not_burn_nonce_on_action_validation_failure() {
         "successful retry must advance admin_nonce exactly once",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ops_sentinel_rejected_by_send_raw_transaction_sync() {
+    // eth_sendRawTransactionSync waits for on-chain inclusion. Sentinel txs are
+    // intercepted at the RPC layer and never enter the pool or a block, so the
+    // sync endpoint must reject them immediately rather than time out at 30s
+    // (the upstream default).
+    reth_tracing::init_test_tracing();
+    let governance = PrivateKeySigner::random();
+    let reader = PrivateKeySigner::random();
+
+    let (node, _tasks, _wallet) = launch_ops_node(&governance).await.unwrap();
+    let client = HttpClientBuilder::default().build(&node.rpc_url().to_string()).unwrap();
+    let ops_client = build_ops_client(&node_ops_url!(node));
+    let chain_id = 5124u64;
+
+    // Build a perfectly valid sentinel envelope — only the endpoint is wrong.
+    let live = fetch_live_envelope_fields(&client, &ops_client).await;
+    let env = Envelope {
+        recent_block_hash: live.recent_block_hash,
+        expires_at_block: live.expires_at_block,
+        validator_id: live.validator_id,
+        nonce: live.next_nonce,
+    };
+    let raw_tx = build_sentinel_tx(
+        &governance,
+        chain_id,
+        whitelist_calldata(reader.address(), current_unix_timestamp() + 3600, env),
+    );
+
+    // Time the round-trip so we can prove it's the early-reject path, not a 30s timeout.
+    let started = std::time::Instant::now();
+    let hex = format!("0x{}", alloy_primitives::hex::encode(&raw_tx));
+    let result = client
+        .request::<serde_json::Value, _>("eth_sendRawTransactionSync", rpc_params![hex])
+        .await;
+    let elapsed = started.elapsed();
+
+    let err = result.expect_err("sentinel tx via sendRawTransactionSync must be rejected");
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("not supported via eth_sendRawTransactionSync"),
+        "expected explicit rejection message, got: {err_str}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "rejection must be immediate; the upstream timeout is 30s. elapsed: {elapsed:?}"
+    );
+
+    // The whitelist mutation must NOT have applied — admin_nonce stays at 0.
+    assert_eq!(
+        ops_get_admin_nonce(&ops_client).await,
+        0,
+        "rejected sentinel must not advance admin_nonce",
+    );
+}

--- a/crates/seismic/rpc/src/eth/transaction.rs
+++ b/crates/seismic/rpc/src/eth/transaction.rs
@@ -6,6 +6,7 @@ use alloy_primitives::{Address, Bytes, Signature, B256};
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
 use alloy_sol_types::SolCall;
 use reth_primitives_traits::SignedTransaction;
+use reth_provider::BlockNumReader;
 use reth_rpc_convert::transaction::{RpcTxConverter, SimTxConverter};
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},

--- a/crates/seismic/rpc/src/eth/transaction.rs
+++ b/crates/seismic/rpc/src/eth/transaction.rs
@@ -5,14 +5,19 @@ use alloy_consensus::{transaction::Recovered, Transaction as _};
 use alloy_primitives::{Address, Bytes, Signature, B256};
 use alloy_rpc_types_eth::{Transaction, TransactionInfo};
 use alloy_sol_types::SolCall;
+use futures::StreamExt;
+use reth_node_api::BlockBody;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::BlockNumReader;
+use reth_provider::CanonStateSubscriptions;
 use reth_rpc_convert::transaction::{RpcTxConverter, SimTxConverter};
 use reth_rpc_eth_api::{
-    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
-    FromEthApiError, RpcConvert, RpcNodeCore,
+    helpers::{spec::SignersForRpc, EthTransactions, LoadReceipt, LoadTransaction},
+    FromEthApiError, RpcConvert, RpcNodeCore, RpcReceipt,
 };
-use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
+use reth_rpc_eth_types::{
+    utils::recover_raw_transaction, EthApiError, EthApiError::TransactionConfirmationTimeout,
+};
 use reth_rpc_layer::{
     OpsWhitelistTxAuth, Whitelist, OPS_AUTH_CONTRACT, OPS_AUTH_SLOT, WHITELIST_TX_SENTINEL,
 };
@@ -163,6 +168,66 @@ where
             .map_err(Self::Error::from_eth_err)?;
 
         Ok(hash)
+    }
+
+    /// Sentinel txs targeting [`WHITELIST_TX_SENTINEL`] are intercepted at the
+    /// RPC layer and never enter the pool or a block, so the default impl's
+    /// "wait for on-chain inclusion" loop would time out at 30s while the
+    /// whitelist mutation has already applied. Reject those up front; for all
+    /// other txs run the upstream submit-and-wait flow.
+    ///
+    /// The non-sentinel branch mirrors the default impl at
+    /// `reth_rpc_eth_api::helpers::EthTransactions::send_raw_transaction_sync`,
+    /// inlined here because Rust does not allow calling a trait's default
+    /// method from an override. Keep in sync with upstream if the receipt-
+    /// waiting strategy changes there.
+    async fn send_raw_transaction_sync(
+        &self,
+        tx: Bytes,
+    ) -> Result<RpcReceipt<Self::NetworkTypes>, Self::Error>
+    where
+        Self: LoadReceipt + 'static,
+    {
+        let recovered: Recovered<
+            <<Self::Pool as TransactionPool>::Transaction as PoolTransaction>::Pooled,
+        > = recover_raw_transaction(&tx)?;
+        if recovered.to() == Some(WHITELIST_TX_SENTINEL) {
+            return Err(Self::Error::from_eth_err(EthApiError::Other(Box::new(
+                jsonrpsee_types::ErrorObject::owned(
+                    -32000,
+                    "ops sentinel transactions are not supported via eth_sendRawTransactionSync; \
+                     use eth_sendRawTransaction",
+                    None::<()>,
+                ),
+            ))));
+        }
+
+        let hash = EthTransactions::send_raw_transaction(self, tx).await?;
+        let mut stream = self.provider().canonical_state_stream();
+        const TIMEOUT_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+        tokio::time::timeout(TIMEOUT_DURATION, async {
+            while let Some(notification) = stream.next().await {
+                let chain = notification.committed();
+                for block in chain.blocks_iter() {
+                    if block.body().contains_transaction(&hash) {
+                        if let Some(receipt) = self.transaction_receipt(hash).await? {
+                            return Ok(receipt);
+                        }
+                    }
+                }
+            }
+            Err(Self::Error::from_eth_err(TransactionConfirmationTimeout {
+                hash,
+                duration: TIMEOUT_DURATION,
+            }))
+        })
+        .await
+        .unwrap_or_else(|_elapsed| {
+            Err(Self::Error::from_eth_err(TransactionConfirmationTimeout {
+                hash,
+                duration: TIMEOUT_DURATION,
+            }))
+        })
     }
 }
 


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/seismic-reth/pull/392.

Sentinel transactions never end up in the pool or in a block, so the subscriber would wait forever.

Changes:
- `eth_sendRawTransactionSync` will reject sentinel transactions
- the `send_raw_transaction_sync` deserializes (recovers) transactions and returns early if the transaction is a sentinel transaction. This means that a normal transaction will be deserialized twice. Avoiding the double deserialization would have meant more invasive changes.