### PR TITLE
feat(cli): add offline genesis-hash subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Seismic Reth extends [Reth](https://github.com/paradigmxyz/reth) with shielded t
 
 See [seismic-features](./docs/seismic/features.md) for a detailed overview of Seismic Reth's new features.
 
-## For Users
-
-See the [Seismic Reth Book](https://seismicsystems.github.io/seismic-reth) for instructions on how to install and run Seismic Reth.
-
 ## For Developers
 
 ### Building and testing

--- a/crates/seismic/chainspec/src/lib.rs
+++ b/crates/seismic/chainspec/src/lib.rs
@@ -33,13 +33,30 @@ const fn normalize_genesis(mut genesis: Genesis) -> Genesis {
 }
 
 /// Genesis hash for the Seismic mainnet
-/// Calculated by rlp encoding the genesis header and hashing it
+/// Calculated by rlp encoding the genesis header and hashing it.
+///
+/// Must be updated whenever `res/genesis/mainnet.json` changes, or when
+/// [`SEISMIC_MAINNET_HARDFORKS`] changes which forks are active at genesis
+/// (active forks add fields to the header). The `genesis_header_hash` test
+/// recomputes it and fails on drift.
+///
+/// Reproduce the correct value with
+/// `seismic-reth genesis-hash --chain crates/seismic/chainspec/res/genesis/mainnet.json`
+/// — the file path matters: `--chain mainnet` echoes this pinned constant back.
 pub const SEISMIC_MAINNET_GENESIS_HASH: B256 =
     b256!("0xd548d4a126d72e43d893b3826c07ad24bddbaeee267489baff2f73fff2ac0976");
 
 /// Genesis hash for the Seismic devnet
-/// Calculated by rlp encoding the genesis header and hashing it
-/// Currently matches the mainnet genesis hash because they have matching hardforks
+/// Calculated by rlp encoding the genesis header and hashing it.
+///
+/// Must be updated whenever `res/genesis/dev.json` changes, or when
+/// [`SEISMIC_DEV_HARDFORKS`] changes which forks are active at genesis
+/// (active forks add fields to the header). The `genesis_header_hash` test
+/// recomputes it and fails on drift.
+///
+/// Reproduce the correct value with
+/// `seismic-reth genesis-hash --chain crates/seismic/chainspec/res/genesis/dev.json`
+/// — the file path matters: `--chain dev` echoes this pinned constant back.
 pub const SEISMIC_DEV_GENESIS_HASH: B256 =
     b256!("0x874a74ba374da00d8c097b4be585a60e40f901cac56a764ad0013a07b0a2f93c");
 

--- a/crates/seismic/cli/README.md
+++ b/crates/seismic/cli/README.md
@@ -1,0 +1,51 @@
+# Seismic Reth CLI
+
+The `seismic-reth` binary exposes a deliberately trimmed command set compared
+to upstream reth (which also ships `init`, `db`, `p2p`, `dump-genesis`, …):
+
+| command        | purpose                                             |
+| -------------- | --------------------------------------------------- |
+| `node`         | run the node                                        |
+| `stage`        | run individual sync stages (debugging)              |
+| `genesis-hash` | print the genesis block hash for `--chain` and exit |
+
+Commands are defined in [`src/lib.rs`](./src/lib.rs).
+
+## `genesis-hash`
+
+```sh
+$ seismic-reth genesis-hash --chain crates/seismic/chainspec/res/genesis/dev.json
+0x874a74ba374da00d8c097b4be585a60e40f901cac56a764ad0013a07b0a2f93c
+```
+
+Offline: computes `keccak(rlp(header))` from the chain spec without touching a
+database or booting the node. Stdout is exactly one lowercase `0x`-hex line
+(logging is suppressed), so the output can be captured directly by scripts.
+
+Things worth knowing:
+
+- **The hash is a *derived* value, not a file digest.** The genesis header
+  contains the state root (a Merkle-trie computation over the entire `alloc`)
+  plus fork-dependent fields; no generic hash tool applied to the genesis JSON
+  can reproduce it. Only an execution-layer implementation can.
+- **It answers with the node's own belief.** The subcommand shares the exact
+  `--chain` parse path with `node`, so the printed hash is what a node booted
+  from the same `--chain` value computes at genesis.
+- **Built-in names echo pinned constants.** `--chain dev` / `--chain mainnet`
+  resolve to the built-in chain specs, whose genesis hashes are pinned as
+  `SEISMIC_DEV_GENESIS_HASH` / `SEISMIC_MAINNET_GENESIS_HASH` in
+  `reth-seismic-chainspec`. To *recompute* a hash — e.g. to update those
+  constants after editing a genesis file — pass the JSON file path, not the
+  chain name. The `genesis_header_hash` test fails whenever a constant drifts
+  from its genesis file, and the constants' doc comments carry the exact
+  reproduce commands.
+
+### Why it exists
+
+summit (Seismic's consensus client) embeds `eth_genesis_hash` in its
+network-params config, pinning which execution genesis consensus builds on —
+and deploy tooling assembles that config **before any node exists**.
+
+Before this subcommand, the hash could only be obtained from a *live* node
+(`eth_getBlockByNumber(0)` or startup logs) or copied by hand — leaving stale
+hardcoded values undetected until runtime.

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -302,21 +302,21 @@ mod test {
     }
 
     #[test]
-    fn parse_genesis_hash_command() {
+    fn parse_genesis_hash_command() -> Result<(), clap::Error> {
         // The global --chain arg is accepted on either side of the subcommand.
         for args in [
             ["seismic-reth", "genesis-hash", "--chain", "dev"],
             ["seismic-reth", "--chain", "dev", "genesis-hash"],
         ] {
-            let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from(args)
-                .expect("genesis-hash args should parse");
+            let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from(args)?;
             assert!(matches!(cli.command, Commands::GenesisHash));
             assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
         }
+        Ok(())
     }
 
     #[test]
-    fn genesis_hash_from_genesis_file() {
+    fn genesis_hash_from_genesis_file() -> Result<(), clap::Error> {
         // Deploy passes a genesis *file* (`--chain reth-genesis.json`), while devs
         // use the built-in `--chain dev`; both must agree on the hash. File parsing
         // derives hardforks from the JSON config rather than SEISMIC_DEV_HARDFORKS,
@@ -327,10 +327,10 @@ mod test {
             "genesis-hash",
             "--chain",
             path,
-        ])
-        .expect("genesis-hash args should parse");
+        ])?;
         assert!(matches!(cli.command, Commands::GenesisHash));
         assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
+        Ok(())
     }
 
     #[test]

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -214,7 +214,9 @@ where
                     command.execute::<SeismicNode, _>(ctx, components).await
                 })
             }
-            Commands::GenesisHash => unreachable!("handled before tracing init"),
+            // Already handled by the early return above (before tracing init); this arm
+            // only exists to keep the match exhaustive.
+            Commands::GenesisHash => Ok(()),
         }
     }
 
@@ -306,7 +308,8 @@ mod test {
             ["seismic-reth", "genesis-hash", "--chain", "dev"],
             ["seismic-reth", "--chain", "dev", "genesis-hash"],
         ] {
-            let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from(args).unwrap();
+            let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from(args)
+                .expect("genesis-hash args should parse");
             assert!(matches!(cli.command, Commands::GenesisHash));
             assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
         }
@@ -325,7 +328,7 @@ mod test {
             "--chain",
             path,
         ])
-        .unwrap();
+        .expect("genesis-hash args should parse");
         assert!(matches!(cli.command, Commands::GenesisHash));
         assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
     }

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -161,6 +161,13 @@ where
         L: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, C::ChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
+        // Handled before tracing init (which logs to stdout): deploy tooling
+        // captures this command's stdout and needs it to be the hash alone.
+        if matches!(self.command, Commands::GenesisHash) {
+            println!("{}", self.chain.genesis_hash());
+            return Ok(());
+        }
+
         // add network name to logs dir
         self.logs.log_file_directory =
             self.logs.log_file_directory.join(self.chain.chain().to_string());
@@ -207,6 +214,7 @@ where
                     command.execute::<SeismicNode, _>(ctx, components).await
                 })
             }
+            Commands::GenesisHash => unreachable!("handled before tracing init"),
         }
     }
 
@@ -229,14 +237,25 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
     /// Manipulate individual stages.
     #[command(name = "stage")]
     Stage(stage::Command<C>),
+    /// Print the genesis block hash for `--chain` and exit.
+    ///
+    /// Offline: computes `keccak(rlp(header))` from the chain spec without touching a
+    /// database or booting the node, so deploy tooling can precompute the
+    /// `eth_genesis_hash` that summit's network-params config embeds, before any node
+    /// exists.
+    ///
+    /// This is the chain's block-0 hash — a value *derived* from the genesis file:
+    /// state root over the alloc, fork-dependent header fields.
+    #[command(name = "genesis-hash")]
+    GenesisHash,
 }
 
 #[cfg(test)]
 mod test {
-    use crate::chainspec::SeismicChainSpecParser;
+    use crate::{chainspec::SeismicChainSpecParser, Cli, Commands};
     use clap::Parser;
     use reth_cli_commands::{node::NoArgs, NodeCommand};
-    use reth_seismic_chainspec::{SEISMIC_DEV, SEISMIC_DEV_OLD};
+    use reth_seismic_chainspec::{SEISMIC_DEV, SEISMIC_DEV_GENESIS_HASH, SEISMIC_DEV_OLD};
 
     #[test]
     fn parse_dev() {
@@ -278,5 +297,47 @@ mod test {
 
         assert!(cmd.rpc.http);
         assert!(cmd.network.discovery.disable_discovery);
+    }
+
+    #[test]
+    fn parse_genesis_hash_command() {
+        // The global --chain arg is accepted on either side of the subcommand.
+        for args in [
+            ["seismic-reth", "genesis-hash", "--chain", "dev"],
+            ["seismic-reth", "--chain", "dev", "genesis-hash"],
+        ] {
+            let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from(args).unwrap();
+            assert!(matches!(cli.command, Commands::GenesisHash));
+            assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
+        }
+    }
+
+    #[test]
+    fn genesis_hash_from_genesis_file() {
+        // Deploy passes a genesis *file* (`--chain reth-genesis.json`), while devs
+        // use the built-in `--chain dev`; both must agree on the hash. File parsing
+        // derives hardforks from the JSON config rather than SEISMIC_DEV_HARDFORKS,
+        // so this also fails if the two chain definitions drift apart.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../chainspec/res/genesis/dev.json");
+        let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from([
+            "seismic-reth",
+            "genesis-hash",
+            "--chain",
+            path,
+        ])
+        .unwrap();
+        assert!(matches!(cli.command, Commands::GenesisHash));
+        assert_eq!(cli.chain.genesis_hash(), SEISMIC_DEV_GENESIS_HASH);
+    }
+
+    #[test]
+    fn genesis_hash_output_format() {
+        // Deploy tooling parses stdout as a single lowercase 0x-hex line; pin the
+        // Display format the command prints. The value itself changes whenever
+        // the dev genesis does, so assert shape, not value.
+        let printed = SEISMIC_DEV.genesis_hash().to_string();
+        assert_eq!(printed.len(), 66);
+        assert!(printed.starts_with("0x"));
+        assert!(printed[2..].chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
     }
 }


### PR DESCRIPTION
Summit's network-params config embeds `eth_genesis_hash`, and deploy
tooling assembles that config before any node exists. Until now the
hash could only be scraped from a live node (`eth_getBlockByNumber(0)`
or startup logs) or left to the stale value baked into summit's
example_genesis.toml, with mismatches undetected until runtime.

Also needed when bootstrap temporary tee devnets with different dev.json 
than the hardcoded one.

`seismic-reth genesis-hash --chain <name-or-genesis.json>` computes
keccak(rlp(header)) offline, with no database or node boot:

- shares the node's `--chain` parse path, so the printed hash is
  exactly what a node booted from the same value computes;
- runs before tracing init, so stdout is the bare hash line and can
  be captured directly by scripts;
- built-in names (`dev`, `mainnet`) echo the pinned chainspec
  constants; passing the genesis JSON path recomputes from scratch,
  which is how to regenerate the constants after a genesis change.

Also documents SEISMIC_{DEV,MAINNET}_GENESIS_HASH: the two inputs
that invalidate them (genesis JSON edits, and hardfork-set changes
that alter which header fields exist at genesis), the
`genesis_header_hash` test that enforces them, and the exact
reproduce commands. Drops the stale "matches the mainnet genesis
hash" note on the dev constant. A new crate README documents the
seismic CLI surface.