### PR TITLE
fix(seismic-node): disable trace_* and ots_* RPC namespaces (Veridise 1207)

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -45,6 +45,17 @@ mod rpc;
 /// Utilities for creating and writing RLP test data
 pub mod test_rlp_utils;
 
+/// Returns the RPC server args used for test nodes: unused ports, HTTP enabled, IPC disabled.
+///
+/// Tests talk to their nodes over local HTTP only, so the IPC server is disabled: nothing
+/// connects to it, its default endpoint lives in the shared `/tmp`, and sandboxed test
+/// environments often forbid binding unix domain sockets altogether.
+fn test_rpc_server_args() -> RpcServerArgs {
+    let mut args = RpcServerArgs::default().with_unused_ports().with_http();
+    args.ipcdisable = true;
+    args
+}
+
 /// Creates the initial setup with `num_nodes` started and interconnected.
 pub async fn setup<N>(
     num_nodes: usize,
@@ -77,7 +88,7 @@ where
         let node_config = NodeConfig::new(chain_spec.clone())
             .with_network(network_config.clone())
             .with_unused_ports()
-            .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
+            .with_rpc(test_rpc_server_args())
             .set_dev(is_dev);
 
         let span = span!(Level::INFO, "node", idx);
@@ -169,12 +180,7 @@ where
         let node_config = NodeConfig::new(chain_spec.clone())
             .with_network(network_config.clone())
             .with_unused_ports()
-            .with_rpc(
-                RpcServerArgs::default()
-                    .with_unused_ports()
-                    .with_http()
-                    .with_http_api(RpcModuleSelection::All),
-            )
+            .with_rpc(test_rpc_server_args().with_http_api(RpcModuleSelection::All))
             .set_dev(is_dev);
 
         let span = span!(Level::INFO, "node", idx);

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -377,13 +377,25 @@ where
                 // Register seismic_ namespace (getTeePublicKey)
                 modules.merge_configured(SeismicApi::new(purpose_keys).into_rpc())?;
 
-                // Disable the entire `debug_*` namespace.
-                let debug_methods: Vec<&'static str> = modules
-                    .methods_by_module::<fn(&str) -> bool>(RethRpcModule::Debug)
-                    .method_names()
-                    .collect();
-                for name in debug_methods {
-                    modules.remove_method_from_configured(name);
+                // Trace endpoints stay off on Seismic. Our traces are already sanitized
+                // (calldata, return data, memory, and stack are stripped — see
+                // https://github.com/SeismicSystems/seismic-revm-inspectors/blob/seismic/README.md),
+                // but the leftover metadata (gas, revert paths, call-tree shape, touched
+                // addresses) is still a side channel on private state. So to be 100% sure,
+                // we just don't serve these namespaces at all, whatever the operator's
+                // `--http.api` says:
+                //   - debug_*: geth-style tracing, plus raw state/DB access
+                //   - trace_*: parity-style tracing (also honors a caller-supplied `from`)
+                //   - ots_*:   Otterscan, which wraps the same tracing internals
+                // We may re-enable (sanitized) tracing here someday if needed.
+                for module in [RethRpcModule::Debug, RethRpcModule::Trace, RethRpcModule::Ots] {
+                    let method_names: Vec<&'static str> = modules
+                        .methods_by_module::<fn(&str) -> bool>(module)
+                        .method_names()
+                        .collect();
+                    for name in method_names {
+                        modules.remove_method_from_configured(name);
+                    }
                 }
 
                 Ok(())

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1688,3 +1688,48 @@ async fn test_eth_call_many_rejects_signed_read_with_stale_recent_block_hash() -
     }
     Ok(())
 }
+
+/// Trace-serving namespaces (`debug_*`, `trace_*`, `ots_*`) must be unreachable on a Seismic
+/// node even when the operator enables them: trace metadata (gas usage, revert paths,
+/// call-tree shape, touched addresses) is a side channel on private state, even after the
+/// payload sanitizers strip calldata/returndata/memory/stack.
+///
+/// The e2e harness launches nodes with `RpcModuleSelection::All`, so every namespace is
+/// configured at the RPC layer — only the launch-time removal in
+/// `SeismicAddOns::launch_add_ons` makes these methods unregistered.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_debug_ots_namespaces_disabled() -> eyre::Result<()> {
+    let (_node, client, _chain_id, _wallet, _tasks) = setup_test_node().await?;
+
+    let disabled_methods = [
+        "debug_traceCall",
+        "debug_traceTransaction",
+        "debug_traceBlockByNumber",
+        "trace_call",
+        "trace_callMany",
+        "trace_transaction",
+        "trace_block",
+        "ots_traceTransaction",
+        "ots_getInternalOperations",
+    ];
+
+    for method in disabled_methods {
+        let result = client.request::<serde_json::Value, _>(method, rpc_params![]).await;
+        match result {
+            Err(jsonrpsee::core::client::Error::Call(err)) => {
+                assert_eq!(
+                    err.code(),
+                    jsonrpsee::types::error::ErrorCode::MethodNotFound.code(),
+                    "{method} must be unregistered, got error: {err}"
+                );
+            }
+            other => panic!("{method} must return method-not-found, got: {other:?}"),
+        }
+    }
+
+    // Control: the standard eth namespace is still served.
+    let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
+    assert!(block_number.starts_with("0x"), "unexpected eth_blockNumber response: {block_number}");
+
+    Ok(())
+}


### PR DESCRIPTION
Trace-serving endpoints expose execution metadata — gas usage, revert paths, call-tree shape, touched addresses — that is a side channel on Seismic's private state even after payload sanitization strips calldata, return data, memory, stack, and storage diffs. We agree with the audit recommendation to disable tracing entirely rather than rely on sanitization alone.

Prior state: debug_* was already removed wholesale at RPC startup (#390), and payload sanitizers were wired into every debug/trace handler (#354), with the sanitizer logic centralized in seismic-revm-inspectors. The gap the finding identifies is real — the trace_* namespace remained registrable, and ots_* (Otterscan) wraps the same tracing internals (ots_traceTransaction returned unsanitized call-tree data until #405).

This removes the two remaining trace-serving namespaces at RPC startup, in one loop alongside debug_*, regardless of the operator's --http.api selection (so an explicit `--http.api trace,ots` cannot re-expose them):

- trace_*: parity-style tracing; also honors a caller-supplied `from` without the sanitization eth_call applies
- ots_*:   Otterscan endpoints

Defense in depth, should tracing ever be re-enabled: the payload sanitizers in crates/rpc/rpc/src/{debug,trace}.rs and the ots_* handler sanitization (#405, Veridise 1085) stay in place. The intent is that any future re-enablement serves only sanitized traces; fully unsanitized traces are meant only for local dev nodes (sanvil), where there is no private state to protect.

If tracing is ever reintroduced, we will treat all returned metadata as sensitive and audit the sanitizers from first principles, including applying the same `from`-sanitization that eth_call uses.

Add an e2e regression test that launches a node with all namespaces configured and asserts debug_*/trace_*/ots_* methods return method-not-found while eth_blockNumber still works; this also backfills coverage for the earlier debug_* removal, which shipped without a test.

Also disable IPC on e2e test node launches (shared test_rpc_server_args helper): tests talk to nodes over local HTTP only, and the default IPC endpoint is a global /tmp socket that sandboxed environments forbid binding.