### PR TITLE
feat(seismic-rpc): eth_getBalance/eth_getAccountInfo native by default, opt-in gas-token balance

### DIFF
--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -327,36 +327,51 @@ async fn rpc_test_gas_and_call_variants(
          (got 0 allowance for a USDC-only wallet)"
     );
 
-    // eth_getAccountInfo is wallet-facing, so it reports the effective (USDC-inclusive)
-    // balance, consistent with eth_getBalance. eth_getAccount mirrors the raw trie record
-    // and must agree with eth_getProof, so it stays on the native balance. The
-    // usdc_only_signer has 0 native and 1000 USDC.
+    // eth_getBalance and eth_getAccountInfo default to the raw native balance, consistent with
+    // eth_getAccount/eth_getProof, so consumers never see divergent balances for the same
+    // account (Veridise 1206). The USDC-inclusive effective balance is opt-in on both via
+    // `includeGasToken = true`. The usdc_only_signer has 0 native and 1000 USDC.
     let usdc_addr = usdc_only_signer.address();
-    let account_info = EthApiClient::<
-        SeismicTransactionRequest,
-        SeismicTransactionSigned,
-        SeismicBlock,
-        SeismicTransactionReceipt,
-        Header,
-    >::get_account_info(client, usdc_addr, alloy_eips::BlockId::latest())
-    .await
-    .unwrap();
-    let get_balance = EthApiClient::<
-        SeismicTransactionRequest,
-        SeismicTransactionSigned,
-        SeismicBlock,
-        SeismicTransactionReceipt,
-        Header,
-    >::balance(client, usdc_addr, None)
-    .await
-    .unwrap();
-    assert!(
-        account_info.balance > U256::ZERO,
-        "eth_getAccountInfo must report the effective USDC-inclusive balance"
-    );
+    let native_balance =
+        EthApiOverrideClient::<Block>::get_balance(client, usdc_addr, None, None).await.unwrap();
     assert_eq!(
-        account_info.balance, get_balance,
-        "eth_getAccountInfo balance must match eth_getBalance"
+        native_balance,
+        U256::ZERO,
+        "eth_getBalance defaults to the native balance (0 for a USDC-only wallet)"
+    );
+    let native_account_info = EthApiOverrideClient::<Block>::get_account_info(
+        client,
+        usdc_addr,
+        alloy_eips::BlockId::latest(),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        native_account_info.balance, native_balance,
+        "eth_getAccountInfo defaults to native, matching eth_getBalance"
+    );
+
+    // Opt-in: both endpoints report the effective USDC-inclusive balance.
+    let effective_balance =
+        EthApiOverrideClient::<Block>::get_balance(client, usdc_addr, None, Some(true))
+            .await
+            .unwrap();
+    assert!(
+        effective_balance > U256::ZERO,
+        "opt-in eth_getBalance must report the effective USDC-inclusive balance"
+    );
+    let effective_account_info = EthApiOverrideClient::<Block>::get_account_info(
+        client,
+        usdc_addr,
+        alloy_eips::BlockId::latest(),
+        Some(true),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        effective_account_info.balance, effective_balance,
+        "opt-in eth_getAccountInfo balance must match opt-in eth_getBalance"
     );
 
     // eth_getAccount must NOT substitute the effective balance: it is either absent (the
@@ -1977,6 +1992,76 @@ async fn test_stale_seismic_tx_is_evicted_from_pool() -> eyre::Result<()> {
         node.advance_block().await?;
     }
     assert!(evicted, "stale parked seismic tx should be evicted from the mempool");
+
+    Ok(())
+}
+
+/// `eth_getBalance` returns the native balance by default, with an opt-in `includeGasToken`
+/// parameter that restores the legacy `max(native, usdc)` effective balance.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_get_balance_native_by_default() -> eyre::Result<()> {
+    let (_node, client, _chain_id, wallet, _tasks) = setup_test_node().await?;
+    let addr = wallet.inner.address();
+
+    // Standard 2-arg eth_getBalance routes through the override with `includeGasToken = None`,
+    // so it returns the native balance.
+    let native = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::balance(&client, addr, None)
+    .await
+    .unwrap();
+    assert!(native > U256::ZERO, "dev wallet should hold a native balance");
+
+    // Explicit opt-out equals the default.
+    let opt_out =
+        EthApiOverrideClient::<Block>::get_balance(&client, addr, None, Some(false)).await.unwrap();
+    assert_eq!(opt_out, native);
+
+    // Opt-in to the effective balance; with no USDC held it equals native (and is never less).
+    let effective =
+        EthApiOverrideClient::<Block>::get_balance(&client, addr, None, Some(true)).await.unwrap();
+    assert_eq!(effective, native, "no USDC held: effective balance equals native");
+
+    // eth_getAccountInfo mirrors the same opt-in: its balance field defaults to native and
+    // matches eth_getBalance under both the default and the opt-in.
+    let info = EthApiOverrideClient::<Block>::get_account_info(
+        &client,
+        addr,
+        alloy_eips::BlockId::latest(),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(info.balance, native, "eth_getAccountInfo defaults to the native balance");
+    let info_effective = EthApiOverrideClient::<Block>::get_account_info(
+        &client,
+        addr,
+        alloy_eips::BlockId::latest(),
+        Some(true),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        info_effective.balance, effective,
+        "opt-in eth_getAccountInfo matches eth_getBalance"
+    );
+
+    // A standard 2-arg eth_getAccountInfo (no includeGasToken) still resolves against the
+    // 3-param override, defaulting to native — existing callers keep working.
+    let info_2arg = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::get_account_info(&client, addr, alloy_eips::BlockId::latest())
+    .await
+    .unwrap();
+    assert_eq!(info_2arg.balance, native, "2-arg eth_getAccountInfo defaults to native");
 
     Ok(())
 }

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types::{
 };
 use alloy_rpc_types_eth::{
     simulate::{SimBlock as EthSimBlock, SimulatePayload as EthSimulatePayload, SimulatedBlock},
-    Bundle, EthCallResponse, StateContext,
+    AccountInfo, Bundle, EthCallResponse, StateContext,
 };
 use jsonrpsee::{
     core::{async_trait, RpcResult},
@@ -27,10 +27,11 @@ use jsonrpsee::{
 use reth_network_api::PeersInfo;
 use reth_network_peers::NodeRecord;
 use reth_rpc_eth_api::{
-    helpers::{EthCall, EthTransactions, FullEthApi},
+    helpers::{EthCall, EthState, EthTransactions, FullEthApi},
     RpcBlock, RpcTypes,
 };
 use reth_rpc_eth_types::EthApiError;
+use reth_seismic_txpool::usdc::effective_balance;
 use reth_tracing::tracing::*;
 use seismic_alloy_consensus::{
     Decodable712, InputDecryptionElements, SeismicTxEnvelope, TxSeismicMetadata,
@@ -154,6 +155,29 @@ pub trait EthApiOverride<B: RpcObject> {
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256>;
+
+    /// Returns the balance of an account. Defaults to the native balance (standard behavior).
+    /// Pass `include_gas_token = true` to instead return the Seismic effective balance
+    /// `max(native, usdc·10^12)`, which accounts for the USDC stablecoin accepted as gas.
+    #[method(name = "getBalance")]
+    async fn get_balance(
+        &self,
+        address: Address,
+        block_number: Option<BlockId>,
+        include_gas_token: Option<bool>,
+    ) -> RpcResult<U256>;
+
+    /// Returns `{balance, nonce, code}` for an account. The `balance` field defaults to the
+    /// native balance (standard behavior). Pass `include_gas_token = true` to instead report
+    /// the Seismic effective balance `max(native, usdc·10^12)`, mirroring the opt-in on
+    /// `eth_getBalance`.
+    #[method(name = "getAccountInfo")]
+    async fn get_account_info(
+        &self,
+        address: Address,
+        block: BlockId,
+        include_gas_token: Option<bool>,
+    ) -> RpcResult<AccountInfo>;
 }
 
 /// Implementation of the `eth_` namespace override
@@ -429,6 +453,56 @@ where
             state_override,
         )
         .await?)
+    }
+
+    async fn get_balance(
+        &self,
+        address: Address,
+        block_number: Option<BlockId>,
+        include_gas_token: Option<bool>,
+    ) -> RpcResult<U256> {
+        debug!(target: "reth-seismic-rpc::eth", ?address, ?block_number, ?include_gas_token, "Serving seismic eth_getBalance extension");
+
+        // Default: native balance, matching standard eth_getBalance.
+        let native = EthState::balance(&self.eth_api, address, block_number).await?;
+        if include_gas_token != Some(true) {
+            return Ok(native);
+        }
+
+        // Opt-in: effective balance, max(native, usdc·10^12).
+        Ok(self
+            .eth_api
+            .spawn_blocking_io_fut(move |this| async move {
+                let state = this.state_at_block_id_or_latest(block_number).await?;
+                Ok::<U256, Eth::Error>(effective_balance(&*state, &address, native))
+            })
+            .await?)
+    }
+
+    async fn get_account_info(
+        &self,
+        address: Address,
+        block: BlockId,
+        include_gas_token: Option<bool>,
+    ) -> RpcResult<AccountInfo> {
+        debug!(target: "reth-seismic-rpc::eth", ?address, ?block, ?include_gas_token, "Serving seismic eth_getAccountInfo extension");
+
+        // Default: native balance, matching standard eth_getAccountInfo and eth_getBalance.
+        let mut info = EthState::get_account_info(&self.eth_api, address, block).await?;
+        if include_gas_token != Some(true) {
+            return Ok(info);
+        }
+
+        // Opt-in: report the effective balance, max(native, usdc·10^12), in the balance field.
+        let native = info.balance;
+        info.balance = self
+            .eth_api
+            .spawn_blocking_io_fut(move |this| async move {
+                let state = this.state_at_block_id(block).await?;
+                Ok::<U256, Eth::Error>(effective_balance(&*state, &address, native))
+            })
+            .await?;
+        Ok(info)
     }
 }
 

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -37,7 +37,6 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_rpc_layer::Whitelist;
-use reth_seismic_txpool::usdc::effective_balance;
 use reth_storage_api::{BlockReader, ProviderHeader, ProviderTx};
 use reth_tasks::{
     pool::{BlockingTaskGuard, BlockingTaskPool},
@@ -303,14 +302,10 @@ where
         self.inner.storage_apis_enabled()
     }
 
-    /// Returns the higher of the native balance or the USDC predeploy balance (scaled to 18
-    /// decimals) for `address`. USDC uses 6 decimals; we multiply by 10^12 so both balances
-    /// are comparable in 18-decimal wei units.
-    ///
-    /// The USDC predeploy on Seismic is a bytecode-less account whose `_balances` mapping
-    /// (slot 3) is read/written directly by the seismic-revm handler.  We therefore read
-    /// the balance from raw storage instead of executing a `balanceOf` call (which would
-    /// return empty bytes since there is no contract code).
+    /// Returns the native balance for `address` — the standard `eth_getBalance` behavior,
+    /// consistent with `eth_getAccount`/`eth_getProof`. The USDC-backed effective balance
+    /// (`max(native, usdc·10^12)`) is available opt-in via the `includeGasToken` parameter on
+    /// the `eth_getBalance` override (see `ext.rs`).
     fn balance(
         &self,
         address: Address,
@@ -318,28 +313,22 @@ where
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
         self.spawn_blocking_io_fut(move |this| async move {
             let state = this.state_at_block_id_or_latest(block_id).await?;
-            let native_balance = state
+            Ok(state
                 .account_balance(&address)
                 .map_err(Self::Error::from_eth_err)?
-                .unwrap_or_default();
-            Ok(effective_balance(&*state, &address, native_balance))
+                .unwrap_or_default())
         })
     }
 
-    /// Reports the *effective* (spendable) balance — `max(native, usdc_scaled)` — for
-    /// `eth_getAccountInfo`, mirroring the upstream default and swapping only the balance
-    /// field. See [`effective_balance`].
+    /// Reports the raw native balance for `eth_getAccountInfo`, matching [`Self::balance`] and
+    /// the other account-surface endpoints (`eth_getAccount`/`eth_getProof`).
     ///
-    /// The dividing line for the account-surface endpoints: anything that answers the
-    /// `eth_getBalance` question ("what can this account spend") returns the effective
-    /// balance; anything that exposes the underlying committed `Account` record returns the
-    /// raw native balance. `eth_getAccountInfo` (`{balance, nonce, code}`, no trie-structural
-    /// fields) is the former, so it matches [`Self::balance`].
-    ///
-    /// `eth_getProof`/`eth_getAccount` are the latter and stay native (upstream default):
-    /// getProof's balance is proven against the state root (a synthetic value wouldn't
-    /// verify), and getAccount's `storage_root`/`code_hash` must stay self-consistent with
-    /// that proven leaf.
+    /// All account-inspection RPCs return the same native balance by default, so consumers never
+    /// see a different value for the same account at the same block (Veridise 1206). The
+    /// USDC-backed effective balance (`max(native, usdc·10^12)`) is opt-in via the
+    /// `includeGasToken` parameter on the `eth_getBalance` and `eth_getAccountInfo` overrides
+    /// (see `ext.rs`); the gas-allowance execution path (`estimateGas`/`call`) keeps accounting
+    /// for USDC independently.
     fn get_account_info(
         &self,
         address: Address,
@@ -352,7 +341,7 @@ where
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
 
-            let balance = effective_balance(&*state, &address, account.balance);
+            let balance = account.balance;
             let nonce = account.nonce;
             let code = if account.get_bytecode_hash() == KECCAK_EMPTY {
                 Default::default()

--- a/crates/seismic/txpool/src/usdc.rs
+++ b/crates/seismic/txpool/src/usdc.rs
@@ -101,6 +101,36 @@ pub fn effective_balance(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::FlaggedStorage;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+
+    /// `read_usdc_balance` scales 6→18 decimals, and `effective_balance` returns the larger of
+    /// native and the scaled USDC balance. This is the math behind the opt-in `includeGasToken`
+    /// branch of `eth_getBalance`.
+    #[test]
+    fn effective_balance_uses_larger_of_native_and_usdc() {
+        let addr = Address::with_last_byte(0xab);
+        let key = usdc_balance_storage_key(&addr);
+        let raw_usdc = U256::from(5_000_000u64); // 5 USDC at 6 decimals
+        let scaled = raw_usdc * USDC_DECIMAL_SCALE; // 5·10^18
+
+        let provider = MockEthProvider::default();
+        provider.add_account(
+            USDC_CONTRACT,
+            ExtendedAccount::new(0, U256::ZERO)
+                .extend_storage([(key, FlaggedStorage::new(raw_usdc, false))]),
+        );
+
+        assert_eq!(read_usdc_balance(&provider, &addr), scaled);
+        // USDC dominates a small native balance (the opt-in effective balance).
+        assert_eq!(effective_balance(&provider, &addr, U256::from(1u64)), scaled);
+        // Native dominates when it is larger.
+        let big_native = scaled + U256::from(1u64);
+        assert_eq!(effective_balance(&provider, &addr, big_native), big_native);
+        // An account with no USDC storage falls back to native.
+        let other = Address::with_last_byte(0xcd);
+        assert_eq!(effective_balance(&provider, &other, U256::from(42u64)), U256::from(42u64));
+    }
 
     #[test]
     fn storage_key_is_deterministic() {


### PR DESCRIPTION
## Problem
Seismic's account-surface RPCs disagreed on what balance to report. `eth_getBalance` and `eth_getAccountInfo` returned the **effective** balance `max(native, usdc·10^12)` (native vs. the SRC20 gas stablecoin, internally named "usdc"), while `eth_getAccount`/`eth_getProof` returned the raw **native** balance. The effective default surprised users expecting standard native-balance semantics, and the disagreement between endpoints is Veridise 1206.

## Change
Make **native the default** for every account-surface RPC, with the effective balance available opt-in:

- `balance()` and `get_account_info()` now return the **native** balance, so `eth_getBalance`, `eth_getAccountInfo`, `eth_getAccount`, and `eth_getProof` all agree on native for the same account at the same block (Veridise 1206 — resolved toward native-consistency, superseding #412's effective-consistency resolution for `eth_getAccountInfo`).
- New optional per-call parameter on both **`eth_getBalance(address, block, includeGasToken?)`** and **`eth_getAccountInfo(address, block, includeGasToken?)`**: `true` → effective `max(native, usdc·10^12)`; absent/`false` → native. Backward compatible — existing 2-arg callers get native.
- The gas-allowance path (`estimateGas`/`call`) is **unchanged**, so accounts holding only the gas stablecoin can still estimate/pay gas even though their reported balance is native.
- `eth_getAccount`/`eth_getProof` deliberately have **no** opt-in: they expose the raw trie record (their balance is proven against the state root / kept consistent with `storage_root`/`code_hash`), so they always report native.
- The opt-in path reuses the audited `effective_balance()` helper rather than re-implementing the `max(native, usdc)` math.

## Tests
- **Unit** (`usdc.rs`): seeds a USDC balance via `MockEthProvider` and checks the effective math (`USDC>native` → scaled USDC; `native>USDC` → native; no-USDC → native). First test exercising the USDC balance path.
- **e2e** (`integration.rs`):
  - native-by-default, explicit opt-out, and opt-in for **both** `eth_getBalance` and `eth_getAccountInfo`;
  - a USDC-only wallet (0 native / 1000 USDC) reports `0` by default and the USDC-inclusive balance on opt-in for both endpoints, while `eth_getAccount` stays native;
  - a standard **2-arg** `eth_getAccountInfo` still resolves against the 3-param override (backward compatibility).

## Live verification (`eth_getBalance`)
Ran a standalone node against a custom genesis that pre-allocated 5 USDC of storage for an address (native = 1 wei), then queried over `curl`:

| call | result |
|---|---|
| `eth_getBalance(addr, latest)` | `0x1` (native) |
| `eth_getBalance(addr, latest, false)` | `0x1` (native) |
| `eth_getBalance(addr, latest, true)` | `0x4563918244f40000` = 5·10^18 (effective) |

> `eth_getAccountInfo`'s `balance` field mirrors the same native-default / opt-in behavior; covered by the e2e tests above.
