### PR TITLE
chore(deps): bump seismic-revm to the merged usdc-as-gas commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10422,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10440,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10451,7 +10451,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10467,7 +10467,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10495,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "auto_impl",
  "either",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "auto_impl",
  "either",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10579,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10614,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=2861f865d2b9249ebb0da4946be5052ec8ab41a0#2861f865d2b9249ebb0da4946be5052ec8ab41a0"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f9c1c8ae0de71c3c2d4cf260c58d0332091f8785#f9c1c8ae0de71c3c2d4cf260c58d0332091f8785"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -768,18 +768,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "2861f865d2b9249ebb0da4946be5052ec8ab41a0" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f9c1c8ae0de71c3c2d4cf260c58d0332091f8785" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 


### PR DESCRIPTION
reth has pinned seismic-revm at 2861f86 -- the tip of the unmerged `usdc-as-gas` branch (SeismicSystems/seismic-revm#222) -- ever since #378 (stablecoin gas) landed. https://github.com/SeismicSystems/seismic-revm/pull/222 should have merged alongside #378 but never did, leaving reth pointing at a dangling branch commit.

https://github.com/SeismicSystems/seismic-revm/pull/222 is now merged, so move the pin to its merge commit f9c1c8a. This is the same usdc-as-gas code reth was already building against, now on merged history -- only the commit reference changes (all 12 revm/seismic-revm crate pins + Cargo.lock). seismic-evm is unchanged (0a75106).