### PR TITLE
feat(seismic-rpc): bound signed-read payload size before crypto (Veridise 1197)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9460,6 +9460,7 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
  "reth-node-ethereum",
  "reth-payload-builder",
  "reth-primitives",

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -3,6 +3,10 @@
 mod enclave;
 pub use enclave::EnclaveArgs;
 
+/// Seismic-specific RPC args and the process-wide handle the RPC layer reads them through
+mod seismic_rpc;
+pub use seismic_rpc::{init_seismic_rpc_args, seismic_rpc_args, SeismicRpcArgs};
+
 /// NetworkArg struct for configuring the network
 mod network;
 pub use network::{DiscoveryArgs, NetworkArgs};

--- a/crates/node/core/src/args/seismic_rpc.rs
+++ b/crates/node/core/src/args/seismic_rpc.rs
@@ -1,0 +1,80 @@
+//! clap [Args](clap::Args) for Seismic-specific RPC configuration, plus a process-wide handle so
+//! the RPC layer can read them.
+
+use clap::Args;
+use reth_transaction_pool::validate::DEFAULT_MAX_TX_INPUT_BYTES;
+use std::sync::OnceLock;
+
+/// Seismic-specific RPC limits.
+///
+/// A signed read (`eth_call`/`eth_estimateGas`/`eth_callMany`/`eth_simulateV1` carrying a signed
+/// seismic payload) decrypts its calldata at the RPC layer before execution — RLP decode, keccak
+/// signature hash, secp256k1 recovery, ECDH, AES-GCM — none of it metered by EVM gas. Unlike a
+/// real transaction it never enters the mempool, so the [`DEFAULT_MAX_TX_INPUT_BYTES`] per-tx size
+/// limit does not apply. This caps a signed read at that same size by default, rejected before any
+/// of that crypto runs and independently of `rpc.max-request-size`.
+#[derive(Debug, Clone, Copy, Args, PartialEq, Eq)]
+#[command(next_help_heading = "Seismic RPC")]
+pub struct SeismicRpcArgs {
+    /// Maximum accepted signed-read payload size, in bytes.
+    #[arg(
+        long = "seismic.rpc.max-signed-read-input-bytes",
+        default_value_t = DEFAULT_MAX_TX_INPUT_BYTES
+    )]
+    pub max_signed_read_input_bytes: usize,
+}
+
+impl Default for SeismicRpcArgs {
+    fn default() -> Self {
+        Self { max_signed_read_input_bytes: DEFAULT_MAX_TX_INPUT_BYTES }
+    }
+}
+
+/// Process-wide Seismic RPC limits.
+///
+/// The signed-read guard lives in a free function in `reth-seismic-rpc`
+/// (`recover_raw_seismic_call_tx`) that has no channel to the parsed CLI args. The CLI sets this
+/// once at startup, before the node is built, and the guard reads it back. A second set is ignored
+/// (first wins) so in-process test harnesses that build several nodes don't panic.
+static SEISMIC_RPC_ARGS: OnceLock<SeismicRpcArgs> = OnceLock::new();
+
+/// Store the Seismic RPC limits for the RPC layer to read. Should be called once at startup.
+pub fn init_seismic_rpc_args(args: SeismicRpcArgs) {
+    let _ = SEISMIC_RPC_ARGS.set(args);
+}
+
+/// Read the Seismic RPC limits, falling back to defaults if never initialized (e.g. tests or
+/// embedders that build the node directly without going through the CLI).
+pub fn seismic_rpc_args() -> SeismicRpcArgs {
+    SEISMIC_RPC_ARGS.get().copied().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    /// A helper type to parse Args more easily.
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn test_seismic_rpc_args_default() {
+        let args = CommandParser::<SeismicRpcArgs>::parse_from(["reth node"]).args;
+        assert_eq!(args.max_signed_read_input_bytes, DEFAULT_MAX_TX_INPUT_BYTES);
+    }
+
+    #[test]
+    fn test_seismic_rpc_args_override() {
+        let args = CommandParser::<SeismicRpcArgs>::parse_from([
+            "reth node",
+            "--seismic.rpc.max-signed-read-input-bytes",
+            "4096",
+        ])
+        .args;
+        assert_eq!(args.max_signed_read_input_bytes, 4096);
+    }
+}

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -12,7 +12,7 @@
 pub mod chainspec;
 
 use chainspec::SeismicChainSpecParser;
-use clap::{value_parser, Parser, Subcommand};
+use clap::{value_parser, Args, Parser, Subcommand};
 use futures_util::Future;
 use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_cli::chainspec::ChainSpecParser;
@@ -21,7 +21,7 @@ use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
 use reth_node_core::{
-    args::{EnclaveArgs, LogArgs},
+    args::{init_seismic_rpc_args, EnclaveArgs, LogArgs, SeismicRpcArgs},
     version::version_metadata,
 };
 use reth_node_ethereum::consensus::EthBeaconConsensus;
@@ -39,6 +39,38 @@ use reth_node_metrics::recorder::install_prometheus_recorder;
 use std::{ffi::OsString, fmt, sync::Arc};
 use tracing::info;
 
+/// Seismic-specific CLI args carried alongside the node command.
+///
+/// This is the default `Ext` for [`Cli`]: it bundles the enclave connection args with the Seismic
+/// RPC limits so both `--enclave.*` and `--seismic.rpc.*` flags are parsed. `AsRef<EnclaveArgs>`
+/// keeps the enclave-boot path unchanged; `AsRef<SeismicRpcArgs>` feeds the RPC-layer signed-read
+/// guard.
+// TODO(samlaf): the enclave flags still use the bare `--enclave.*` namespace, predating the
+// `seismic.*` convention. We probably want to move them under `seismic.enclave.*` so all
+// fork-specific flags live under one `seismic.*` namespace.
+#[derive(Debug, Clone, Copy, Args, PartialEq, Eq, Default)]
+pub struct SeismicNodeArgs {
+    /// Enclave connection configuration.
+    #[command(flatten)]
+    pub enclave: EnclaveArgs,
+
+    /// Seismic-specific RPC limits.
+    #[command(flatten)]
+    pub seismic_rpc: SeismicRpcArgs,
+}
+
+impl AsRef<EnclaveArgs> for SeismicNodeArgs {
+    fn as_ref(&self) -> &EnclaveArgs {
+        &self.enclave
+    }
+}
+
+impl AsRef<SeismicRpcArgs> for SeismicNodeArgs {
+    fn as_ref(&self) -> &SeismicRpcArgs {
+        &self.seismic_rpc
+    }
+}
+
 /// The main seismic-reth cli interface.
 ///
 /// This is the entrypoint to the executable.
@@ -46,7 +78,7 @@ use tracing::info;
 #[command(author, version =version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
 pub struct Cli<
     Spec: ChainSpecParser = SeismicChainSpecParser,
-    Ext: clap::Args + fmt::Debug = EnclaveArgs,
+    Ext: clap::Args + fmt::Debug = SeismicNodeArgs,
 > {
     /// The command to run
     #[command(subcommand)]
@@ -109,7 +141,7 @@ impl Cli {
 impl<C, Ext> Cli<C, Ext>
 where
     C: ChainSpecParser<ChainSpec = ChainSpec>,
-    Ext: clap::Args + fmt::Debug + AsRef<EnclaveArgs>,
+    Ext: clap::Args + fmt::Debug + AsRef<EnclaveArgs> + AsRef<SeismicRpcArgs>,
 {
     /// Execute the configured cli command.
     ///
@@ -139,6 +171,11 @@ where
         // Install the prometheus recorder to be sure to record all metrics
         let _ = install_prometheus_recorder();
         let enclave_args = self.enclave;
+
+        // Store the Seismic RPC limits before building the node. The signed-read guard lives in a
+        // free function in `reth-seismic-rpc` that has no other channel to the parsed CLI args and
+        // reads them back via `seismic_rpc_args()`.
+        init_seismic_rpc_args(*AsRef::<SeismicRpcArgs>::as_ref(&enclave_args));
 
         match self.command {
             Commands::Node(command) => runner.run_command_until_exit(|ctx| {

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -33,6 +33,7 @@ reth-provider.workspace = true
 reth-rpc.workspace = true
 reth-rpc-convert.workspace = true
 reth-rpc-eth-api.workspace = true
+reth-node-core.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-layer.workspace = true
 reth-rpc-server-types.workspace = true

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -70,6 +70,9 @@ pub fn convert_seismic_call_to_tx_request(
             // we can delete this arm and the `TypedData` variant entirely.
             let req = SeismicTransactionRequest::decode_712(&typed_request)
                 .map_err(|_e| EthApiError::FailedToDecodeSignedTransaction)?;
+            // Bound the calldata before the downstream ECDH/AES decrypt — same limit as the bytes
+            // path, so the guard can't be bypassed by submitting via TypedData instead of Bytes.
+            check_signed_read_input_size(req.inner.input.input().map_or(0, |b| b.len()))?;
             Ok((req, true))
         }
 
@@ -80,6 +83,26 @@ pub fn convert_seismic_call_to_tx_request(
             Ok((req, true))
         }
     }
+}
+
+/// Reject a signed read whose payload exceeds the configured size cap, before any of the unmetered
+/// decrypt crypto (decode, keccak sighash, secp256k1 recovery, ECDH, AES-GCM) runs.
+///
+/// A signed read is a transaction that skips the mempool, so we hold it to the same per-tx size
+/// limit real transactions obey (`--seismic.rpc.max-signed-read-input-bytes`, default
+/// `DEFAULT_MAX_TX_INPUT_BYTES`). Both submission paths gate on this so the bound can't be bypassed
+/// by choosing one format over the other: `len` is the raw tx size on the bytes path, the calldata
+/// size on the typed-data path.
+fn check_signed_read_input_size(len: usize) -> Result<(), EthApiError> {
+    let max = reth_node_core::args::seismic_rpc_args().max_signed_read_input_bytes;
+    if len > max {
+        return Err(EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
+            -32602,
+            format!("signed-read payload exceeds {max} bytes (got {len})"),
+            None::<String>,
+        ))));
+    }
+    Ok(())
 }
 
 /// Decode a raw EIP-2718 transaction submitted via the `eth_call` bytes path
@@ -95,6 +118,8 @@ fn recover_raw_seismic_call_tx(data: &[u8]) -> EthResult<Recovered<SeismicTxEnve
     if data.is_empty() {
         return Err(EthApiError::EmptyRawTransactionData);
     }
+    // Bound the raw tx size before any decode/recover/decrypt crypto runs.
+    check_signed_read_input_size(data.len())?;
     let mut buf: &[u8] = data;
     let transaction = SeismicTxEnvelope::decode_2718_permit_seismic_calls(&mut buf)
         .map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
@@ -353,6 +378,35 @@ mod test {
         .unwrap();
         assert_eq!(signed_sighash, expected_sighash);
         assert_eq!(recovered_sighash, expected_sighash);
+    }
+
+    #[test]
+    fn rejects_oversized_signed_read_payload() {
+        // One byte over the cap is rejected by the size guard, before any decode/recovery crypto.
+        let cap = reth_node_core::args::seismic_rpc_args().max_signed_read_input_bytes;
+        let data = vec![0u8; cap + 1];
+        let err = super::recover_raw_seismic_call_tx(&data).unwrap_err().to_string().to_lowercase();
+        assert!(err.contains("signed-read payload exceeds"), "{err}");
+    }
+
+    #[test]
+    fn at_limit_payload_passes_size_guard() {
+        // Exactly at the cap clears the guard; this junk then fails to *decode*, proving the size
+        // check let it through rather than rejecting on size.
+        let cap = reth_node_core::args::seismic_rpc_args().max_signed_read_input_bytes;
+        let data = vec![0u8; cap];
+        let err = super::recover_raw_seismic_call_tx(&data).unwrap_err().to_string().to_lowercase();
+        assert!(!err.contains("signed-read payload exceeds"), "{err}");
+    }
+
+    #[test]
+    fn input_size_gate_rejects_over_and_passes_at_limit() {
+        // The shared gate used by both submission paths (bytes via `recover_raw_seismic_call_tx`,
+        // typed-data via the `convert_*` arm): at the cap is allowed, one byte over is rejected.
+        let cap = reth_node_core::args::seismic_rpc_args().max_signed_read_input_bytes;
+        assert!(super::check_signed_read_input_size(cap).is_ok());
+        let err = super::check_signed_read_input_size(cap + 1).unwrap_err().to_string();
+        assert!(err.to_lowercase().contains("signed-read payload exceeds"), "{err}");
     }
 
     mod freshness {


### PR DESCRIPTION
Addresses Veridise audit finding 1197: "Signed-read `eth_call` requests amplify unmetered CPU usage."

A signed read (`eth_call`/`eth_estimateGas`/`eth_callMany`/`eth_simulateV1` carrying a signed seismic payload) decrypts its calldata at the RPC layer before execution — RLP decode, keccak signature hash, secp256k1 recovery, ECDH, AES-GCM — none of it metered by EVM gas. Unlike a real transaction, a signed read never enters the mempool, so the standard DEFAULT_MAX_TX_INPUT_BYTES (128 KiB) per-tx size limit did not apply; it was bounded only by the 15 MB `rpc.max-request-size` frame limit.

This adds a size guard (`check_signed_read_input_size`) that rejects oversized payloads BEFORE any of that crypto runs, on both signed-read submission formats so the cap cannot be bypassed by choosing one over the other: the raw-bytes path (in `recover_raw_seismic_call_tx`, before decode/recovery) and the legacy EIP-712 `TypedData` path (before the shared ECDH/AES decrypt). All four signed-read endpoints route through these. The bound is configurable via a new `--seismic.rpc.max-signed-read-input-bytes` flag, independent of `rpc.max-request-size` (as the finding asks). Its default is DEFAULT_MAX_TX_INPUT_BYTES: a signed read is a transaction that bypasses the mempool, so by default we hold it to the same per-tx size limit every real transaction must satisfy, rather than inventing a new constant.

Rationale and scope
-------------------
The marginal cost of a signed read is dominated by fixed, size-independent crypto that a byte cap cannot bound. Over an unsigned `eth_call`, a signed read also performs: secp256k1 recovery (ecrecover, ~50 us), a secp256k1 ECDH (~40 us), a keccak256 signature hash (linear), an AES-256-GCM decrypt (linear), plus an AES-256-GCM re-encrypt of the result (linear, already bounded by `rpc.gascap`). The two asymmetric ops are fixed cost regardless of payload size.

Estimated marginal cost (AES-NI; secp256k1 via libsecp256k1; keccak ~1 GB/s; AES-GCM ~6.8 GB/s, measured locally):

  Operation                | 512-byte payload    | 128 KiB payload
  -------------------------|---------------------|----------------
  ecrecover (fixed)        | 50 us               | 50 us
  ECDH (fixed)             | 40 us               | 40 us
  keccak sighash (linear)  | ~0.5 us             | ~131 us
  AES-GCM decrypt (linear) | ~0.1 us             | ~19 us
  marginal total           | ~91 us (~99% fixed) | ~240 us

Two consequences:
- For small payloads (the worst signed-to-unsigned ratio), the overhead is ~90 us of irreducible asymmetric crypto. No byte cap removes it; only request-rate limiting bounds how often it can be triggered.
- For large payloads, the cost is dominated by linear work done DURING decode/recovery — the keccak sighash (~131 us at 128 KiB) and the ecrecover — not by the later AES decrypt (~19 us). This is why the bytes-path guard checks the raw payload size BEFORE decode rather than the decrypted-calldata length after: placed after decode it would save only the AES; placed before, it rejects the entire decode/recover/decrypt pipeline for oversized inputs.

The amplification is a bounded constant factor (~2x at most, approaching 1x as EVM execution dominates) applied to a request already bounded by `rpc.max-request-size` — not unbounded amplification. The ECDH (~25k ops/s/core, parallel across cores) is never the throughput-limiting stage; TLS, JSON parsing, EVM execution, and state IO each dominate it.

We scoped this to a single INPUT bound and did not add an output cap: result size is already bounded by `rpc.gascap` (producing return data costs gas), and the output is only available after execution, so there is no pre-crypto point to reject it. The guard does not address the two vectors a per-request byte cap structurally cannot — the fixed per-request crypto on small payloads, and request VOLUME — which remain operational concerns (`rpc.gascap`, request timeouts, ingress rate-limiting / connection limits), exactly as on any public Ethereum node's `eth_call` surface.

Wiring
------
SeismicRpcArgs and a process-wide OnceLock bridge (init_seismic_rpc_args / seismic_rpc_args) live in reth-node-core — the one crate both the CLI writer and the rpc-layer reader reach — so EthApiExt and the node builder are untouched. The CLI sets it once at startup via a new SeismicNodeArgs default Ext (bundling EnclaveArgs + SeismicRpcArgs); the guard reads it back. reth-seismic-rpc gains a direct reth-node-core dependency (already transitive; no cycle).

Tests: arg parse (default + override) in reth-node-core; the shared size gate and the bytes-path guard (over-limit rejected pre-decode, at-limit passes the guard) in reth-seismic-rpc.