### PR TITLE
fix(codecs): honor Compact remainder contract for seismic txs (Veridise 1172)

### DIFF
--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -519,6 +519,11 @@ impl reth_codecs::Compact for SeismicTransactionSigned {
         buf.as_mut().len() - start
     }
 
+    // `_len` is intentionally unused: the encoding is self-describing — the leading bitflags byte
+    // carries the tx type, signature presence, and zstd bit, and each field decodes itself from
+    // there, so the total byte length is never needed. This matches upstream reth's
+    // `TransactionSigned::from_compact`, which likewise ignores the `len`/identifier arg rather
+    // than treating it as a byte length.
     fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
         use bytes::Buf;
 
@@ -529,6 +534,12 @@ impl reth_codecs::Compact for SeismicTransactionSigned {
         let (signature, buf) = Signature::from_compact(buf, sig_bit);
 
         let zstd_bit = bitflags >> 3;
+        // zstd path: the tx body is decoded from a *separate* decompressed buffer, so we can't
+        // cheaply tell how many bytes of the original (compressed) `buf` the frame occupied. We
+        // therefore return `buf` un-advanced (as if nothing was consumed). This matches upstream
+        // reth's `TransactionSigned`/`OpTypedTransaction` Compact impls, and is sound because a
+        // compressed tx is always the terminal field of its enclosing record, so the returned
+        // remainder is never read.
         let (transaction, buf) = if zstd_bit != 0 {
             if cfg!(feature = "std") {
                 reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {

--- a/crates/storage/codecs/src/alloy/transaction/seismic.rs
+++ b/crates/storage/codecs/src/alloy/transaction/seismic.rs
@@ -108,6 +108,12 @@ impl Compact for TxSeismicElements {
         len
     }
 
+    // `_len` is intentionally unused: the encoding is self-describing — every variable-size field
+    // (`encryption_nonce`, `expires_at_block`) carries its own 1-byte length prefix from
+    // `to_compact` and the rest are fixed-size, so the total byte length is never needed. This
+    // mirrors reth's `Compact` convention, where the `len`/identifier arg is not always a byte
+    // length (e.g. `Signature` repurposes it as a y-parity flag; see
+    // crates/storage/codecs/src/alloy/signature.rs).
     #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
     fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
         // Codec format is fixed by to_compact; malformed data indicates corruption and should panic
@@ -171,7 +177,7 @@ impl Compact for AlloyTxSeismic {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (tx, _) = TxSeismic::from_compact(buf, len);
+        let (tx, buf) = TxSeismic::from_compact(buf, len);
 
         let alloy_tx = Self {
             chain_id: tx.chain_id,
@@ -490,5 +496,90 @@ mod tests {
             tx.seismic_elements.signed_read,
             decoded_tx.seismic_elements.signed_read
         );
+    }
+}
+
+#[cfg(test)]
+mod compact_remainder_tests {
+    use super::*;
+    use alloy_primitives::hex;
+    use proptest::prelude::*;
+    use proptest_arbitrary_interop::arb;
+    use seismic_enclave::secp256k1::PublicKey;
+
+    fn sample_tx(input: &'static [u8]) -> AlloyTxSeismic {
+        AlloyTxSeismic {
+            chain_id: 1,
+            nonce: 1,
+            gas_price: 1,
+            gas_limit: 1,
+            to: TxKind::Create,
+            value: U256::from(1u64),
+            seismic_elements: TxSeismicElements {
+                encryption_pubkey: PublicKey::from_slice(
+                    &hex::decode(
+                        "02d211b6b0a191b9469bb3674e9c609f453d3801c3e3fd7e0bb00c6cc1e1d941df",
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+                encryption_nonce: U96::from(123u64),
+                message_version: 0,
+                recent_block_hash: alloy_primitives::B256::ZERO,
+                expires_at_block: 1,
+                signed_read: false,
+            },
+            authorization_list: vec![],
+            input: Bytes::from_static(input),
+        }
+    }
+
+    proptest! {
+        // `AlloyTxSeismic::from_compact` must return the buffer advanced past the bytes it
+        // consumed; previously it returned the un-advanced input. Asserting an empty remainder
+        // is the regression guard.
+        #[test]
+        fn alloy_tx_seismic_consumes_buffer(tx in arb::<AlloyTxSeismic>()) {
+            let mut buf = vec![];
+            let len = tx.to_compact(&mut buf);
+            let (decoded, remainder) = AlloyTxSeismic::from_compact(&buf, len);
+            prop_assert_eq!(&tx, &decoded);
+            prop_assert!(remainder.is_empty(), "left {} unconsumed bytes", remainder.len());
+        }
+
+        #[test]
+        fn tx_seismic_elements_consumes_buffer(elements in arb::<TxSeismicElements>()) {
+            let mut buf = vec![];
+            let len = elements.to_compact(&mut buf);
+            let (decoded, remainder) = TxSeismicElements::from_compact(&buf, len);
+            prop_assert_eq!(&elements, &decoded);
+            prop_assert!(remainder.is_empty(), "left {} unconsumed bytes", remainder.len());
+        }
+    }
+
+    // Roundtrip a Seismic envelope through the non-zstd path (input < 32 bytes) and assert the
+    // whole buffer is consumed — exercises `AlloyTxSeismic::from_compact` via the envelope decoder.
+    #[test]
+    fn seismic_envelope_consumes_buffer() {
+        let signature = Signature::new(
+            alloy_primitives::b256!(
+                "0x1fd474b1f9404c0c5df43b7620119ffbc3a1c3f942c73b6e14e9f55255ed9b1d"
+            )
+            .into(),
+            alloy_primitives::b256!(
+                "0x29aca24813279a901ec13b5f7bb53385fa1fc627b946592221417ff74a49600d"
+            )
+            .into(),
+            false,
+        );
+        let envelope =
+            SeismicTxEnvelope::Seismic(Signed::new_unhashed(sample_tx(&[0x24]), signature));
+
+        let mut buf = BytesMut::new();
+        let len = Compact::to_compact(&envelope, &mut buf);
+        let (decoded, remainder) = <SeismicTxEnvelope as Compact>::from_compact(&buf, len);
+
+        assert_eq!(envelope, decoded);
+        assert!(remainder.is_empty(), "left {} unconsumed bytes", remainder.len());
     }
 }


### PR DESCRIPTION
The audit (1172.12, 1172.13) flagged the seismic `Compact::from_compact` impls for two deviations from the trait contract: returning the wrong remainder slice, and ignoring the `len` parameter. One is a genuine bug; the rest match upstream reth convention and are documented, not changed.

Fix (1172.13): `AlloyTxSeismic::from_compact` discarded the remainder from the inner `TxSeismic::from_compact` and returned the original, un-advanced `buf` — claiming it consumed zero bytes. It now forwards the advanced remainder. The bug was latent only because a `TxSeismic` is the terminal field in every enclosing decoder, so nothing read the bad remainder. Encoding is untouched, so there is no stored-data migration.

Docs (1172.12): both `TxSeismicElements::from_compact` and `SeismicTransactionSigned::from_compact` ignore the `len` argument. This is intentional, not a defect: their encodings are self-describing (per-field length prefixes / a leading bitflags byte), and reth's `Compact` deliberately overloads `len` as a flag/identifier rather than a strict byte length elsewhere too (e.g. `Signature` carries y-parity in it). Added comments stating the deviation matches upstream convention.

Why we don't advance `buf` in the zstd branch (the audit suggested we should): the compressed body is decoded from a *separate* decompressed buffer, so the number of compressed input bytes the frame occupied is not cheaply recoverable. We deliberately return `buf` un-advanced, matching upstream reth's `TransactionSigned`/`OpTypedTransaction` impls. It is sound because a compressed tx is always the terminal field of its record, so the returned remainder is never read. Documented in place rather than "fixed".

Tests: proptest roundtrips asserting an empty remainder for `AlloyTxSeismic` and `TxSeismicElements`, plus a `SeismicTxEnvelope` roundtrip through the non-zstd path — regression guards for 1172.13.