### PR TITLE
fix(seismic): harden three audit-flagged corner cases

### DIFF
--- a/crates/seismic/primitives/src/receipt.rs
+++ b/crates/seismic/primitives/src/receipt.rs
@@ -2,7 +2,10 @@ use alloy_consensus::{
     proofs::ordered_trie_root_with_encoder, Eip2718EncodableReceipt, Eip658Value, Receipt,
     ReceiptWithBloom, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt, Typed2718,
 };
-use alloy_eips::{eip2718::Eip2718Result, Decodable2718, Encodable2718};
+use alloy_eips::{
+    eip2718::{Eip2718Error, Eip2718Result},
+    Decodable2718, Encodable2718,
+};
 use alloy_primitives::{Bloom, Log, B256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use reth_primitives_traits::InMemorySize;
@@ -317,7 +320,12 @@ impl Encodable2718 for SeismicReceipt {
 
 impl Decodable2718 for SeismicReceipt {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        Ok(Self::rlp_decode_inner_without_bloom(buf, SeismicTxType::try_from(ty)?)?)
+        // Legacy receipts must be decoded via `fallback_decode`, not as a typed envelope.
+        let tx_type = SeismicTxType::try_from(ty)?;
+        if tx_type == SeismicTxType::Legacy {
+            return Err(Eip2718Error::UnexpectedType(0));
+        }
+        Ok(Self::rlp_decode_inner_without_bloom(buf, tx_type)?)
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
@@ -705,5 +713,12 @@ mod tests {
         let decoded: ReceiptWithBloom<SeismicReceipt> =
             ReceiptWithBloom::decode(&mut &data[..]).unwrap();
         assert_eq!(receipt, decoded);
+    }
+
+    #[test]
+    fn typed_decode_rejects_legacy() {
+        // ty == 0 (legacy) must go through `fallback_decode`, not `typed_decode`.
+        let err = SeismicReceipt::typed_decode(0, &mut [].as_slice()).unwrap_err();
+        assert!(matches!(err, Eip2718Error::UnexpectedType(0)));
     }
 }

--- a/crates/seismic/rpc/src/eth/receipt.rs
+++ b/crates/seismic/rpc/src/eth/receipt.rs
@@ -1,8 +1,10 @@
 //! Loads and formats Seismic receipt RPC response.
 
+use alloy_consensus::Typed2718;
 use reth_rpc_convert::transaction::{ConvertReceiptInput, ReceiptConverter};
 use reth_rpc_eth_api::{helpers::LoadReceipt, RpcConvert, RpcNodeCore};
 use reth_rpc_eth_types::{receipt::build_receipt, EthApiError};
+use reth_rpc_server_types::result::internal_rpc_err;
 use reth_seismic_primitives::{SeismicPrimitives, SeismicReceipt};
 use seismic_alloy_consensus::SeismicReceiptEnvelope;
 use seismic_alloy_rpc_types::SeismicTransactionReceipt;
@@ -29,6 +31,15 @@ pub struct SeismicReceiptBuilder {
 impl SeismicReceiptBuilder {
     /// Returns a new builder.
     pub fn new(input: ConvertReceiptInput<'_, SeismicPrimitives>) -> Result<Self, EthApiError> {
+        // The receipt and its transaction must agree on the transaction type.
+        let receipt_ty = input.receipt.tx_type() as u8;
+        let tx_ty = input.tx.ty();
+        if receipt_ty != tx_ty {
+            return Err(EthApiError::other(internal_rpc_err(format!(
+                "receipt type {receipt_ty} does not match transaction type {tx_ty}"
+            ))));
+        }
+
         let base = build_receipt(&input, None, |receipt_with_bloom| match input.receipt.as_ref() {
             SeismicReceipt::Legacy(_) => SeismicReceiptEnvelope::Legacy(receipt_with_bloom),
             SeismicReceipt::Eip2930(_) => SeismicReceiptEnvelope::Eip2930(receipt_with_bloom),
@@ -81,5 +92,36 @@ impl ReceiptConverter<SeismicPrimitives> for SeismicReceiptConverter {
                     .map(|builder| builder.build())
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{
+        transaction::{Recovered, TransactionMeta},
+        Eip658Value, Receipt,
+    };
+    use alloy_primitives::{Address, B256};
+    use reth_seismic_primitives::test_utils::get_signed_seismic_tx;
+    use std::borrow::Cow;
+
+    #[test]
+    fn new_rejects_mismatched_receipt_and_tx_types() {
+        // Seismic-typed transaction paired with a legacy-typed receipt.
+        let tx = get_signed_seismic_tx(B256::ZERO);
+        let receipt = SeismicReceipt::Legacy(Receipt {
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+            logs: Vec::new(),
+        });
+        let input = ConvertReceiptInput {
+            receipt: Cow::Owned(receipt),
+            tx: Recovered::new_unchecked(&tx, Address::ZERO),
+            gas_used: 0,
+            next_log_index: 0,
+            meta: TransactionMeta::default(),
+        };
+        assert!(SeismicReceiptBuilder::new(input).is_err());
     }
 }

--- a/crates/seismic/txpool/src/recent_block_cache.rs
+++ b/crates/seismic/txpool/src/recent_block_cache.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::B256;
 use std::collections::{HashSet, VecDeque};
+use tracing::warn;
 
 /// Maximum number of blocks to look back for `recent_block_hash` validation.
 pub const SEISMIC_TX_RECENT_BLOCK_LOOKBACK: u64 = 100;
@@ -41,7 +42,20 @@ impl RecentBlockCache {
     }
 
     /// Inserts a block hash into the cache, evicting the oldest entry if at capacity.
+    ///
+    /// Block numbers must be strictly increasing (the `ordered` deque relies on it for FIFO
+    /// eviction); a non-monotonic insert is rejected rather than corrupting the ordering.
     pub fn insert(&mut self, hash: B256, block_number: u64) {
+        if !self.is_empty() && block_number <= self.current_block_number {
+            warn!(
+                target: "seismic::txpool",
+                block_number,
+                current = self.current_block_number,
+                "ignoring out-of-order recent block cache insert",
+            );
+            return;
+        }
+
         self.current_block_number = block_number;
         self.ordered.push_back(hash);
         self.hashes.insert(hash);
@@ -170,6 +184,27 @@ mod tests {
         assert!(cache.contains(&h2));
         assert!(!cache.contains(&B256::from([3u8; 32])));
         assert_eq!(cache.current_block_number(), 2);
+    }
+
+    #[test]
+    fn test_insert_rejects_non_monotonic() {
+        let mut cache = RecentBlockCache::new(3);
+        let h2 = B256::from([2u8; 32]);
+        cache.insert(h2, 2);
+
+        // An out-of-order insert (<= current) is ignored and leaves the cache untouched.
+        let stale = B256::from([9u8; 32]);
+        cache.insert(stale, 1);
+        cache.insert(B256::from([8u8; 32]), 2);
+
+        assert!(!cache.contains(&stale));
+        assert_eq!(cache.current_block_number(), 2);
+
+        // A strictly-increasing insert is still accepted.
+        let h3 = B256::from([3u8; 32]);
+        cache.insert(h3, 3);
+        assert!(cache.contains(&h3));
+        assert_eq!(cache.current_block_number(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Addresses the three defensive-hardening items from the audit finding. Each is an independent, low-risk strengthening against future corner cases; one commit per item.

## 1. `RecentBlockCache::insert` — enforce monotonic block numbers
`insert` relied on strictly increasing block numbers (the `ordered` deque uses front = oldest / back = newest for FIFO eviction) but never enforced it. A non-monotonic insert would set `current_block_number` backwards and break eviction ordering. It now rejects (and warns on) an out-of-order insert instead of corrupting the deque. `update` already only calls `insert` ascending, so this is unreachable today — it guards against future misuse. (Chose a runtime guard over `debug_assert!` so it's enforced in all builds, and over a `Result` cascade since the error can never actually occur with correct callers.)

## 2. `SeismicReceiptBuilder::new` — verify receipt and tx types agree
`new` picked the receipt envelope from `input.receipt` but never checked `input.tx` was the same type. It now compares `input.receipt.tx_type()` against `input.tx.ty()` and returns an error on mismatch instead of silently building a receipt whose type disagrees with its transaction. `new` already returns `Result`, so this is a natural use of the existing error path.

## 3. `SeismicReceipt::typed_decode` — reject legacy (ty == 0)
`typed_decode(0, …)` decoded a legacy receipt, but per EIP-2718 legacy must go through `fallback_decode`. It now returns `Eip2718Error::UnexpectedType(0)` for ty == 0, matching the signed-transaction `typed_decode` already in this repo and upstream behavior.

## Testing
- `test_insert_rejects_non_monotonic` — an out-of-order insert is ignored and leaves the cache untouched; a strictly-increasing insert is still accepted.
- `typed_decode_rejects_legacy` — `typed_decode(0, …)` returns `UnexpectedType(0)`.
- `new_rejects_mismatched_receipt_and_tx_types` — a Seismic-typed tx paired with a legacy-typed receipt makes `SeismicReceiptBuilder::new` return an error.

clippy (`-D warnings` + the seismic lint set, `--all-features`) and `cargo +nightly fmt --check` are clean for all three crates.