### PR TITLE
fix(seismic-rpc): reject node-side signing instead of fabricating a placeholder tx (Veridise 1204)

### DIFF
--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -441,3 +441,22 @@ where
         Ok(SeismicEthApi { inner: Arc::new(eth_api), ops_whitelist })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SignableSeismicTransactionRequest;
+    use alloy_signer_local::PrivateKeySigner;
+    use reth_rpc_convert::SignTxRequestError;
+    use reth_rpc_eth_api::SignableTxRequest;
+
+    /// Seismic must reject node-side signing rather than returning a fabricated placeholder tx
+    /// (Veridise 1204), so `eth_sendTransaction`/`eth_signTransaction` fail cleanly.
+    #[tokio::test]
+    async fn try_build_and_sign_is_rejected() {
+        let req = SignableSeismicTransactionRequest::from(
+            alloy_rpc_types_eth::TransactionRequest::default(),
+        );
+        let result = req.try_build_and_sign(&PrivateKeySigner::random()).await;
+        assert!(matches!(result, Err(SignTxRequestError::InvalidTransactionRequest)));
+    }
+}

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -17,7 +17,6 @@ use crate::{
     eth::transaction::{SeismicRpcTxConverter, SeismicSimTxConverter},
     SeismicEthApiError,
 };
-use alloy_consensus::TxEip4844;
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, U256};
 use futures::Future;
@@ -103,35 +102,15 @@ impl TryIntoTxEnv<seismic_revm::SeismicTransaction<TxEnv>> for SignableSeismicTr
 impl SignableTxRequest<reth_seismic_primitives::SeismicTransactionSigned>
     for SignableSeismicTransactionRequest
 {
+    /// Node-side signing (`eth_sendTransaction`/`eth_signTransaction`) is unsupported on Seismic:
+    /// it would have the node custody keys and build a transaction from a plaintext request, which
+    /// does not fit Seismic's client-side-encryption model. Reject rather than return a fabricated
+    /// placeholder transaction.
     async fn try_build_and_sign(
         self,
         _signer: impl TxSigner<Signature> + Send,
     ) -> Result<reth_seismic_primitives::SeismicTransactionSigned, SignTxRequestError> {
-        // TODO: Implement proper signing logic
-        // For now, create a placeholder transaction to make it compile
-        use alloy_consensus::{Signed, TxLegacy};
-        use alloy_primitives::{B256, U256};
-        use reth_seismic_primitives::SeismicTransactionSigned;
-        use seismic_alloy_consensus::SeismicTxEnvelope;
-
-        // Create a minimal transaction for compilation - this should be replaced with proper
-        // signing
-        let tx = TxLegacy {
-            chain_id: Some(1),
-            nonce: 0,
-            gas_price: 20_000_000_000u128,
-            gas_limit: 21_000,
-            to: alloy_primitives::TxKind::Create,
-            value: U256::ZERO,
-            input: Default::default(),
-        };
-
-        let signature = Signature::new(U256::ZERO, U256::ZERO, false);
-        let signed_tx = Signed::new_unchecked(tx, signature, B256::ZERO);
-        let envelope = SeismicTxEnvelope::<TxEip4844>::Legacy(signed_tx);
-        let seismic_signed = SeismicTransactionSigned::from(envelope);
-
-        Ok(seismic_signed)
+        Err(SignTxRequestError::InvalidTransactionRequest)
     }
 }
 
@@ -449,7 +428,7 @@ mod tests {
     use reth_rpc_convert::SignTxRequestError;
     use reth_rpc_eth_api::SignableTxRequest;
 
-    /// Seismic must reject node-side signing rather than returning a fabricated placeholder tx
+    /// Seismic rejects node-side signing rather than returning a fabricated placeholder tx
     /// (Veridise 1204), so `eth_sendTransaction`/`eth_signTransaction` fail cleanly.
     #[tokio::test]
     async fn try_build_and_sign_is_rejected() {


### PR DESCRIPTION
## Veridise 1204 — `eth_sendTransaction` / `eth_signTransaction` return fabricated transactions

### Problem
On Seismic, `eth_sendTransaction`/`eth_signTransaction` flow through `SignableSeismicTransactionRequest::try_build_and_sign`, which was a stub: it ignored both the request and the signer and returned a hard-coded zero-signature legacy *create* transaction (`B256::ZERO` hash). With a local/dev signer configured, `eth_signTransaction` returned bytes for that fabricated tx and `eth_sendTransaction` attempted to submit it.

### Fix
`try_build_and_sign` now returns `SignTxRequestError::InvalidTransactionRequest`, so both endpoints fail cleanly instead of fabricating. Node-side signing would require the node to custody keys and build a transaction from a *plaintext* request, which does not fit Seismic's client-side-encryption model — so rejecting is the correct behavior until real signing is implemented. (Matches the finding's recommendation.)

### Commits
1. `test`: adds a unit test asserting rejection — **fails** against the placeholder (demonstrates the bug).
2. `fix`: replaces the placeholder body with the rejection — test goes green.

### Verification
- `cargo test -p reth-seismic-rpc try_build_and_sign_is_rejected` — fails on commit 1, passes on commit 2.
- No existing e2e tests affected: all `provider.send_transaction` call sites use `.wallet(...)`-backed providers, so alloy signs client-side and submits via `eth_sendRawTransaction` — they never hit the node-side signing path.

To re-enable these endpoints later, `try_build_and_sign` must build a transaction from the request and sign it with the provided signer (see the Ethereum/Optimism impls in `rpc-convert`).