### PR TITLE
fix(seismic-node): disable eth_createAccessList (privacy side channel)

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -398,6 +398,15 @@ where
                     }
                 }
 
+                // `eth_createAccessList` is off for the same reason as the trace namespaces
+                // above: it returns the set of addresses and storage slots a call touches (plus
+                // the call-tree shape, and it honors a caller-supplied `from`), so it is a side
+                // channel on private state — a branch on shielded state touches a different set of
+                // public slots. Unlike `eth_call` there is no signed-read path to encrypt the
+                // result; the touched-slot set *is* the answer, so there is nothing to sanitize.
+                // It lives in the Eth module (which we keep), so we drop just this one method.
+                modules.remove_method_from_configured("eth_createAccessList");
+
                 Ok(())
             })
             .await

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -256,7 +256,7 @@ async fn rpc_test_set_number(
     Ok(())
 }
 
-/// Test estimateGas, createAccessList, legacy call, and no-type call.
+/// Test estimateGas, legacy call, and no-type call.
 async fn rpc_test_gas_and_call_variants(
     client: &jsonrpsee::http_client::HttpClient,
     chain_id: u64,
@@ -364,17 +364,8 @@ async fn rpc_test_gas_and_call_variants(
     println!("eth_estimateGas for plain unsigned is_odd() gas: {:?}", plain_unsigned_result);
     assert!(plain_unsigned_result > U256::ZERO);
 
-    // TODO: should remove this functionality from seismic tx (audit)
-    let _access_list =
-        EthApiClient::<
-            SeismicTransactionRequest,
-            SeismicTransactionSigned,
-            SeismicBlock,
-            SeismicTransactionReceipt,
-            Header,
-        >::create_access_list(client, simulate_tx_request.inner.clone().into(), None, None)
-        .await
-        .unwrap();
+    // NB: eth_createAccessList is intentionally not exercised here — it is disabled on Seismic
+    // as a state-introspection side channel (see node.rs and test_create_access_list_disabled).
 
     let is_odd_tx_request = get_unsigned_legacy_tx_request(
         &wallet.inner,
@@ -1211,40 +1202,6 @@ async fn test_usdc_only_eth_call_signed_bytes() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_usdc_only_eth_create_access_list() -> eyre::Result<()> {
-    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
-    let (contract_addr, recent_block_hash) =
-        rpc_test_deploy_contract(&mut node, &client, chain_id, &wallet).await?;
-    let _ = recent_block_hash;
-
-    let signer = usdc_only_signer();
-    let req = TransactionRequest {
-        from: Some(signer.address()),
-        to: Some(TxKind::Call(contract_addr)),
-        gas_price: Some(20e9 as u128),
-        input: TransactionInput {
-            input: Some(ContractTestContext::get_is_odd_input_plaintext()),
-            data: None,
-        },
-        chain_id: Some(chain_id),
-        ..Default::default()
-    };
-
-    let access_list = EthApiClient::<
-        SeismicTransactionRequest,
-        SeismicTransactionSigned,
-        SeismicBlock,
-        SeismicTransactionReceipt,
-        Header,
-    >::create_access_list(&client, req.into(), None, None)
-    .await
-    .expect("create_access_list must honor USDC balance for caller_gas_allowance");
-
-    assert!(access_list.gas_used > U256::ZERO, "got {:?}", access_list);
-    Ok(())
-}
-
 /// simulateV1 does not route through `caller_gas_allowance`; seismic-revm's caller-deduct charges
 /// in USDC at execution time instead. Locks in that routing.
 #[tokio::test(flavor = "multi_thread")]
@@ -1728,6 +1685,33 @@ async fn test_trace_debug_ots_namespaces_disabled() -> eyre::Result<()> {
     }
 
     // Control: the standard eth namespace is still served.
+    let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
+    assert!(block_number.starts_with("0x"), "unexpected eth_blockNumber response: {block_number}");
+
+    Ok(())
+}
+
+/// `eth_createAccessList` is disabled on Seismic: the returned access list (touched addresses +
+/// storage slots + call-tree shape) is a side channel on private state, and there is no signed-read
+/// path to encrypt it. It is removed from the otherwise-served Eth namespace; see `node.rs`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_access_list_disabled() -> eyre::Result<()> {
+    let (_node, client, _chain_id, _wallet, _tasks) = setup_test_node().await?;
+
+    let result =
+        client.request::<serde_json::Value, _>("eth_createAccessList", rpc_params![]).await;
+    match result {
+        Err(jsonrpsee::core::client::Error::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                jsonrpsee::types::error::ErrorCode::MethodNotFound.code(),
+                "eth_createAccessList must be unregistered, got error: {err}"
+            );
+        }
+        other => panic!("eth_createAccessList must return method-not-found, got: {other:?}"),
+    }
+
+    // Control: a sibling Eth method we do not remove is still served.
     let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
     assert!(block_number.starts_with("0x"), "unexpected eth_blockNumber response: {block_number}");
 


### PR DESCRIPTION
eth_createAccessList was not overridden by EthApiExt, so it fell through to stock reth: given a caller-supplied request (including an arbitrary `from`), it executes the call and returns the set of addresses and storage slots it touches plus the call-tree shape. On a privacy chain that is a metadata side channel on shielded state — a branch on private data touches a different set of public slots — the same family as the trace/debug/ots namespaces disabled in #407. A standing TODO from #281 ("should remove this functionality ... (audit)") already flagged it for removal; this actions it.

Disable it the same way as #407: unregister the method at RPC launch so callers get method-not-found. There is nothing to sanitize — the touched-slot set *is* the result, and unlike eth_call there is no signed-read path to encrypt it. Disabling the helper does not affect sending transactions: an access list is a client-populated tx field, TxSeismic has no access-list field at all, and an on-chain access list would itself publish the touched slots (and gives no benefit for shielded storage, which is flat-gas). The AccessListInspector hooks SLOAD/SSTORE only (not CLOAD/CSTORE), so private slots are not directly enumerated, but the public-slot + call-shape metadata still leaks.

Removes the two tests that exercised it (one already carrying the #281 audit TODO); the caller_gas_allowance coverage they shared is retained by the eth_call and estimateGas USDC tests. Adds test_create_access_list_disabled.