### PR TITLE
fix(seismic-node): enforce enclave_timeout when fetching purpose keys on boot

### DIFF
--- a/crates/seismic/node/src/enclave.rs
+++ b/crates/seismic/node/src/enclave.rs
@@ -1,12 +1,21 @@
 //! Tools to communicate with the seismic-enclave-server's RPC
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
-use jsonrpsee_http_client::HttpClientBuilder;
+use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
 use reth_node_core::args::EnclaveArgs;
 use seismic_enclave::{
     api::TdxQuoteRpcClient as _, mock::start_mock_server, GetPurposeKeysResponse,
 };
 use tracing::{info, warn};
+
+/// Builds the enclave JSON-RPC client, binding each request to the configured `enclave_timeout`.
+#[allow(clippy::expect_used)] // Intentional panic on startup failure - enclave is required
+fn build_enclave_client(config: &EnclaveArgs) -> HttpClient {
+    HttpClientBuilder::default()
+        .request_timeout(Duration::from_secs(config.enclave_timeout))
+        .build(format!("http://{}:{}", config.enclave_server_addr, config.enclave_server_port))
+        .expect("Failed to build enclave client")
+}
 
 /// Boot the enclave (or mock server) and fetch purpose keys.
 /// This must be called before building the node components.
@@ -31,9 +40,7 @@ where
         // Give the mock server time to start
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
-    let enclave_client = HttpClientBuilder::default()
-        .build(format!("http://{}:{}", config.enclave_server_addr, config.enclave_server_port))
-        .expect("Failed to build enclave client");
+    let enclave_client = build_enclave_client(config);
 
     // Fetch purpose keys from enclave - this must succeed or we panic
     info!(target: "reth::cli", "Fetching purpose keys from enclave");
@@ -53,4 +60,45 @@ where
         }
     }
     panic!("FATAL: Failed to fetch purpose keys from enclave on boot after {} failures", failures);
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)] // Test code - expect on failure is acceptable
+
+    use super::*;
+    use std::time::Instant;
+    use tokio::net::TcpListener;
+
+    /// A stalled enclave endpoint (accepts connections but never replies) must make the fetch
+    /// error within the configured `enclave_timeout`, not hang on the underlying client default.
+    #[tokio::test]
+    async fn enclave_timeout_bounds_a_stalled_fetch() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream); // keep the connection open without ever responding
+            }
+        });
+
+        let config = EnclaveArgs {
+            enclave_server_addr: addr.ip(),
+            enclave_server_port: addr.port(),
+            enclave_timeout: 1,
+            ..Default::default()
+        };
+        let client = build_enclave_client(&config);
+
+        let started = Instant::now();
+        let result = client.get_purpose_keys(0).await;
+
+        assert!(result.is_err(), "stalled fetch should error, not succeed");
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "fetch should be bounded by enclave_timeout, took {:?}",
+            started.elapsed()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`boot_enclave_and_fetch_keys()` (run on the node boot path, before components are built) built the enclave JSON-RPC client with `HttpClientBuilder::default()` and never applied the operator-configured `--enclave.timeout` (`EnclaveArgs::enclave_timeout`). So the setting had no effect: a stalled or slow enclave endpoint could delay startup by the client's default request timeout (60s) regardless of what the operator configured — a misleading availability control.

## Fix

Build the client with `request_timeout(Duration::from_secs(config.enclave_timeout))`, so each `get_purpose_keys` attempt is bound by the configured value. The client construction is extracted into a small `build_enclave_client` helper so the timeout behavior is unit-testable.

## Testing

`enclave_timeout_bounds_a_stalled_fetch` points the client at a local endpoint that accepts connections but never replies, sets `enclave_timeout = 1`, and asserts the fetch errors well within the configured bound. Without the fix the request would hang on the jsonrpsee default (60s); with it the call returns in ~1s — the test's 10s margin cleanly distinguishes the two. clippy (`-D warnings` + seismic lint set) clean for the crate `--lib`.

Note: a `--tests` clippy run on this crate also surfaces the two pre-existing `clippy::doc_markdown` nits in `tests/e2e/integration.rs` that exist on the audit base (fixed in #395); left untouched here to avoid conflicting with that PR.