### PR TITLE
fix(seismic-rpc): submit RPC transactions with External origin (Veridise 1198)

### DIFF
--- a/crates/seismic/rpc/src/eth/transaction.rs
+++ b/crates/seismic/rpc/src/eth/transaction.rs
@@ -164,10 +164,23 @@ where
 
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
-        // submit the transaction to the pool with a `Local` origin
+        // Submit with `External` origin (upstream reth uses `Local` for RPC submissions).
+        //
+        // The default differs because the operating models differ. Ethereum assumes a
+        // run-your-own-node-at-home setting, where txs hitting your RPC are your own — so
+        // tagging them `Local` (auto-exempt from the per-sender slot cap, price rules, and
+        // stale-queued eviction) is reasonable. Seismic is a TEE chain requiring proof of
+        // cloud to run a node, so most users do NOT run their own node and instead submit to
+        // someone else's public RPC. There, RPC submitters are untrusted and those exemptions
+        // become a queued-subpool DoS vector.
+        //
+        // `External` withholds the exemptions by default; an operator who does run their own
+        // node can still exempt specific trusted senders by address via `--txpool.locals`.
+        // External transactions are still propagated to peers (only `Private` is withheld), so
+        // submissions reach block producers.
         let AddedTransactionOutcome { hash, .. } = self
             .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
+            .add_transaction(TransactionOrigin::External, pool_transaction)
             .await
             .map_err(Self::Error::from_eth_err)?;
 


### PR DESCRIPTION
RPC-submitted transactions were tagged `TransactionOrigin::Local` (inherited from upstream reth), which auto-exempts them from the per-sender slot cap (`max_account_slots`), minimum-price rules, and stale-queued eviction. Those exemptions are intended for a node operator submitting their own transactions.

The right default differs for Seismic because the operating model differs. Ethereum assumes a run-your-own-node-at-home setting, where transactions hitting your RPC are your own — so treating them as local is reasonable. Seismic is a TEE chain requiring proof of cloud to run a node, so most users do NOT run their own node and instead submit to someone else's public RPC. Those submitters are untrusted, and granting them the local-origin exemptions is a queued-subpool bloat / DoS vector: an attacker can fill the queued subpool with future-nonce transactions that are never slot-capped and never evicted, displacing honest users' transactions.

Tag RPC submissions `External` instead. They get no exemptions by default and are held to the same per-sender limits as any other transaction. An operator who runs their own node can still exempt specific trusted senders by address via `--txpool.locals` (the sender-based allowlist still applies under External). Transactions are still propagated to peers (only `Private` origin is withheld), so submissions still reach block producers.

This makes the audit's "narrow exemptions to an explicit allowlist of trusted senders" recommendation the default, rather than relying on operators to pass `--txpool.nolocals`.