### PR TITLE
fix(net): accept TxSeismic announcements in tx gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8400,6 +8400,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "schnellru",
  "secp256k1 0.30.0",
+ "seismic-alloy-consensus",
  "serde",
  "smallvec",
  "thiserror 2.0.17",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -34,6 +34,9 @@ reth-consensus.workspace = true
 reth-network-peers = { workspace = true, features = ["net"] }
 reth-network-types.workspace = true
 
+# seismic
+seismic-alloy-consensus.workspace = true
+
 # ethereum
 alloy-consensus.workspace = true
 alloy-eips.workspace = true

--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use crate::{
     eth_requests::EthRequestHandler,
     transactions::{
-        config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
+        config::{
+            AnnouncementFilteringPolicy, StrictEthAnnouncementFilter, TransactionPropagationKind,
+        },
         policy::NetworkPolicies,
         TransactionPropagationPolicy, TransactionsManager, TransactionsManagerConfig,
     },
@@ -107,12 +109,36 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
         Eth,
         N,
     > {
+        self.transactions_with_policies(
+            pool,
+            transactions_manager_config,
+            NetworkPolicies::new(propagation_policy, StrictEthAnnouncementFilter::default()),
+        )
+    }
+
+    /// Creates a new [`TransactionsManager`] with the given policy bundle (transaction
+    /// propagation + announcement filtering) and wires it to the network.
+    ///
+    /// Seismic addition: upstream's [`Self::transactions_with_policy`] pins the announcement
+    /// filter to [`StrictEthAnnouncementFilter`], which rejects TxSeismic announcements and
+    /// penalizes the announcing peer. That method is kept untouched (delegating here) so the
+    /// fork stays additive over upstream reth. Upstreaming this would mean generalizing
+    /// `transactions_with_policy` to take a [`NetworkPolicies`] bundle directly, at which
+    /// point this method folds away.
+    pub fn transactions_with_policies<
+        Pool: TransactionPool,
+        P: TransactionPropagationPolicy + Debug,
+        A: AnnouncementFilteringPolicy + Debug,
+    >(
+        self,
+        pool: Pool,
+        transactions_manager_config: TransactionsManagerConfig,
+        policies: NetworkPolicies<P, A>,
+    ) -> NetworkBuilder<TransactionsManager<Pool, N, NetworkPolicies<P, A>>, Eth, N> {
         let Self { mut network, request_handler, .. } = self;
         let (tx, rx) = mpsc::unbounded_channel();
         network.set_transactions(tx);
         let handle = network.handle().clone();
-        let announcement_policy = StrictEthAnnouncementFilter::default();
-        let policies = NetworkPolicies::new(propagation_policy, announcement_policy);
 
         let transactions = TransactionsManager::with_policy(
             handle,

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -1,10 +1,10 @@
 use metrics::Histogram;
 use reth_eth_wire::DisconnectReason;
-use reth_ethereum_primitives::TxType;
 use reth_metrics::{
     metrics::{Counter, Gauge},
     Metrics,
 };
+use seismic_alloy_consensus::SeismicTxType as TxType;
 
 /// Scope for monitoring transactions sent from the manager to the tx manager
 pub(crate) const NETWORK_POOL_TRANSACTIONS_SCOPE: &str = "network.pool.transactions";
@@ -396,6 +396,9 @@ impl TxTypesCounter {
             }
             TxType::Eip7702 => {
                 self.eip7702 += 1;
+            }
+            TxType::Seismic => {
+                self.seismic += 1;
             }
         }
     }

--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -280,6 +280,36 @@ pub type RelaxedEthAnnouncementFilter = TypedRelaxedFilter<TxType>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use seismic_alloy_consensus::{SeismicTxType, SEISMIC_TX_TYPE_ID};
+
+    /// Documents why the Ethereum-typed strict filter must not be used on a Seismic
+    /// network: it rejects TxSeismic announcements and penalizes the announcing peer.
+    #[test]
+    fn strict_eth_filter_rejects_and_penalizes_seismic_tx_type() {
+        let filter = StrictEthAnnouncementFilter::default();
+        assert_eq!(
+            filter.decide_on_announcement(SEISMIC_TX_TYPE_ID, &B256::random(), 100),
+            AnnouncementAcceptance::Reject { penalize_peer: true }
+        );
+    }
+
+    /// Regression test: the Seismic-typed strict filter accepts every Seismic tx type,
+    /// TxSeismic (type 74) included, while still rejecting unknown type bytes.
+    #[test]
+    fn seismic_strict_filter_accepts_seismic_tx_types() {
+        let filter = TypedStrictFilter::<SeismicTxType>::default();
+        for ty in [0x00, 0x01, 0x02, 0x03, 0x04, SEISMIC_TX_TYPE_ID] {
+            assert_eq!(
+                filter.decide_on_announcement(ty, &B256::random(), 100),
+                AnnouncementAcceptance::Accept,
+                "tx type {ty:#04x} must be accepted"
+            );
+        }
+        assert_eq!(
+            filter.decide_on_announcement(0xff, &B256::random(), 100),
+            AnnouncementAcceptance::Reject { penalize_peer: true }
+        );
+    }
 
     #[test]
     fn test_transaction_propagation_mode_from_str() {

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -45,7 +45,7 @@ use reth_eth_wire::{
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, PooledTransactions,
     RequestTxHashes, Transactions, ValidAnnouncementData,
 };
-use reth_ethereum_primitives::{TransactionSigned, TxType};
+use reth_ethereum_primitives::TransactionSigned;
 use reth_metrics::common::mpsc::UnboundedMeteredReceiver;
 use reth_network_api::{
     events::{PeerEvent, SessionInfo},
@@ -64,6 +64,7 @@ use reth_transaction_pool::{
     AddedTransactionOutcome, GetPooledTransactionLimit, PoolTransaction, PropagateKind,
     PropagatedTransactions, TransactionPool, ValidPoolTransaction,
 };
+use seismic_alloy_consensus::SeismicTxType;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     pin::Pin,
@@ -697,7 +698,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives, PBundle: TransactionPolicies>
 
             if is_eth68_message {
                 if let Some((actual_ty_byte, _)) = *metadata_ref_mut {
-                    if let Ok(parsed_tx_type) = TxType::try_from(actual_ty_byte) {
+                    if let Ok(parsed_tx_type) = SeismicTxType::try_from(actual_ty_byte) {
                         tx_types_counter.increase_by_tx_type(parsed_tx_type);
                     }
                 }
@@ -2972,6 +2973,113 @@ mod tests {
         assert!(
             !unexpected_request_received,
             "An unexpected P2P request was received by the mock peer."
+        );
+
+        network_service_handle.abort();
+    }
+
+    /// Regression test for TxSeismic (type 74) gossip: an eth/68 announcement carrying a
+    /// seismic tx type must lead to a `GetPooledTransactions` fetch when the manager runs
+    /// with the Seismic-typed announcement filter. Under the default Ethereum-typed strict
+    /// filter this exact announcement is dropped and the peer penalized (see
+    /// `strict_eth_filter_rejects_and_penalizes_seismic_tx_type` in `config::tests`).
+    #[tokio::test]
+    async fn test_seismic_filter_fetches_announced_seismic_txs() {
+        reth_tracing::init_test_tracing();
+
+        use crate::transactions::config::TypedStrictFilter;
+        use seismic_alloy_consensus::{SeismicTxType, SEISMIC_TX_TYPE_ID};
+
+        type SeismicFilter = TypedStrictFilter<SeismicTxType>;
+
+        let transactions_manager_config = TransactionsManagerConfig::default();
+        let policy_bundle =
+            NetworkPolicies::new(TransactionPropagationKind::default(), SeismicFilter::default());
+
+        let pool = testing_pool();
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let client = NoopProvider::default();
+
+        let network_config = NetworkConfigBuilder::new(secret_key)
+            .listener_port(0)
+            .disable_discovery()
+            .build(client.clone());
+
+        let mut network_manager = NetworkManager::new(network_config).await.unwrap();
+        let (to_tx_manager_tx, from_network_rx) =
+            mpsc::unbounded_channel::<NetworkTransactionEvent<EthNetworkPrimitives>>();
+        network_manager.set_transactions(to_tx_manager_tx);
+        let network_handle = network_manager.handle().clone();
+        let network_service_handle = tokio::spawn(network_manager);
+
+        let mut tx_manager = TransactionsManager::<
+            TestPool,
+            EthNetworkPrimitives,
+            NetworkPolicies<TransactionPropagationKind, SeismicFilter>,
+        >::with_policy(
+            network_handle.clone(),
+            pool.clone(),
+            from_network_rx,
+            transactions_manager_config,
+            policy_bundle,
+        );
+
+        let peer_id = PeerId::random();
+        let eth_version = EthVersion::Eth68;
+        let (mock_peer_metadata, mut mock_session_rx) = new_mock_session(peer_id, eth_version);
+        tx_manager.peers.insert(peer_id, mock_peer_metadata);
+
+        let mut tx_factory = MockTransactionFactory::default();
+        let eip1559_tx: Arc<ValidPoolTransaction<MockTransaction>> =
+            Arc::new(tx_factory.create_eip1559());
+        let eip1559_tx_hash = *eip1559_tx.hash();
+
+        // The announcement path only inspects (type, size, hash) tuples, so a random hash
+        // with the seismic type byte exercises the filter without a full seismic tx.
+        let seismic_tx_hash = B256::random();
+
+        let announcement_msg = NewPooledTransactionHashes::Eth68(NewPooledTransactionHashes68 {
+            types: vec![eip1559_tx.transaction.tx_type(), SEISMIC_TX_TYPE_ID],
+            sizes: vec![eip1559_tx.encoded_length(), 200],
+            hashes: vec![eip1559_tx_hash, seismic_tx_hash],
+        });
+
+        tx_manager.on_new_pooled_transaction_hashes(peer_id, announcement_msg);
+
+        let mut requested_hashes = HashSet::new();
+        // Fetch requests are dispatched while polling the manager; drain until quiescent.
+        for _ in 0..3 {
+            poll_fn(|cx| {
+                let _ = tx_manager.poll_unpin(cx);
+                Poll::Ready(())
+            })
+            .await;
+
+            match tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                mock_session_rx.recv(),
+            )
+            .await
+            {
+                Ok(Some(PeerRequest::GetPooledTransactions { request, response })) => {
+                    let GetPooledTransactions(hashes) = request;
+                    requested_hashes.extend(hashes);
+                    let _ = response.send(Ok(PooledTransactions(vec![])));
+                }
+                Ok(Some(other_request)) => {
+                    panic!("unexpected P2P request: {other_request:?}");
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        assert!(
+            requested_hashes.contains(&seismic_tx_hash),
+            "TxSeismic (type 74) announcement must be fetched, not filtered out. Requested: {requested_hashes:?}"
+        );
+        assert!(
+            requested_hashes.contains(&eip1559_tx_hash),
+            "EIP-1559 announcement must still be fetched. Requested: {requested_hashes:?}"
         );
 
         network_service_handle.abort();

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -16,7 +16,11 @@ use reth_cli_util::get_secret_key;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_exex::ExExContext;
 use reth_network::{
-    transactions::{TransactionPropagationPolicy, TransactionsManagerConfig},
+    transactions::{
+        config::{AnnouncementFilteringPolicy, StrictEthAnnouncementFilter},
+        policy::NetworkPolicies,
+        TransactionPropagationPolicy, TransactionsManagerConfig,
+    },
     NetworkBuilder, NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
     NetworkPrimitives,
 };
@@ -821,8 +825,41 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         Node::Provider: BlockReaderFor<N>,
         Policy: TransactionPropagationPolicy + Debug,
     {
+        self.start_network_with_policies(
+            builder,
+            pool,
+            tx_config,
+            NetworkPolicies::new(propagation_policy, StrictEthAnnouncementFilter::default()),
+        )
+    }
+
+    /// Convenience function to start the network tasks with a full policy bundle
+    /// (transaction propagation + announcement filtering).
+    ///
+    /// Spawns the configured network and associated tasks and returns the [`NetworkHandle`]
+    /// connected to that network.
+    pub fn start_network_with_policies<Pool, N, P, A>(
+        &self,
+        builder: NetworkBuilder<(), (), N>,
+        pool: Pool,
+        tx_config: TransactionsManagerConfig,
+        policies: NetworkPolicies<P, A>,
+    ) -> NetworkHandle<N>
+    where
+        N: NetworkPrimitives,
+        Pool: TransactionPool<
+                Transaction: PoolTransaction<
+                    Consensus = N::BroadcastedTransaction,
+                    Pooled = N::PooledTransaction,
+                >,
+            > + Unpin
+            + 'static,
+        Node::Provider: BlockReaderFor<N>,
+        P: TransactionPropagationPolicy + Debug,
+        A: AnnouncementFilteringPolicy + Debug,
+    {
         let (handle, network, txpool, eth) = builder
-            .transactions_with_policy(pool, tx_config, propagation_policy)
+            .transactions_with_policies(pool, tx_config, policies)
             .request_handler(self.provider().clone())
             .split_with_handle();
 

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -13,7 +13,10 @@ use reth_eth_wire_types::NewBlock;
 use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmFactory, EvmFactoryFor, NextBlockEnvAttributes,
 };
-use reth_network::{NetworkHandle, NetworkPrimitives};
+use reth_network::{
+    transactions::{config::TypedStrictFilter, policy::NetworkPolicies},
+    NetworkHandle, NetworkPrimitives,
+};
 use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, PrimitivesTy, TxTy};
 use reth_node_builder::{
     components::{
@@ -55,7 +58,7 @@ use reth_transaction_pool::{
     CoinbaseTipOrdering, PoolTransaction, TransactionPool, TransactionValidationTaskExecutor,
 };
 use revm::context::TxEnv;
-use seismic_alloy_consensus::SeismicTxEnvelope;
+use seismic_alloy_consensus::{SeismicTxEnvelope, SeismicTxType};
 use std::{sync::Arc, time::SystemTime};
 
 use crate::{purpose_keys::get_purpose_keys, seismic_evm_config};
@@ -693,6 +696,10 @@ where
     }
 }
 
+/// Strict eth/68 announcement filter over [`SeismicTxType`]: accepts every Seismic
+/// transaction type (including `TxSeismic`, type 74) and rejects unknown type bytes.
+pub type SeismicAnnouncementFilter = TypedStrictFilter<SeismicTxType>;
+
 /// A basic ethereum payload service.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct SeismicNetworkBuilder {
@@ -715,7 +722,19 @@ where
         pool: Pool,
     ) -> eyre::Result<NetworkHandle<SeismicNetworkPrimitives>> {
         let network = ctx.network_builder().await?;
-        let handle = ctx.start_network(network, pool);
+        // The default announcement filter only knows the Ethereum tx types, so eth/68
+        // announcements carrying TxSeismic (type 74) would be dropped and the announcing
+        // peer penalized. Filter announcements by SeismicTxType instead.
+        let policies = NetworkPolicies::new(
+            ctx.config().network.tx_propagation_policy,
+            SeismicAnnouncementFilter::default(),
+        );
+        let handle = ctx.start_network_with_policies(
+            network,
+            pool,
+            ctx.config().network.transactions_manager_config(),
+            policies,
+        );
         // info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking
         // initialized");
         Ok(handle)


### PR DESCRIPTION
The TransactionsManager ran with the default StrictEthAnnouncementFilter, which is typed over Ethereum's TxType: an [eth/68](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth68-eip-5793-october-2022) announcement carrying TxSeismic (type 74) was dropped and the announcing peer penalized. That breaks cross-validator tx gossip — a TxSeismic submitted to a non-leader node's RPC only gets included once that node is itself leader. Gossip is safe for TxSeismic: it travels as ciphertext and is only decrypted in-enclave at execution.

## Effect on our Testnet

On our testnet this bug degrades gossip rather than cleanly breaking it, which made it  hard to spot. A TxSeismic submitted to a non-leader node still reaches ~√peers of its neighbors as a full-body broadcast (that path bypasses the announcement filter), but the hash announcements sent to everyone else are silently rejected — so whether a tx gets included promptly depends on whether the rotating leader happened to be in the full-broadcast subset. The failure is also nearly unobservable: both the rejection and the resulting BadAnnouncement penalty are logged at trace level only (net::tx::policy::strict_typed / net::tx), so default-verbosity logs show nothing. Each rejected announcement additionally slashes the announcing peer's reputation by 1/50th of the ban threshold; at our current traffic levels peers accumulate penalties too slowly to actually get banned (since reputation always increases by 1 unit every second), so the cohort stays connected — but on a high-traffic or larger network the same bug is devastating: every seismic-tx announcement chips away at reputation until validators ban and disconnect one another and the gossip mesh collapses.

## Fix

- seismic/node: run the TransactionsManager with SeismicAnnouncementFilter (TypedStrictFilter<SeismicTxType>), which accepts every Seismic tx type and still rejects unknown type bytes.
- net/network: add NetworkBuilder::transactions_with_policies, accepting the full NetworkPolicies bundle (propagation + announcement filtering) instead of only the propagation half.
- node/builder: same pattern one level up via start_network_with_policies.
- net/network metrics: count announced tx types over SeismicTxType so type-74 traffic is counted instead of failing to parse.

## Upstreamability Note

The TransactionsManager is already generic over the announcement-filtering policy, but the builder entry points were not — NetworkBuilder::transactions_with_policy and BuilderContext:: start_network_with_policy both hardcode StrictEthAnnouncementFilter, so the network crate could not be used as-is. Rather than copy-pasting the manager wiring under crates/seismic, we made the entry points generic (the *_with_policies variants), with the existing methods kept untouched and delegating to them. That new surface is chain-agnostic and could and should be upstreamed to paradigmxyz/reth; the fork-local part is then just SeismicAnnouncementFilter and the metrics arm.