### PR TITLE
fix(seismic-rpc): require seismic_elements on signed reads (Veridise 1172.7)

### DIFF
--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -156,10 +156,18 @@ where
     match signed_read {
         false => Ok(seismic_tx_request),
         true => {
+            // A signed read must carry seismic_elements: they hold the freshness fields validated
+            // below and the encryption metadata `plaintext_copy` needs to decrypt. Treating them as
+            // optional here would silently skip both checks.
+            let Some(elements) = seismic_tx_request.seismic_elements.as_ref() else {
+                return Err(EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
+                    -32602,
+                    "signed read missing seismic_elements",
+                    None::<String>,
+                ))));
+            };
             // Reject stale or expired signed reads before doing any ECDH work.
-            if let Some(elements) = seismic_tx_request.seismic_elements.as_ref() {
-                validate_seismic_freshness(elements, provider)?;
-            }
+            validate_seismic_freshness(elements, provider)?;
 
             let sender = parse_request_sender(&seismic_tx_request)?;
             let seismic_tx_request = seismic_tx_request
@@ -589,6 +597,24 @@ mod test {
                 .unwrap_err()
                 .to_string();
             assert!(err.contains("recent_block_hash"), "{err}");
+        }
+
+        #[test]
+        fn signed_read_without_seismic_elements_is_rejected() {
+            // A signed read carries its freshness fields + decryption metadata in
+            // `seismic_elements`; if it's absent the request must be rejected outright rather than
+            // silently skipping freshness validation and proceeding to decrypt.
+            use crate::utils::signed_read_to_plaintext_tx;
+            use seismic_enclave::secp256k1::SecretKey;
+
+            let secret_key = SecretKey::from_slice(&[1u8; 32]).unwrap();
+            // Provider is never touched: the missing-elements check fires before any lookup.
+            let provider = MockProvider::default();
+            let request = super::spoofed_request(None);
+
+            let err =
+                signed_read_to_plaintext_tx((request, true), &secret_key, &provider).unwrap_err();
+            assert!(err.to_string().contains("signed read missing seismic_elements"), "{err}");
         }
     }
 }


### PR DESCRIPTION
In signed_read_to_plaintext_tx, make seismic_elements required when signed_read == true: return -32602 (invalid params) if absent, before any provider lookup or ECDH/AES work.

Previously the freshness check sat behind `if let Some(elements)`, so a signed read arriving without elements silently skipped both validate_seismic_freshness (expiry + recent-block-hash replay protection) and decryption — plaintext_copy is a no-op when elements are absent, so the request would be handled as if it were plaintext. This closes a gap in #386 (prevent replayed signed reads): the replay protection it added was reachable only behind that guard, so a signed read without elements bypassed it entirely.

This is defense-in-depth, not a live hole: both signed-read paths (From<TxSeismic>
for the raw-bytes path, decode_712 for the typed-data path) decode a TxSeismic whose seismic_elements field is mandatory, so the request always carries Some today. The change makes that implicit invariant explicit at the boundary and turns a future regression — e.g. a new signed_read = true path that forgets to populate elements — into a loud error instead of a silent security downgrade.

Test: signed_read_without_seismic_elements_is_rejected asserts the rejection fires before the provider is queried (MockProvider is never touched).

## TODO (follow-up, out of scope here)

convert_seismic_call_to_tx_request collapses the SeismicCallRequest enum into a (SeismicTransactionRequest, bool) tuple, which is what makes the invalid (None elements, signed_read = true) state representable in the first place. Returning a sum type instead — e.g. ResolvedCall::SignedRead { request, elements } with non-optional elements — would make this guard unnecessary by construction and drop the bool (which is also redundant with TxSeismicElements::signed_read).