### PR TITLE
fix(seismic-rpc): effective balance on eth_getAccountInfo (Veridise 1206)

### DIFF
--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -326,6 +326,54 @@ async fn rpc_test_gas_and_call_variants(
          (got 0 allowance for a USDC-only wallet)"
     );
 
+    // eth_getAccountInfo is wallet-facing, so it reports the effective (USDC-inclusive)
+    // balance, consistent with eth_getBalance. eth_getAccount mirrors the raw trie record
+    // and must agree with eth_getProof, so it stays on the native balance. The
+    // usdc_only_signer has 0 native and 1000 USDC.
+    let usdc_addr = usdc_only_signer.address();
+    let account_info = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::get_account_info(client, usdc_addr, alloy_eips::BlockId::latest())
+    .await
+    .unwrap();
+    let get_balance = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::balance(client, usdc_addr, None)
+    .await
+    .unwrap();
+    assert!(
+        account_info.balance > U256::ZERO,
+        "eth_getAccountInfo must report the effective USDC-inclusive balance"
+    );
+    assert_eq!(
+        account_info.balance, get_balance,
+        "eth_getAccountInfo balance must match eth_getBalance"
+    );
+
+    // eth_getAccount must NOT substitute the effective balance: it is either absent (the
+    // account has no native presence) or reports the raw native balance (0 here).
+    let raw_account = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::get_account(client, usdc_addr, alloy_eips::BlockId::latest())
+    .await
+    .unwrap();
+    assert!(
+        raw_account.map_or(true, |a| a.balance == U256::ZERO),
+        "eth_getAccount must keep the raw native balance, not the effective USDC balance"
+    );
+
     // test eth_estimateGas sanitizes unsigned seismic requests (clears `from` and
     // seismic_elements to prevent caller spoofing, same as eth_call)
     let unsigned_seismic_result = EthApiOverrideClient::<Block>::estimate_gas(

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -10,7 +10,9 @@ use reth_rpc_eth_api::{
     RpcNodeCore, RpcTxReq,
 };
 use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
-use reth_seismic_txpool::usdc::{usdc_balance_storage_key, USDC_CONTRACT, USDC_DECIMAL_SCALE};
+use reth_seismic_txpool::usdc::{
+    gas_allowance, usdc_balance_storage_key, USDC_CONTRACT, USDC_DECIMAL_SCALE,
+};
 use revm::{
     context::TxEnv,
     context_interface::{Block, Transaction},
@@ -71,17 +73,17 @@ where
         self.inner.max_simulate_blocks()
     }
 
-    /// Override the upstream allowance computation to use the *effective* gas
-    /// balance: `max(native_balance, usdc_balance × 10^12)`. Without this,
-    /// `eth_estimateGas` rejects USDC-only wallets with `gas required exceeds
-    /// allowance (0)` even though `eth_getBalance` correctly reports their
-    /// USDC-backed balance.
+    /// Override the upstream allowance computation: on Seismic, gas can be paid
+    /// in native token or USDC, while the transferred value always comes out of
+    /// the native balance. Without this, `eth_estimateGas` rejects USDC-only
+    /// wallets with `gas required exceeds allowance (0)`.
     ///
-    /// **Keep this in sync with [`reth_seismic_txpool::usdc::effective_balance`]**
-    /// — same `max(native, usdc · USDC_DECIMAL_SCALE)` recipe, just operating on
-    /// a [`Database`] instead of a [`StateProvider`]. The two layers must agree
-    /// on the effective-balance definition, otherwise a tx the pool admits can
-    /// still be rejected at `eth_estimateGas` (or vice versa).
+    /// Delegates to [`gas_allowance`], which mirrors the component-wise
+    /// affordability rule the txpool enforces at admission via
+    /// [`reth_seismic_txpool::usdc::can_afford`] (distinct from the single-scalar
+    /// `native + usdc` bound the pool uses internally for promote/demote) — this
+    /// only differs in reading balances from a [`Database`] instead of a
+    /// [`StateProvider`](reth_provider::StateProvider).
     fn caller_gas_allowance(
         &self,
         mut db: impl Database<Error: Into<EthApiError>>,
@@ -100,10 +102,9 @@ where
             .map_err(|e| Self::Error::from_eth_err(e.into()))?
             .value
             .saturating_mul(USDC_DECIMAL_SCALE);
-        let balance = std::cmp::max(native, usdc);
 
-        let usable = balance.checked_sub(tx_env.value()).unwrap_or_default();
-        Ok(usable.checked_div(U256::from(tx_env.gas_price())).unwrap_or_default().saturating_to())
+        Ok(gas_allowance(native, usdc, tx_env.value(), U256::from(tx_env.gas_price()))
+            .saturating_to())
     }
 
     fn create_txn_env(

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -15,8 +15,10 @@ use crate::{
     eth::transaction::{SeismicRpcTxConverter, SeismicSimTxConverter},
     SeismicEthApiError,
 };
+use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, U256};
+use alloy_rpc_types_eth::AccountInfo;
 use futures::Future;
 use reth_evm::{ConfigureEvm, SpecFor, TxEnvFor};
 use reth_node_api::{FullNodeComponents, HeaderTy};
@@ -321,6 +323,48 @@ where
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
             Ok(effective_balance(&*state, &address, native_balance))
+        })
+    }
+
+    /// Reports the *effective* (spendable) balance — `max(native, usdc_scaled)` — for
+    /// `eth_getAccountInfo`, mirroring the upstream default and swapping only the balance
+    /// field. See [`effective_balance`].
+    ///
+    /// The dividing line for the account-surface endpoints: anything that answers the
+    /// `eth_getBalance` question ("what can this account spend") returns the effective
+    /// balance; anything that exposes the underlying committed `Account` record returns the
+    /// raw native balance. `eth_getAccountInfo` (`{balance, nonce, code}`, no trie-structural
+    /// fields) is the former, so it matches [`Self::balance`].
+    ///
+    /// `eth_getProof`/`eth_getAccount` are the latter and stay native (upstream default):
+    /// getProof's balance is proven against the state root (a synthetic value wouldn't
+    /// verify), and getAccount's `storage_root`/`code_hash` must stay self-consistent with
+    /// that proven leaf.
+    fn get_account_info(
+        &self,
+        address: Address,
+        block_id: BlockId,
+    ) -> impl Future<Output = Result<AccountInfo, Self::Error>> + Send {
+        self.spawn_blocking_io_fut(move |this| async move {
+            let state = this.state_at_block_id(block_id).await?;
+            let account = state
+                .basic_account(&address)
+                .map_err(Self::Error::from_eth_err)?
+                .unwrap_or_default();
+
+            let balance = effective_balance(&*state, &address, account.balance);
+            let nonce = account.nonce;
+            let code = if account.get_bytecode_hash() == KECCAK_EMPTY {
+                Default::default()
+            } else {
+                state
+                    .account_code(&address)
+                    .map_err(Self::Error::from_eth_err)?
+                    .unwrap_or_default()
+                    .original_bytes()
+            };
+
+            Ok(AccountInfo { balance, nonce, code })
         })
     }
 }

--- a/crates/seismic/rpc/src/eth/transaction.rs
+++ b/crates/seismic/rpc/src/eth/transaction.rs
@@ -8,8 +8,7 @@ use alloy_sol_types::SolCall;
 use futures::StreamExt;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::SignedTransaction;
-use reth_provider::BlockNumReader;
-use reth_provider::CanonStateSubscriptions;
+use reth_provider::{BlockNumReader, CanonStateSubscriptions};
 use reth_rpc_convert::transaction::{RpcTxConverter, SimTxConverter};
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadReceipt, LoadTransaction},

--- a/crates/seismic/txpool/src/maintain.rs
+++ b/crates/seismic/txpool/src/maintain.rs
@@ -6,12 +6,36 @@ use reth_provider::StateProvider;
 use reth_transaction_pool::maintain::ChangedAccountsHook;
 use tracing::debug;
 
-/// A [`ChangedAccountsHook`] that reads each sender's USDC predeploy balance
-/// and sets `balance = max(native, usdc_scaled)` so the pool can make accurate
-/// demotion decisions for accounts paying gas in USDC.
+/// Makes the transaction pool's balance accounting aware of USDC gas payment.
 ///
-/// The hook uses the [`StateProvider`] passed by the maintenance loop rather
-/// than opening its own snapshot, so the USDC balance is always read from the
+/// On Seismic, gas can be paid in USDC, but the pool tracks a single native
+/// balance per account and uses it to promote/demote transactions between the
+/// Pending and Queued subpools. Without help, an account paying gas in USDC
+/// (with little or no native balance) looks broke to the pool, so its otherwise
+/// valid transactions end up parked in the Queued subpool — never promoted to
+/// Pending, or demoted back out of it — and are never mined. This
+/// [`ChangedAccountsHook`] augments that per-account balance with the sender's
+/// USDC balance so those decisions are accurate. It runs in the maintenance loop
+/// on new blocks/reorgs and only feeds promote/demote — admission is gated
+/// separately by the validator (see [`crate::usdc::can_afford`]).
+///
+/// The pool's single scalar can't express the validator's component-wise rule
+/// (value from native, gas from remaining native or USDC). We report
+/// `native + usdc` instead, a sound upper bound: any transaction the validator
+/// admits satisfies `cost ≤ native + usdc`, so the pool's `cost ≤ balance` check
+/// never parks it in Queued. Keep in sync with the scalar reported by the
+/// validator (see `validator.rs`).
+///
+/// The sum over-promotes only when an account overcommits its *native* balance
+/// across multiple value-bearing txs (value=0 gas traffic is gated near-exactly).
+/// Such a tx then fails at block building, the final affordability gate. That is
+/// safe: an unincluded tx consumes no nonce — it just lingers in the pending
+/// subpool and blocks higher nonces from the same sender until balances change
+/// (standard stuck-nonce behavior, not on-chain inconsistency).
+///
+/// Implementation: for each changed account it sets `balance = native + usdc_scaled`
+/// ([`crate::usdc::read_usdc_balance`]), reading USDC via the [`StateProvider`] the
+/// maintenance loop passes in rather than its own snapshot, so USDC is read from the
 /// same block as the native balance and nonce.
 #[derive(Debug, Default)]
 pub struct SeismicBalanceHook;
@@ -20,14 +44,14 @@ impl ChangedAccountsHook for SeismicBalanceHook {
     fn transform(&self, state: &dyn StateProvider, accounts: &mut Vec<ChangedAccount>) {
         for acc in accounts.iter_mut() {
             let usdc = crate::usdc::read_usdc_balance(state, &acc.address);
-            let new_balance = std::cmp::max(acc.balance, usdc);
+            let new_balance = acc.balance.saturating_add(usdc);
             if new_balance != acc.balance {
                 debug!(
                     target: "seismic::txpool",
                     address = %acc.address,
                     native_balance = %acc.balance,
                     usdc_scaled_balance = %usdc,
-                    effective_balance = %new_balance,
+                    pool_balance = %new_balance,
                     "augmenting changed account balance with USDC"
                 );
                 acc.balance = new_balance;

--- a/crates/seismic/txpool/src/usdc.rs
+++ b/crates/seismic/txpool/src/usdc.rs
@@ -45,17 +45,50 @@ pub fn read_usdc_balance(state: &dyn StateProvider, address: &Address) -> U256 {
     }
 }
 
-/// Returns the *effective* balance: `max(native_balance, usdc_balance_scaled)`.
+/// Returns `true` if a sender with the given balances can afford a transaction
+/// transferring `value` native tokens with a maximum gas cost of `gas_cost`
+/// (including blob fees, in 18-decimal wei units).
 ///
-/// This is used as the balance for transaction pool ordering and demotion
-/// decisions so that accounts paying gas in USDC are treated equivalently to
-/// accounts paying in native token.
+/// On Seismic, gas can be paid in native token *or* USDC, but `tx.value` is
+/// always a native-token transfer. The two requirements must therefore be
+/// checked component-wise rather than against a single combined balance:
+/// - `value` can only come out of the native balance: `native >= value`.
+/// - gas is paid from a single token, either what remains of the native balance after the transfer
+///   (`native - value >= gas_cost`) or USDC (`usdc >= gas_cost`); it cannot be split across both.
 ///
-/// **Keep in sync with `SeismicEthApi::caller_gas_allowance`** in
-/// `reth-seismic-rpc::eth::call` — that's the `Database`-flavored mirror used
-/// by `eth_estimateGas`. Both layers must agree on the effective-balance
-/// definition (currently `max(native, usdc · USDC_DECIMAL_SCALE)`), otherwise
-/// a tx the pool admits can be rejected by `eth_estimateGas` or vice versa.
+/// `usdc` must already be scaled to 18 decimals (see [`read_usdc_balance`]).
+pub fn can_afford(native: U256, usdc: U256, gas_cost: U256, value: U256) -> bool {
+    match native.checked_sub(value) {
+        Some(remaining_native) => remaining_native >= gas_cost || usdc >= gas_cost,
+        // Native balance cannot cover the value transfer; USDC cannot stand in
+        // for it, so the transaction is unaffordable regardless of `usdc`.
+        None => false,
+    }
+}
+
+/// Returns the maximum number of gas units a sender can pay for, mirroring the
+/// component-wise rule of [`can_afford`]: `value` must come out of the native
+/// balance, and gas is paid from whichever single balance — remaining native or
+/// USDC — is larger.
+///
+/// Returns zero when the native balance cannot cover `value` (no amount of gas
+/// makes the transfer executable) or when `gas_price` is zero.
+///
+/// `usdc` must already be scaled to 18 decimals (see [`read_usdc_balance`]).
+pub fn gas_allowance(native: U256, usdc: U256, value: U256, gas_price: U256) -> U256 {
+    let Some(remaining_native) = native.checked_sub(value) else { return U256::ZERO };
+    std::cmp::max(remaining_native, usdc).checked_div(gas_price).unwrap_or_default()
+}
+
+/// Returns the *display* balance reported by `eth_getBalance`:
+/// `max(native_balance, usdc_balance_scaled)`, so wallets holding only USDC
+/// still see a non-zero spendable balance.
+///
+/// This is a display convention only — it is **not** an affordability check.
+/// `max` conflates the two balances, while value transfers can only be paid in
+/// native token and gas in either token: use [`can_afford`] /
+/// [`gas_allowance`] for any decision about whether a transaction can be paid
+/// for.
 pub fn effective_balance(
     state: &dyn StateProvider,
     address: &Address,
@@ -82,6 +115,86 @@ mod tests {
         let a = alloy_primitives::address!("0000000000000000000000000000000000000001");
         let b = alloy_primitives::address!("0000000000000000000000000000000000000002");
         assert_ne!(usdc_balance_storage_key(&a), usdc_balance_storage_key(&b));
+    }
+
+    #[test]
+    fn can_afford_native_only() {
+        // native covers gas + value with room to spare, no USDC
+        assert!(can_afford(U256::from(200), U256::ZERO, U256::from(50), U256::from(100)));
+        // exact boundary: native == gas + value
+        assert!(can_afford(U256::from(150), U256::ZERO, U256::from(50), U256::from(100)));
+        // native one short of gas + value
+        assert!(!can_afford(U256::from(149), U256::ZERO, U256::from(50), U256::from(100)));
+    }
+
+    #[test]
+    fn can_afford_split_balances() {
+        // native covers value exactly, USDC covers gas exactly; neither alone
+        // covers gas + value
+        assert!(can_afford(U256::from(100), U256::from(50), U256::from(50), U256::from(100)));
+        // USDC one short of gas while remaining native is zero
+        assert!(!can_afford(U256::from(100), U256::from(49), U256::from(50), U256::from(100)));
+    }
+
+    #[test]
+    fn can_afford_value_exceeds_native() {
+        // USDC can never pay for the value transfer
+        assert!(!can_afford(U256::from(99), U256::MAX, U256::ZERO, U256::from(100)));
+        assert!(!can_afford(U256::ZERO, U256::MAX, U256::MAX, U256::from(1)));
+    }
+
+    #[test]
+    fn can_afford_gas_cannot_be_split_across_tokens() {
+        // remaining native (40) + USDC (40) would cover gas (50), but gas is
+        // paid from a single token
+        assert!(!can_afford(U256::from(140), U256::from(40), U256::from(50), U256::from(100)));
+    }
+
+    #[test]
+    fn can_afford_usdc_gas_zero_native() {
+        // the common USDC-gas case: no native balance, no value transfer
+        assert!(can_afford(U256::ZERO, U256::from(50), U256::from(50), U256::ZERO));
+        assert!(!can_afford(U256::ZERO, U256::from(49), U256::from(50), U256::ZERO));
+    }
+
+    #[test]
+    fn can_afford_zero_cost() {
+        assert!(can_afford(U256::ZERO, U256::ZERO, U256::ZERO, U256::ZERO));
+    }
+
+    #[test]
+    fn gas_allowance_value_exceeds_native() {
+        assert_eq!(
+            gas_allowance(U256::from(99), U256::MAX, U256::from(100), U256::from(1)),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn gas_allowance_zero_gas_price() {
+        assert_eq!(
+            gas_allowance(U256::from(100), U256::from(100), U256::ZERO, U256::ZERO),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn gas_allowance_uses_larger_of_remaining_native_and_usdc() {
+        // remaining native (100) > usdc (60)
+        assert_eq!(
+            gas_allowance(U256::from(200), U256::from(60), U256::from(100), U256::from(2)),
+            U256::from(50)
+        );
+        // usdc (300) > remaining native (100)
+        assert_eq!(
+            gas_allowance(U256::from(200), U256::from(300), U256::from(100), U256::from(2)),
+            U256::from(150)
+        );
+        // native == value: gas can still be paid in USDC
+        assert_eq!(
+            gas_allowance(U256::from(100), U256::from(300), U256::from(100), U256::from(2)),
+            U256::from(150)
+        );
     }
 
     /// Replicates the seismic-revm `erc_address_storage` computation byte-for-byte

--- a/crates/seismic/txpool/src/validator.rs
+++ b/crates/seismic/txpool/src/validator.rs
@@ -134,25 +134,27 @@ where
                     }
                 }
 
-                // Compute the effective balance: max(native, usdc_scaled).
-                // Gas on Seismic can be paid in either native token or USDC, so
-                // we consider both when deciding pool admission.
+                // Gas on Seismic can be paid in native token or USDC, but the
+                // transferred value always comes out of the native balance, so
+                // affordability is checked component-wise (see `usdc::can_afford`).
                 let sender = *valid_tx.transaction().sender_ref();
                 let cost = *valid_tx.transaction().cost();
-                let (eff_balance, usdc_raw) = match self.inner.client().latest() {
-                    Ok(state) => {
-                        let usdc = crate::usdc::read_usdc_balance(&*state, &sender);
-                        (std::cmp::max(balance, usdc), usdc)
-                    }
-                    // If we can't read state, fall back to native balance only.
+                let value = valid_tx.transaction().value();
+                // `cost` is gas + blob + value, so stripping value leaves the
+                // maximum gas (incl. blob) cost.
+                let gas_cost = cost.saturating_sub(value);
+                let usdc = match self.inner.client().latest() {
+                    Ok(state) => crate::usdc::read_usdc_balance(&*state, &sender),
+                    // If we can't read state, fall back to native balance only:
+                    // usdc = 0 degrades `can_afford` to `native >= cost`.
                     Err(err) => {
                         tracing::warn!(
                             target: "seismic::txpool",
                             %err,
                             %sender,
-                            "failed to read state for USDC balance check"
+                            "failed to read state for USDC balance check, defaulting to zero"
                         );
-                        (balance, U256::ZERO)
+                        U256::ZERO
                     }
                 };
 
@@ -161,33 +163,48 @@ where
                     %sender,
                     tx_hash = %valid_tx.hash(),
                     native_balance = %balance,
-                    usdc_scaled_balance = %usdc_raw,
-                    effective_balance = %eff_balance,
-                    cost = %cost,
-                    "seismic validator effective balance check"
+                    usdc_scaled_balance = %usdc,
+                    gas_cost = %gas_cost,
+                    value = %value,
+                    "seismic validator affordability check"
                 );
 
-                // Reject if the sender cannot afford the transaction with either token.
-                if cost > eff_balance {
+                if !crate::usdc::can_afford(balance, usdc, gas_cost, value) {
                     tracing::debug!(
                         target: "seismic::txpool",
                         %sender,
                         tx_hash = %valid_tx.hash(),
-                        effective_balance = %eff_balance,
-                        cost = %cost,
-                        "rejecting tx: effective balance insufficient for cost"
+                        native_balance = %balance,
+                        usdc_scaled_balance = %usdc,
+                        gas_cost = %gas_cost,
+                        value = %value,
+                        "rejecting tx: balances insufficient for gas cost and value"
                     );
+                    // The error carries a single got/expected pair, so report the
+                    // native-token shortfall: `got` is the native balance, `expected`
+                    // the minimum native balance that would make the tx affordable
+                    // given the current USDC balance — just the value if USDC covers
+                    // gas, the full cost otherwise.
+                    let expected = if usdc >= gas_cost { value } else { cost };
                     return TransactionValidationOutcome::Invalid(
                         valid_tx.into_transaction(),
                         InvalidTransactionError::InsufficientFunds(
-                            GotExpected { got: eff_balance, expected: cost }.into(),
+                            GotExpected { got: balance, expected }.into(),
                         )
                         .into(),
                     );
                 }
 
                 TransactionValidationOutcome::Valid {
-                    balance: eff_balance,
+                    // The pool tracks one balance scalar per sender, so the
+                    // component-wise rule isn't expressible. Report native + usdc:
+                    // a sound upper bound (`can_afford ⟹ cost ≤ native + usdc`), so
+                    // any admitted tx also clears the pool's `cost ≤ balance`
+                    // promotion check instead of stranding in the Queued subpool.
+                    // Over-approximates across multiple txs from one sender, but
+                    // block building is the final affordability gate. Keep in sync
+                    // with `SeismicBalanceHook` (maintain.rs).
+                    balance: balance.saturating_add(usdc),
                     state_nonce,
                     transaction: valid_tx,
                     propagate,
@@ -255,5 +272,165 @@ impl<Client, Tx> SeismicTransactionValidator<Client, Tx> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)] // Test code - panic on failure is acceptable
+mod tests {
+    use super::*;
+    use crate::SeismicPooledTransaction;
+    use alloy_consensus::{transaction::Recovered, SignableTransaction, TxLegacy};
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::{Address, Bytes, FlaggedStorage, Signature, TxKind};
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use reth_seismic_chainspec::SEISMIC_MAINNET;
+    use reth_transaction_pool::{
+        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder, TransactionOrigin,
+    };
+
+    const GAS_LIMIT: u64 = 100_000;
+    const GAS_PRICE: u128 = 10_000_000_000; // 10 gwei
+    /// Maximum gas cost of the test transaction: `GAS_LIMIT * GAS_PRICE` = 10^15 wei.
+    const GAS_COST: u128 = GAS_LIMIT as u128 * GAS_PRICE;
+    /// Raw 6-decimal USDC amount that scales to exactly [`GAS_COST`] (scaling is 10^12).
+    const USDC_RAW_GAS_COST: u128 = GAS_COST / 1_000_000_000_000;
+    const ONE_ETH: u128 = 1_000_000_000_000_000_000;
+
+    fn sender() -> Address {
+        Address::with_last_byte(0x42)
+    }
+
+    /// Validates a legacy transfer of `value` against a mock state where the
+    /// sender holds `native` wei and `usdc_raw` 6-decimal USDC units.
+    ///
+    /// Uses a legacy (non-Seismic-type) transaction so the affordability check
+    /// is exercised without needing a recent-block-hash cache entry.
+    async fn validate_with(
+        native: U256,
+        usdc_raw: U256,
+        value: U256,
+    ) -> TransactionValidationOutcome<SeismicPooledTransaction> {
+        let sender = sender();
+        let client = MockEthProvider::default().with_chain_spec(SEISMIC_MAINNET.clone());
+        client.add_account(sender, ExtendedAccount::new(0, native));
+        client.add_account(
+            crate::usdc::USDC_CONTRACT,
+            ExtendedAccount::new(0, U256::ZERO).extend_storage([(
+                crate::usdc::usdc_balance_storage_key(&sender),
+                FlaggedStorage::public(usdc_raw),
+            )]),
+        );
+
+        // Mirror the production pool wiring: the inner Ethereum validator runs
+        // with its native balance check disabled, making the seismic validator
+        // the sole affordability gate.
+        let eth_validator = EthTransactionValidatorBuilder::new(client)
+            .no_shanghai()
+            .no_cancun()
+            .disable_balance_check()
+            .build(InMemoryBlobStore::default());
+        let validator = SeismicTransactionValidator::new(eth_validator);
+
+        let tx = TxLegacy {
+            chain_id: Some(5123),
+            nonce: 0,
+            gas_price: GAS_PRICE,
+            gas_limit: GAS_LIMIT,
+            to: TxKind::Call(Address::with_last_byte(0x43)),
+            value,
+            input: Bytes::new(),
+        };
+        // The validator never recovers the signer (it trusts `Recovered`), so a
+        // dummy signature is sufficient.
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let signed: SeismicTransactionSigned =
+            SignableTransaction::into_signed(tx, signature).into();
+        let recovered = Recovered::new_unchecked(signed, sender);
+        let encoded_length = recovered.encode_2718_len();
+        let pooled = SeismicPooledTransaction::new(recovered, encoded_length);
+
+        validator.validate_transaction(TransactionOrigin::External, pooled).await
+    }
+
+    /// Asserts the outcome is an `InsufficientFunds` rejection and returns the
+    /// reported `(got, expected)` balances.
+    fn expect_insufficient_funds(
+        outcome: TransactionValidationOutcome<SeismicPooledTransaction>,
+    ) -> (U256, U256) {
+        match outcome {
+            TransactionValidationOutcome::Invalid(
+                _,
+                InvalidPoolTransactionError::Consensus(InvalidTransactionError::InsufficientFunds(
+                    err,
+                )),
+            ) => (err.got, err.expected),
+            other => panic!("expected InsufficientFunds rejection, got: {other:?}"),
+        }
+    }
+
+    /// Native covers the value exactly and USDC covers gas exactly. Neither
+    /// balance alone covers gas + value, but component-wise the tx is payable.
+    #[tokio::test]
+    async fn accepts_when_native_covers_value_and_usdc_covers_gas() {
+        let outcome =
+            validate_with(U256::from(ONE_ETH), U256::from(USDC_RAW_GAS_COST), U256::from(ONE_ETH))
+                .await;
+        match outcome {
+            TransactionValidationOutcome::Valid { balance, .. } => {
+                // pool-tracked scalar is native + usdc_scaled (a sound upper bound
+                // on cost; see the `Valid` arm in the validator)
+                assert_eq!(balance, U256::from(ONE_ETH) + U256::from(GAS_COST));
+            }
+            other => panic!("expected Valid outcome, got: {other:?}"),
+        }
+    }
+
+    /// USDC alone covers gas + value, but the value transfer can only be paid
+    /// in native token: the tx could never execute and must be rejected.
+    #[tokio::test]
+    async fn rejects_when_usdc_covers_cost_but_native_below_value() {
+        let native = U256::from(ONE_ETH - 1);
+        // 2 ETH worth of USDC (raw 6-decimal units), well above gas + value
+        let usdc_raw = U256::from(2 * ONE_ETH / 1_000_000_000_000);
+        let outcome = validate_with(native, usdc_raw, U256::from(ONE_ETH)).await;
+        let (got, expected) = expect_insufficient_funds(outcome);
+        assert_eq!(got, native);
+        // USDC covers gas, so the native balance only needs to cover the value
+        assert_eq!(expected, U256::from(ONE_ETH));
+    }
+
+    /// Native alone covers gas + value with no USDC at all.
+    #[tokio::test]
+    async fn accepts_when_native_covers_cost_without_usdc() {
+        let outcome = validate_with(U256::from(2 * ONE_ETH), U256::ZERO, U256::from(ONE_ETH)).await;
+        assert!(
+            matches!(outcome, TransactionValidationOutcome::Valid { .. }),
+            "expected Valid outcome, got: {outcome:?}"
+        );
+    }
+
+    /// Native covers the value but nothing more, and USDC is one raw unit short
+    /// of the gas cost: unaffordable in every combination.
+    #[tokio::test]
+    async fn rejects_when_neither_balance_sufficient() {
+        let native = U256::from(ONE_ETH);
+        let usdc_raw = U256::from(USDC_RAW_GAS_COST - 1);
+        let outcome = validate_with(native, usdc_raw, U256::from(ONE_ETH)).await;
+        let (got, expected) = expect_insufficient_funds(outcome);
+        assert_eq!(got, native);
+        // USDC cannot cover gas, so native would need to cover gas + value
+        assert_eq!(expected, U256::from(ONE_ETH + GAS_COST));
+    }
+
+    /// The common USDC-gas case: no native balance, no value transfer, USDC
+    /// covering exactly the gas cost.
+    #[tokio::test]
+    async fn accepts_usdc_gas_only_with_zero_native() {
+        let outcome = validate_with(U256::ZERO, U256::from(USDC_RAW_GAS_COST), U256::ZERO).await;
+        assert!(
+            matches!(outcome, TransactionValidationOutcome::Valid { .. }),
+            "expected Valid outcome, got: {outcome:?}"
+        );
     }
 }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -96,7 +96,9 @@ impl LocalTransactionBackupConfig {
 /// Hook to transform changed accounts before they are passed to the pool.
 ///
 /// This is used by Seismic to augment native balances with USDC balances so that
-/// the pool can make accurate demotion decisions for accounts paying gas in USDC.
+/// the pool can make accurate promote/demote decisions for accounts paying gas in
+/// USDC. It runs in the maintenance loop on new blocks/reorgs and does not affect
+/// transaction validation/admission.
 pub trait ChangedAccountsHook: Send + Sync + 'static {
     /// Transforms the changed accounts list in place.  Implementations may read
     /// additional state (e.g. ERC-20 storage) and adjust the `balance` field of
@@ -136,7 +138,9 @@ where
 }
 
 /// Like [`maintain_transaction_pool_future`] but accepts a [`ChangedAccountsHook`]
-/// that can transform account balances before the pool processes them.
+/// that can transform the changed-account balances applied on new blocks and reorgs.
+/// These feed the pool's promote/demote between subpools — not the transaction
+/// validation path.
 pub fn maintain_transaction_pool_future_with_hook<N, Client, P, St, Tasks, H>(
     client: Client,
     pool: P,
@@ -187,7 +191,9 @@ pub async fn maintain_transaction_pool<N, Client, P, St, Tasks>(
 }
 
 /// Like [`maintain_transaction_pool`] but accepts a [`ChangedAccountsHook`] that
-/// can transform account balances before the pool processes them.
+/// can transform the changed-account balances applied on new blocks and reorgs.
+/// These feed the pool's promote/demote between subpools — not the transaction
+/// validation path.
 pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
     client: Client,
     pool: P,


### PR DESCRIPTION
Fixes Veridise-1206: Account inspection RPCs return native balance instead of Seismic effective balance

Built on top of https://github.com/SeismicSystems/seismic-reth/pull/411 since we use its `effective_balance` function. Should be merged into `veridise-audit` branch after that one is merged.

The account-surface RPCs split into two contracts, and the balance each reports should follow that split:
- Spendability view ("what can this account spend"): eth_getBalance and eth_getAccountInfo. Wallet-facing, so they report the effective balance, max(native, usdc_scaled).
- Committed account record: eth_getProof and eth_getAccount. These expose the raw trie leaf, so they report the raw native balance.

eth_getAccountInfo (balance, nonce, code) was inheriting the upstream default and returning the raw native balance, so a USDC-only account showed zero there while eth_getBalance reported it correctly. Override get_account_info in SeismicEthApi to report the effective balance, mirroring the upstream default and swapping only the balance field.

eth_getProof and eth_getAccount deliberately stay native:
- eth_getProof returns a Merkle proof against the state root; the balance is part of the proven account leaf, so a synthetic value would make the proof unverifiable (the leaf would no longer hash to the proven path).
- eth_getAccount mirrors the raw trie record (it also returns storage_root and code_hash) and is kept consistent with eth_getProof, so the two raw-state endpoints never disagree with each other or with the state root. Swapping only its balance would leave the record self-inconsistent with its own storage_root/code_hash.

The native-vs-effective divide is documented on the override so future account-surface endpoints follow it deliberately rather than by accident.