### PR TITLE
fix(zstd): use transaction dictionary for tx compressor

### DIFF
--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -60,7 +60,8 @@ mod locals {
 
 /// Fn creates tx [`Compressor`]
 pub fn create_tx_compressor() -> Compressor<'static> {
-    Compressor::with_dictionary(0, RECEIPT_DICTIONARY).expect("Failed to instantiate tx compressor")
+    Compressor::with_dictionary(0, TRANSACTION_DICTIONARY)
+        .expect("Failed to instantiate tx compressor")
 }
 
 /// Fn creates tx [`Decompressor`]
@@ -151,5 +152,36 @@ impl ReusableDecompressor {
                 existing = self.buf.capacity(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tx_roundtrip_compression() {
+        let data: Vec<u8> = (0u8..=255).collect();
+
+        let mut compressor = create_tx_compressor();
+        let compressed = compressor.compress(&data).expect("compress tx");
+
+        let mut decompressor = create_tx_decompressor();
+        let decompressed = decompressor.decompress(&compressed);
+
+        assert_eq!(decompressed, &*data);
+    }
+
+    #[test]
+    fn receipt_roundtrip_compression() {
+        let data: Vec<u8> = (0u8..=255).rev().collect();
+
+        let mut compressor = create_receipt_compressor();
+        let compressed = compressor.compress(&data).expect("compress receipt");
+
+        let mut decompressor = create_receipt_decompressor();
+        let decompressed = decompressor.decompress(&compressed);
+
+        assert_eq!(decompressed, &*data);
     }
 }


### PR DESCRIPTION
## Summary

`create_tx_compressor()` in `reth-zstd-compressors` instantiates with `RECEIPT_DICTIONARY`, while its partner `create_tx_decompressor()` uses `TRANSACTION_DICTIONARY`. So that compressor/decompressor pair is configured with **mismatched dictionaries** and compressed tx bytes from that path cannot round-trip through `from_compact()`.

```diff
 pub fn create_tx_compressor() -> Compressor<'static> {
-    Compressor::with_dictionary(0, RECEIPT_DICTIONARY).expect("Failed to instantiate tx compressor")
+    Compressor::with_dictionary(0, TRANSACTION_DICTIONARY)
+        .expect("Failed to instantiate tx compressor")
 }
```

## Impact (latent today)

`SeismicTransactionSigned::to_compact()` uses the `std` thread-local `TRANSACTION_COMPRESSOR` (correct dictionary) and only falls back to `create_tx_compressor()` in the non-`std` branch. The `Compact` impl is gated behind `reth-codec`, and `reth-codec` enables `std`, so the buggy branch is currently unreachable — a latent correctness hazard rather than an active failure. Any future feature-graph change that makes the non-`std` compact path reachable would break compact tx round-tripping (the decompressor sees bytes produced with the wrong dictionary). The bug affects the shared crate, so ethereum/optimism/seismic primitives all call into it.

## Fix

Use `TRANSACTION_DICTIONARY` in `create_tx_compressor()` so the tx compressor and decompressor are symmetric on all feature combinations, and add round-trip tests for both the tx and receipt compressors.

## Provenance

This is upstream reth code, inherited via the squashed upstream merge. Upstream already fixed it in **paradigmxyz/reth#21382** ("fix(zstd): use transaction dictionary for tx compressor"); the fork's last upstream sync predates that fix. This PR mirrors #21382 exactly (same one-line dictionary change + the same two round-trip tests), to stay aligned and minimize future merge friction.

## Testing

Added `tx_roundtrip_compression` and `receipt_roundtrip_compression` (compress with the `create_*_compressor`, decompress with the matching `create_*_decompressor`, assert equality). Verified red→green: with the dictionary reverted, `tx_roundtrip_compression` fails with `Dictionary mismatch`; with the fix both pass. `cargo +nightly fmt --check` and clippy (`-D warnings --all-features`) clean.