### PR TITLE
fix(enclave): unify EnclaveArgs defaults and remove dead NodeConfig field (Veridise 1172)

### DIFF
--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -172,7 +172,6 @@ where
 
         // set up node config
         let mut node_config = NodeConfig {
-            enclave: reth_node_core::args::EnclaveArgs::default(),
             datadir,
             config,
             chain,

--- a/crates/node/core/src/args/enclave.rs
+++ b/crates/node/core/src/args/enclave.rs
@@ -17,8 +17,9 @@ pub struct EnclaveArgs {
     #[arg(long = "enclave.endpoint-port", default_value_t = ENCLAVE_DEFAULT_ENDPOINT_PORT)]
     pub enclave_server_port: u16,
 
-    /// How many failures to tolerate before we panic
-    #[arg(long = "enclave.retries", default_value_t = 0)]
+    /// How many boot-time fetch failures to tolerate before we panic.
+    /// Total attempts = `retries` + 1 (one initial attempt plus `retries` re-attempts).
+    #[arg(long = "enclave.retries", default_value_t = 5)]
     pub retries: u32,
 
     /// How many seconds to pause between retries

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     args::{
-        DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EnclaveArgs, EngineArgs, NetworkArgs,
-        PayloadBuilderArgs, PruningArgs, RpcServerArgs, TxPoolArgs,
+        DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
+        PruningArgs, RpcServerArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -153,8 +153,6 @@ pub struct NodeConfig<ChainSpec> {
     /// All engine related arguments
     pub engine: EngineArgs,
 
-    /// All enclave related arguments
-    pub enclave: EnclaveArgs,
     /// All ERA import related arguments with --era prefix
     pub era: EraArgs,
 }
@@ -186,7 +184,6 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             pruning: PruningArgs::default(),
             datadir: DatadirArgs::default(),
             engine: EngineArgs::default(),
-            enclave: EnclaveArgs::default(),
             era: EraArgs::default(),
         }
     }
@@ -284,12 +281,6 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
     /// Set the dev args for the node
     pub const fn with_dev(mut self, dev: DevArgs) -> Self {
         self.dev = dev;
-        self
-    }
-
-    /// Set the enclave args for the node
-    pub const fn with_enclave(mut self, enclave: EnclaveArgs) -> Self {
-        self.enclave = enclave;
         self
     }
 
@@ -499,7 +490,6 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             dev: self.dev,
             pruning: self.pruning,
             engine: self.engine,
-            enclave: self.enclave,
             era: self.era,
         }
     }
@@ -540,7 +530,6 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             pruning: self.pruning.clone(),
             datadir: self.datadir.clone(),
             engine: self.engine.clone(),
-            enclave: self.enclave.clone(),
             era: self.era.clone(),
         }
     }

--- a/crates/seismic/node/src/enclave.rs
+++ b/crates/seismic/node/src/enclave.rs
@@ -20,6 +20,9 @@ fn build_enclave_client(config: &EnclaveArgs) -> HttpClient {
 /// Boot the enclave (or mock server) and fetch purpose keys.
 /// This must be called before building the node components.
 /// Panics if the enclave cannot be booted or purpose keys cannot be fetched.
+///
+/// Total fetch attempts = `config.retries` + 1 (one initial attempt plus `retries`
+/// re-attempts); the `while failures <= config.retries` loop encodes this directly.
 #[allow(clippy::expect_used)] // Intentional panic on startup failure - enclave is required
 #[allow(clippy::panic)] // Intentional panic on fetching keys failure - enclave keys are required
 pub async fn boot_enclave_and_fetch_keys<T>(config: &T) -> GetPurposeKeysResponse


### PR DESCRIPTION
Addresses Veridise audit finding 1172, items 5, 8, and 9.

Item 5 — default mismatch: the clap `--enclave.retries` default (0) disagreed with the `Default for EnclaveArgs` impl (5). Align both on 5; the field exists for boot resilience, so the higher value is the intended behavior. Retries are lazy (they only sleep on a failed fetch), so a healthy enclave still boots on the first attempt. This is a small behavioral change for the default CLI path, which previously performed a single attempt with no retries.

Item 8 — retry loop bound (disputed, doc-only): the `while failures <= retries` loop is correct. It performs one initial attempt plus `retries` re-attempts (total = retries + 1), the conventional meaning of "retries". The suggested `<` would make retries = 0 perform zero attempts and break boot. Documented the semantics on the field and on `boot_enclave_and_fetch_keys`; the comparison is left unchanged.

Item 9 — dead NodeConfig.enclave field: remove `NodeConfig.enclave` and its `with_enclave` setter. The field was only ever set to `EnclaveArgs::default()` and never read — the enclave boot path consumes the parsed CLI args directly via `AsRef<EnclaveArgs>` in both the node and stage commands. The field was left behind by #289 when the `--enclave.*` flags moved to the top-level CLI, becoming a decoy that looked like config but always held defaults: exactly the "unsafe to rely on" hazard the finding flagged. Operator-facing flags are unchanged.