### PR TITLE
chore(seismic): misc audit cleanups (Veridise 1172.{2,3,4,6,11})

### DIFF
--- a/crates/seismic/chainspec/src/lib.rs
+++ b/crates/seismic/chainspec/src/lib.rs
@@ -18,6 +18,20 @@ use reth_chainspec::{make_genesis_header, ChainSpec};
 use reth_primitives_traits::{sync::LazyLock, SealedHeader};
 use reth_seismic_forks::{SEISMIC_DEV_HARDFORKS, SEISMIC_MAINNET_HARDFORKS};
 
+/// Normalizes a parsed genesis so all Seismic specs derive their config from one place:
+/// scales the JSON (seconds) timestamp to milliseconds when internal timestamps are in ms,
+/// and enables DAO-fork support.
+fn normalize_genesis(mut genesis: Genesis) -> Genesis {
+    // Genesis JSON timestamps are in seconds, but when timestamp-in-seconds feature is disabled,
+    // we store timestamps internally as milliseconds
+    #[cfg(not(feature = "timestamp-in-seconds"))]
+    {
+        genesis.timestamp *= 1000;
+    }
+    genesis.config.dao_fork_support = true;
+    genesis
+}
+
 /// Genesis hash for the Seismic mainnet
 /// Calculated by rlp encoding the genesis header and hashing it
 pub const SEISMIC_MAINNET_GENESIS_HASH: B256 =
@@ -36,15 +50,9 @@ pub const SEISMIC_DEV_GENESIS_HASH: B256 =
 /// Indicates a build error, not a runtime issue.
 #[allow(clippy::expect_used)] // Documented panic - genesis deserialization is required
 pub static SEISMIC_DEV: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
-    let mut genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
+    let genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
         .expect("FATAL: Can't deserialize Dev testnet genesis json");
-
-    // Genesis JSON timestamps are in seconds, but when timestamp-in-seconds feature is disabled,
-    // we store timestamps internally as milliseconds
-    #[cfg(not(feature = "timestamp-in-seconds"))]
-    {
-        genesis.timestamp *= 1000;
-    }
+    let genesis = normalize_genesis(genesis);
 
     let hardforks = SEISMIC_DEV_HARDFORKS.clone();
     ChainSpec {
@@ -69,15 +77,9 @@ pub static SEISMIC_DEV: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
 /// Indicates a build error, not a runtime issue.
 #[allow(clippy::expect_used)] // Documented panic - genesis deserialization is required
 pub static SEISMIC_DEV_OLD: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
-    let mut genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
+    let genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/dev.json"))
         .expect("FATAL: Can't deserialize Dev testnet genesis json");
-
-    // Genesis JSON timestamps are in seconds, but when timestamp-in-seconds feature is disabled,
-    // we store timestamps internally as milliseconds
-    #[cfg(not(feature = "timestamp-in-seconds"))]
-    {
-        genesis.timestamp *= 1000;
-    }
+    let genesis = normalize_genesis(genesis);
 
     let hardforks = SEISMIC_DEV_HARDFORKS.clone();
     ChainSpec {
@@ -101,18 +103,12 @@ pub static SEISMIC_DEV_OLD: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
 /// Indicates a build issue, not a runtime issue.
 #[allow(clippy::expect_used)] // Documented panic - genesis deserialization is required
 pub static SEISMIC_MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
-    let mut genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/mainnet.json"))
+    let genesis: Genesis = serde_json::from_str(include_str!("../res/genesis/mainnet.json"))
         .expect("FATAL: Can't deserialize Mainnet genesis json"); //
-
-    // Genesis JSON timestamps are in seconds, but when timestamp-in-seconds feature is disabled,
-    // we store timestamps internally as milliseconds
-    #[cfg(not(feature = "timestamp-in-seconds"))]
-    {
-        genesis.timestamp *= 1000;
-    }
+    let genesis = normalize_genesis(genesis);
 
     let hardforks = SEISMIC_MAINNET_HARDFORKS.clone();
-    let mut spec = ChainSpec {
+    ChainSpec {
         chain: Chain::from_id(5123),
         genesis_header: SealedHeader::new(
             make_genesis_header(&genesis, &hardforks),
@@ -122,9 +118,8 @@ pub static SEISMIC_MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         paris_block_and_final_difficulty: Some((0, U256::from(0))),
         hardforks,
         ..Default::default()
-    };
-    spec.genesis.config.dao_fork_support = true;
-    spec.into()
+    }
+    .into()
 });
 
 /// Returns `true` if the given chain is a seismic chain.

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -123,8 +123,7 @@ impl ConfigureEvm for SeismicEvmConfig {
     }
 
     fn evm_env(&self, header: &Header) -> EvmEnv<SeismicSpecId> {
-        // TODO: use the correct spec id
-        let spec = SeismicSpecId::MERCURY;
+        let spec = revm_spec(self.chain_spec(), header);
 
         // configure evm env based on parent block
         let cfg_env = CfgEnv::new().with_chain_id(self.chain_spec().chain().id()).with_spec(spec);

--- a/crates/seismic/node/src/evm.rs
+++ b/crates/seismic/node/src/evm.rs
@@ -1,8 +1,0 @@
-//! Ethereum EVM support
-
-#[doc(inline)]
-pub use reth_evm::execute::BasicBlockExecutorProvider;
-#[doc(inline)]
-pub use reth_evm_ethereum::execute::EthExecutorProvider;
-#[doc(inline)]
-pub use reth_evm_ethereum::{EthEvm, SeismicEvmConfig};

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -95,7 +95,6 @@ impl SeismicNode {
             .executor(SeismicExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::<SeismicPayloadBuilder>::default())
             .network(SeismicNetworkBuilder::default())
-            .executor(SeismicExecutorBuilder::default())
             .consensus(SeismicConsensusBuilder::default())
     }
 

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -74,15 +74,15 @@ impl SeismicApiServer for SeismicApi {
 
 /// Localhost with port 0 so a free port is used.
 pub const fn test_address() -> SocketAddr {
-    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
 }
 
 /// Seismic `eth_` RPC namespace overrides.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 pub trait EthApiOverride<B: RpcObject> {
-    /// Returns the account and storage values of the specified account including the Merkle-proof.
-    /// This call can be used to verify that the data you are pulling from is not tampered with.
+    /// Signs the given EIP-712 typed structured data for the specified address and returns the
+    /// resulting signature.
     #[method(name = "signTypedData_v4")]
     async fn sign_typed_data_v4(&self, address: Address, data: TypedData) -> RpcResult<String>;
 


### PR DESCRIPTION
Maintainability fixes from the Veridise audit grab-bag. No runtime behavior change except where noted.

- 1172.2: drop duplicate `.executor()` in the node component chain (last-wins, dead call) — node/src/node.rs
- 1172.3: derive evm_env() spec via revm_spec() instead of hardcoding SeismicSpecId::MERCURY, matching next_evm_env()/evm_env_for_payload() (no-op today, parity for the next hardfork) — evm/src/lib.rs
- 1172.4: extract normalize_genesis() so all specs derive timestamp scaling and dao_fork_support from one place; dev specs now also set dao_fork_support = true (genesis hashes unaffected) — chainspec/src/lib.rs
- 1172.6: fix sign_typed_data_v4 doc copy-pasted from get_proof — rpc/src/eth/ext.rs
- 1172.11: test_address() binds LOCALHOST instead of UNSPECIFIED (0.0.0.0) so test servers don't listen on all interfaces — rpc/src/eth/ext.rs

Also delete the dead node/src/evm.rs: not in the module tree and re-exports reth_evm_ethereum, which isn't a dependency of seismic-node.