### PR TITLE
fix(zellic-audit-may-2026-seismic-std-lib-3.3): reject block overrides on eth_call

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip2930::AccessListResult;
-use alloy_evm::overrides::{apply_block_overrides, apply_state_overrides, OverrideBlockHashes};
+use alloy_evm::overrides::{apply_state_overrides, OverrideBlockHashes};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{
@@ -119,18 +119,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 
-                    if let Some(block_overrides) = block_overrides {
-                        // ensure we don't allow uncapped gas limit per block
-                        if let Some(gas_limit_override) = block_overrides.gas_limit {
-                            if gas_limit_override > evm_env.block_env.gas_limit &&
-                                gas_limit_override > this.call_gas_limit()
-                            {
-                                return Err(
-                                    EthApiError::other(EthSimulateError::GasLimitReached).into()
-                                )
-                            }
-                        }
-                        apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
+                    // Seismic: reject user-supplied block overrides — rewinding
+                    // block.timestamp/number could revive an expired signed read, breaking
+                    // confidentiality.
+                    if block_overrides.is_some() {
+                        return Err(EthApiError::BlockOverrideNotPermitted.into())
                     }
                     if let Some(state_overrides) = state_overrides {
                         apply_state_overrides(state_overrides, &mut db)
@@ -779,8 +772,11 @@ pub trait Call:
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 
-        if let Some(block_overrides) = overrides.block {
-            apply_block_overrides(*block_overrides, db, &mut evm_env.block_env);
+        // Seismic: reject user-supplied block overrides — rewinding block.timestamp/number could
+        // revive an expired signed read, breaking confidentiality. This is the shared chokepoint
+        // for eth_call, eth_callMany, and the trace_/debug_ call variants.
+        if overrides.block.is_some() {
+            return Err(EthApiError::BlockOverrideNotPermitted.into())
         }
         if let Some(state_overrides) = overrides.state {
             apply_state_overrides(state_overrides, db)

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -121,6 +121,12 @@ pub enum EthApiError {
     /// Storage overrides are not permitted (Seismic privacy)
     #[error("storage overrides are not permitted on Seismic (account: {0:?})")]
     StorageOverrideNotPermitted(Address),
+    /// Block overrides are not permitted (Seismic privacy)
+    ///
+    /// A user-supplied block override can rewind `block.timestamp`/`number` and revive an expired
+    /// signed read (e.g. `balanceOfSigned`), so they are rejected on user-facing RPC entrypoints.
+    #[error("block overrides are not permitted on Seismic")]
+    BlockOverrideNotPermitted,
     /// Other internal error
     #[error(transparent)]
     Internal(RethError),
@@ -262,6 +268,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::BothStateAndStateDiffInOverride(_) |
             EthApiError::CodeOverrideNotPermitted(_) |
             EthApiError::StorageOverrideNotPermitted(_) |
+            EthApiError::BlockOverrideNotPermitted |
             EthApiError::InvalidTracerConfig |
             EthApiError::TransactionConversionError |
             EthApiError::InvalidRewardPercentiles |

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -20,7 +20,7 @@ use alloy_primitives::{
 use alloy_provider::{Provider, SendableTx};
 use alloy_rpc_types::{
     state::{AccountOverride, StateOverride},
-    Block, Header, TransactionInput, TransactionRequest,
+    Block, BlockOverrides, Header, TransactionInput, TransactionRequest,
 };
 use alloy_rpc_types_eth::Bundle;
 use alloy_signer_local::PrivateKeySigner;
@@ -1551,6 +1551,110 @@ async fn test_eth_simulate_v1_rejects_storage_override() -> eyre::Result<()> {
             assert!(
                 err_msg.to_lowercase().contains("storage overrides are not permitted"),
                 "Expected storage override rejection error, got: {}",
+                err_msg
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A user-supplied block override on `eth_call` can rewind `block.timestamp`
+/// (`BlockOverrides.time`) below a `balanceOfSigned` expiry and revive an expired signature — a
+/// confidentiality break the seismic-std-lib cannot defend against (Zellic seismic-std-lib finding
+/// 3.3). The node must reject any user-supplied block override. Positive control: the identical
+/// call without overrides succeeds.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_call_rejects_block_override() -> eyre::Result<()> {
+    let (_node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let victim_addr = Address::from_hex("0x0000000000000000000000000000000000001234").unwrap();
+
+    let request: SeismicCallRequest = SeismicTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(wallet.inner.address()),
+            to: Some(TxKind::Call(victim_addr)),
+            gas: Some(1_000_000),
+            chain_id: Some(chain_id),
+            ..Default::default()
+        },
+        seismic_elements: None,
+    }
+    .into();
+
+    // Rewind the block timestamp far into the past.
+    let block_overrides = BlockOverrides { time: Some(1), ..Default::default() };
+
+    let result = EthApiOverrideClient::<Block>::call(
+        &client,
+        request.clone(),
+        None,
+        None,
+        Some(Box::new(block_overrides)),
+    )
+    .await;
+
+    match &result {
+        Ok(output) => panic!(
+            "eth_call with block override should be rejected, but got Ok: 0x{}",
+            hex::encode(output)
+        ),
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.to_lowercase().contains("block overrides are not permitted"),
+                "Expected block override rejection error, got: {}",
+                err_msg
+            );
+        }
+    }
+
+    // Positive control: the same call without block overrides must succeed.
+    let ok = EthApiOverrideClient::<Block>::call(&client, request, None, None, None).await;
+    assert!(ok.is_ok(), "eth_call without overrides should succeed, got: {:?}", ok.err());
+
+    Ok(())
+}
+
+/// `eth_simulateV1` counterpart to [`test_eth_call_rejects_block_override`]: a
+/// `BlockOverrides.time` rewind carried on a simulated block must be rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_simulate_v1_rejects_block_override() -> eyre::Result<()> {
+    let (_node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let victim_addr = Address::from_hex("0x0000000000000000000000000000000000001234").unwrap();
+
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        get_nonce(&client, wallet.inner.address()).await,
+        TxKind::Call(victim_addr),
+        chain_id,
+        ContractTestContext::get_is_odd_input_plaintext(),
+        get_recent_block_hash(&client).await,
+    )
+    .await;
+
+    let block_with_block_override = SimBlock {
+        block_overrides: Some(BlockOverrides { time: Some(1), ..Default::default() }),
+        state_overrides: None,
+        calls: vec![SeismicCallRequest::Bytes(tx_bytes)],
+    };
+
+    let simulate_payload = SimulatePayload::<SeismicCallRequest> {
+        block_state_calls: vec![block_with_block_override],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: false,
+    };
+
+    let result = EthApiOverrideClient::<Block>::simulate_v1(&client, simulate_payload, None).await;
+
+    match &result {
+        Ok(_) => panic!("eth_simulateV1 with block override should be rejected"),
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.to_lowercase().contains("block overrides are not permitted"),
+                "Expected block override rejection error, got: {}",
                 err_msg
             );
         }


### PR DESCRIPTION
## Summary

Closes the **node-half of Zellic seismic-std-lib finding 3.3** (expired `balanceOfSigned` revived via `BlockOverrides.time`) and **finding 3.7b** (node-level RPC integration coverage).

`eth_call` / `eth_callMany` / `eth_simulateV1` applied user-supplied `BlockOverrides` unconditionally. A caller could rewind `block.timestamp` (`BlockOverrides.time`) below a `balanceOfSigned` expiry and revive an expired signed read — a confidentiality break the seismic-std-lib cannot defend against. State/storage/code overrides were already rejected; this mirrors that for block overrides.

## Changes

- **`rpc-eth-types`**: new `EthApiError::BlockOverrideNotPermitted` variant (message `"block overrides are not permitted on Seismic"`), mapped to an invalid-params RPC error — beside the existing `StorageOverrideNotPermitted` / `CodeOverrideNotPermitted`.
- **`rpc-eth-api` (`helpers/call.rs`)**: reject any user-supplied block override at the two user-facing RPC entrypoints:
  - `prepare_call_env` — the shared chokepoint for `eth_call`, `eth_callMany`, and the `trace_`/`debug_` call variants.
  - `simulate_v1` — the per-`SimBlock` override path.
- Dropped the now-unused `apply_block_overrides` import.

**Default policy**: reject *any* user-supplied block override (simplest, matches how storage overrides are fully rejected). Zellic's floor is the `time` field. Pending the #engineering thread — if the team lands on "time/number only", the check can be narrowed to those fields.

## Scope safety

`eth_estimateGas` does **not** consume block overrides (`estimate.rs` operates on `evm_env` directly), so gas estimation is unaffected. Only user-supplied overrides at the public RPC entry are rejected — no internal construction path is touched.

## Test plan (test-first, two commits)

- `test:` commit — e2e in `crates/seismic/node/tests/e2e/integration.rs` asserting a `BlockOverrides { time: <past> }` rewind on `eth_call` and `eth_simulateV1` is rejected with `"block overrides are not permitted"`, plus a positive control (same `eth_call` without overrides succeeds). Verified **failing** on pre-fix code.
- `fix:` commit — implements the rejection; the two new tests pass, and the existing storage/code-override, `estimate_gas`, `call_many`, and usdc e2e tests remain green.

CI: `cargo +nightly fmt --all -- --check` OK; Seismic clippy clean.

## Notes

- Merge with **rebase-and-merge** (not squash) to preserve the `test:` → `fix:` pair.
- The GitBook docs update Zellic requested (`docs/gitbook/reference/rpc-methods/eth-call.md`) lives in the **monorepo** — separate small docs PR, not included here.
- No client/downstream changes (block overrides on `eth_call` aren't a supported Seismic client feature).
