### PR TITLE
chore(seismic): drop dead decrypt arm, bump evm dep (Veridise 1172.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=0a751067fa55afc762e64c919c4443eea72546ca#0a751067fa55afc762e64c919c4443eea72546ca"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190#41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=0a751067fa55afc762e64c919c4443eea72546ca#0a751067fa55afc762e64c919c4443eea72546ca"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190#41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190#41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e844531f59f6821482984731b570323601e32eb4#e844531f59f6821482984731b570323601e32eb4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190#41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e844531f59f6821482984731b570323601e32eb4#e844531f59f6821482984731b570323601e32eb4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2251,7 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4110,7 +4110,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6577,7 +6577,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6614,7 +6614,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -12619,7 +12619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -13141,7 +13141,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,5 +792,7 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c1ce53389ad2bf9bd04c15f4924abe77677395b6" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "0a751067fa55afc762e64c919c4443eea72546ca" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "0a751067fa55afc762e64c919c4443eea72546ca" }
+# TODO: temporarily pointing to https://github.com/SeismicSystems/seismic-evm/pull/54
+# Re-pin to the merged commit on `seismic` once that PR lands.
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,7 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "c1ce53389ad2bf9bd04c15f4924abe77677395b6" }
 
 # evm
-# TODO: temporarily pointing to https://github.com/SeismicSystems/seismic-evm/pull/54
-# Re-pin to the merged commit on `seismic` once that PR lands.
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "41d2a9165cdb00f22c3e8a7c11c823e0b8cf8190" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e844531f59f6821482984731b570323601e32eb4" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e844531f59f6821482984731b570323601e32eb4" }

--- a/crates/errors/src/error.rs
+++ b/crates/errors/src/error.rs
@@ -61,8 +61,8 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 64);
-    static_assert_size!(BlockExecutionError, 64);
+    static_assert_size!(RethError, 56);
+    static_assert_size!(BlockExecutionError, 56);
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 32);
     static_assert_size!(ProviderError, 48);

--- a/crates/seismic/payload/src/builder.rs
+++ b/crates/seismic/payload/src/builder.rs
@@ -28,7 +28,6 @@ use revm::context_interface::Block as _;
 use std::sync::Arc;
 use tracing::{debug, trace, warn};
 
-use reth_evm::execute::InternalBlockExecutionError;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 
 type BestTransactionsIter<Pool> = Box<
@@ -222,19 +221,11 @@ where
                 }
                 continue
             }
-            Err(BlockExecutionError::Internal(
-                InternalBlockExecutionError::FailedToDecryptSeismicTx(error),
-            )) => {
-                trace!(target: "payload_builder", %error, ?tx, "skipping seismic tx with wrong encryption");
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    InvalidPoolTransactionError::Consensus(InvalidTransactionError::SeismicTx(
-                        "failed to decrypt seismic transaction".to_string(),
-                    )),
-                );
-                continue
-            }
-            // this is an error that we should treat as fatal for this attempt
+            // Any other execution error aborts this payload attempt. The one recoverable case is
+            // an individually invalid tx (bad nonce, or a stale/expired seismic tx — the executor
+            // reports both as BlockValidationError::InvalidTx), which is skipped above. Reaching
+            // here means a genuine EVM / provider / internal failure, so we abort rather than seal
+            // a block built on incomplete or incorrect state.
             Err(err) => return Err(PayloadBuilderError::evm(err)),
         };
 


### PR DESCRIPTION
Remove the payload builder's match arm for InternalBlockExecutionError::FailedToDecryptSeismicTx. The variant is never constructed — decryption runs in the block executor, which handles a decrypt failure inline as a charged no-op (the DecryptionFailed path) — so the arm is unreachable and the catch-all already covers any future construction.

And more importantly, bumps alloy-evm/alloy-seismic-evm to the seismic-evm commit that removes that variant and reclassifies block-level freshness failures as BlockValidationError::InvalidTx (SeismicSystems/seismic-evm#54); this fixes a real bug: stale/expired seismic txs are now skipped by the existing InvalidTx arm instead of aborting the block.