### PR TITLE
fix(seismic): forward timestamp-in-seconds to all crates with cfg sites (Veridise 1200)

### DIFF
--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -81,7 +81,11 @@ rand.workspace = true
 
 [features]
 default = []
-timestamp-in-seconds = ["revm/timestamp-in-seconds"]
+timestamp-in-seconds = [
+    "revm/timestamp-in-seconds",
+    "reth-evm-ethereum/timestamp-in-seconds",
+    "reth-ethereum-engine-primitives/timestamp-in-seconds",
+]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -40,7 +40,10 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 
 [features]
-timestamp-in-seconds = ["reth-primitives-traits/timestamp-in-seconds"]
+timestamp-in-seconds = [
+    "reth-primitives-traits/timestamp-in-seconds",
+    "reth-ethereum-engine-primitives/timestamp-in-seconds",
+]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-primitives-traits/test-utils",

--- a/crates/seismic/chainspec/Cargo.toml
+++ b/crates/seismic/chainspec/Cargo.toml
@@ -48,7 +48,7 @@ seismic-alloy-rpc-types.workspace = true
 
 [features]
 default = ["std"]
-timestamp-in-seconds = []
+timestamp-in-seconds = ["reth-chainspec/timestamp-in-seconds"]
 std = [
     "alloy-chains/std",
     "alloy-genesis/std",

--- a/crates/seismic/evm/Cargo.toml
+++ b/crates/seismic/evm/Cargo.toml
@@ -69,7 +69,10 @@ timestamp-in-seconds = [
     "seismic-revm/timestamp-in-seconds",
     "reth-seismic-chainspec/timestamp-in-seconds",
     "alloy-evm/timestamp-in-seconds",
-    "alloy-seismic-evm/timestamp-in-seconds"
+    "alloy-seismic-evm/timestamp-in-seconds",
+    "reth-chainspec/timestamp-in-seconds",
+    "reth-evm/timestamp-in-seconds",
+    "reth-primitives-traits/timestamp-in-seconds",
 ]
 std = [
     "reth-consensus/std",

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -133,6 +133,14 @@ timestamp-in-seconds = [
     "reth-seismic-primitives/timestamp-in-seconds",
     "reth-seismic-rpc/timestamp-in-seconds",
     "reth-seismic-chainspec/timestamp-in-seconds",
+    "reth-rpc/timestamp-in-seconds",
+    "reth-rpc-eth-api/timestamp-in-seconds",
+    "reth-rpc-eth-types/timestamp-in-seconds",
+    "reth-chainspec/timestamp-in-seconds",
+    "reth-evm/timestamp-in-seconds",
+    "reth-transaction-pool/timestamp-in-seconds",
+    "reth-payload-builder/timestamp-in-seconds",
+    "reth-node-ethereum/timestamp-in-seconds",
 ]
 asm-keccak = [
     "alloy-primitives/asm-keccak",

--- a/crates/seismic/node/tests/e2e/main.rs
+++ b/crates/seismic/node/tests/e2e/main.rs
@@ -5,6 +5,7 @@ mod hardfork_config;
 mod integration;
 mod ops;
 mod p2p;
+mod pending_block;
 //mod rpc_compat; // todo: disabling for now we need a more sustainable way to generate state
 // roots. Currently broken from stable coin gas update not burning gas
 mod testsuite;

--- a/crates/seismic/node/tests/e2e/pending_block.rs
+++ b/crates/seismic/node/tests/e2e/pending_block.rs
@@ -1,0 +1,109 @@
+//! E2E test for the locally built pending block returned by `eth_getBlockByNumber("pending")`.
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Test file - panics are acceptable
+
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+use reth_e2e_test_utils::{
+    node::NodeTestContext, transaction::TransactionTestContext, wallet::Wallet,
+};
+use reth_node_builder::{EngineNodeLauncher, Node, NodeBuilder, NodeConfig, NodeHandle};
+use reth_node_core::args::RpcServerArgs;
+use reth_rpc_builder::RpcModuleSelection;
+use reth_seismic_chainspec::SEISMIC_DEV;
+use reth_seismic_node::{
+    node::SeismicNode,
+    utils::e2e::{ensure_mock_purpose_keys, seismic_payload_attributes, SeismicTestNode},
+};
+use reth_tasks::TaskManager;
+
+/// Launches a single Seismic node on the dev chain spec with an HTTP-only RPC
+/// server. The test only talks HTTP, so the IPC endpoint (which binds a socket
+/// under the global temp dir) is disabled.
+async fn launch_http_node() -> eyre::Result<(SeismicTestNode, TaskManager, Wallet)> {
+    let tasks = TaskManager::current();
+    let exec = tasks.executor();
+
+    ensure_mock_purpose_keys();
+
+    let mut rpc_args = RpcServerArgs::default()
+        .with_unused_ports()
+        .with_http()
+        .with_http_api(RpcModuleSelection::All);
+    rpc_args.ipcdisable = true;
+
+    let node_config = NodeConfig::new(SEISMIC_DEV.clone()).with_unused_ports().with_rpc(rpc_args);
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(exec)
+        .with_types_and_provider::<SeismicNode, reth_provider::providers::BlockchainProvider<_>>()
+        .with_components(SeismicNode::default().components_builder())
+        .with_add_ons(SeismicNode::default().add_ons())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                builder.task_executor().clone(),
+                builder.config().datadir(),
+                Default::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await?;
+
+    let node = NodeTestContext::new(node, seismic_payload_attributes).await?;
+    let wallet = Wallet::default().with_chain_id(5124);
+
+    Ok((node, tasks, wallet))
+}
+
+/// Parses a hex quantity field (`"0x..."`) from a JSON block response.
+fn hex_field(block: &serde_json::Value, field: &str) -> u64 {
+    let raw = block[field].as_str().unwrap_or_else(|| panic!("missing block field: {field}"));
+    u64::from_str_radix(raw.trim_start_matches("0x"), 16)
+        .unwrap_or_else(|_| panic!("invalid hex quantity for {field}: {raw}"))
+}
+
+/// The pending block is built locally on top of the latest block, advancing the
+/// timestamp by one 12-second slot. Header timestamps are in milliseconds by
+/// default and in seconds with the `timestamp-in-seconds` feature, so the
+/// expected offset is 12000 or 12 respectively. This guards the feature
+/// forwarding into the RPC crates: if `reth-rpc-eth-api` were built without the
+/// feature in a seconds-mode node, the offset would be 12000 instead of 12.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_block_timestamp_offset() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (node, _tasks, wallet) = launch_http_node().await?;
+    let client = HttpClientBuilder::default().build(node.rpc_url().to_string())?;
+
+    // Put a transfer in the pool so the pending block is genuinely built from
+    // the mempool rather than echoing an existing block.
+    let raw_tx =
+        TransactionTestContext::transfer_tx_bytes(wallet.chain_id, wallet.inner.clone()).await;
+    let tx_hash: String = client
+        .request(
+            "eth_sendRawTransaction",
+            rpc_params![format!("0x{}", alloy_primitives::hex::encode(&raw_tx))],
+        )
+        .await
+        .expect("eth_sendRawTransaction");
+
+    let latest: serde_json::Value =
+        client.request("eth_getBlockByNumber", rpc_params!["latest", false]).await?;
+    let pending: serde_json::Value =
+        client.request("eth_getBlockByNumber", rpc_params!["pending", false]).await?;
+
+    // The pending block extends the latest block and includes the pooled tx.
+    assert_eq!(hex_field(&pending, "number"), hex_field(&latest, "number") + 1);
+    let pending_txs = pending["transactions"].as_array().expect("pending block tx list");
+    assert!(
+        pending_txs.iter().any(|tx| tx.as_str() == Some(tx_hash.as_str())),
+        "pending block should contain the pooled transaction {tx_hash}, got {pending_txs:?}"
+    );
+
+    let expected_offset: u64 = if cfg!(feature = "timestamp-in-seconds") { 12 } else { 12_000 };
+    assert_eq!(
+        hex_field(&pending, "timestamp"),
+        hex_field(&latest, "timestamp") + expected_offset,
+        "pending block timestamp should advance by exactly one slot"
+    );
+
+    Ok(())
+}

--- a/crates/seismic/payload/Cargo.toml
+++ b/crates/seismic/payload/Cargo.toml
@@ -50,4 +50,9 @@ proptest-arbitrary-interop.workspace = true
 reth-execution-types.workspace = true
 
 [features]
-timestamp-in-seconds = ["revm/timestamp-in-seconds"]
+timestamp-in-seconds = [
+    "revm/timestamp-in-seconds",
+    "reth-chainspec/timestamp-in-seconds",
+    "reth-payload-builder/timestamp-in-seconds",
+    "reth-seismic-evm/timestamp-in-seconds",
+]

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -100,6 +100,9 @@ timestamp-in-seconds = [
     "seismic-revm/timestamp-in-seconds",
     "reth-seismic-primitives/timestamp-in-seconds",
     "reth-seismic-chainspec/timestamp-in-seconds",
+    "reth-rpc/timestamp-in-seconds",
+    "reth-rpc-eth-api/timestamp-in-seconds",
+    "reth-rpc-eth-types/timestamp-in-seconds",
 ]
 client = [
     "jsonrpsee/client",


### PR DESCRIPTION
timestamp-in-seconds switches block timestamps from milliseconds to seconds. The binary enables it via reth-seismic-node, but Cargo only activates the feature in a crate when a dependency edge forwards it — and several crates with cfg!(feature = "timestamp-in-seconds") code had no incoming forward from the Seismic tree. They silently compiled in milliseconds mode while the rest of the node ran in seconds mode.

The audit reported the symptom: reth-rpc-eth-api gates the pending-block timestamp delta on the feature but nobody forwarded it, so a seconds-mode node returned pending timestamps 1000x too large (parent + 12000 instead of + 12) via eth_getBlockByNumber("pending").

A full feature-graph audit found the gap was wider than the three crates named in the finding. This forwards the feature to all eight crates that have cfg sites and were unreachable from the binary's feature graph:
- reth-rpc-eth-api, reth-rpc, reth-rpc-eth-types  (the three reported)
- reth-chainspec        (genesis header + fork-ID computation)
- reth-evm              (NextBlockEnvAttributes::timestamp_seconds)
- reth-transaction-pool (fork tracker on new head)
- reth-ethereum-engine-primitives (Cancun/Prague payload fork-activation)
- reth-evm-ethereum     (defensive; cfg code not on the seismic path today)

## Tests / CI

Add an e2e regression test (pending_block.rs) that pools a transfer, queries the pending block, and asserts its timestamp advances by exactly one slot — 12 in seconds mode, 12000 otherwise. Verified to bite: dropping just the reth-rpc-eth-api forward makes the seconds-mode assertion fail with +12000.

Note: no CI lane builds with timestamp-in-seconds today, so this test's seconds-mode assertion only runs when invoked with the feature; a seconds-mode CI job is worth adding as a follow-up.

## Future direction (proposal, not done here)

This fix makes the seconds-mode build coherent, but the deeper problem is that the timestamp-in-seconds flag is fragile: it has spread to ~26 conditional- compilation sites and ~20 feature-propagation entries across several repos, and gaps like this one keep producing unit-mismatch bugs (the same class as a past fork_id() ms-vs-seconds bug).

A stronger structural fix would make milliseconds the canonical unit in production — header.timestamp, Head.timestamp, and ForkCondition::Timestamp all ms — and delete the production conversion code (* 1000, / 1000, genesis_timestamp_seconds()) and most of the feature propagation. The flag would be retained only for ef-tests, whose Ethereum Foundation fixtures bake seconds into RLP-encoded blocks and so genuinely need the seconds path.

Benefit: the seconds-mode-in-production path disappears entirely, so this class of propagation bug cannot recur in production, and the cfg/propagation surface shrinks dramatically. Cost: a multi-repo change (seismic-reth, seismic-revm, seismic-evm, seismic-foundry). Left as a follow-up to decide later; this PR is the tactical fix that closes the finding now.