### PR TITLE
feat(rpc): expose enode on seismic_ namespace for devp2p bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9821,6 +9821,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-network-peers",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9821,6 +9821,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-network-api",
  "reth-network-peers",
  "reth-node-api",
  "reth-node-builder",

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -15,7 +15,7 @@ use reth_evm::{
 };
 use reth_network::{
     transactions::{config::TypedStrictFilter, policy::NetworkPolicies},
-    NetworkHandle, NetworkPrimitives,
+    NetworkHandle, NetworkPrimitives, PeersInfo,
 };
 use reth_node_api::{AddOnsContext, FullNodeComponents, NodeAddOns, PrimitivesTy, TxTy};
 use reth_node_builder::{
@@ -60,6 +60,7 @@ use reth_transaction_pool::{
 use revm::context::TxEnv;
 use seismic_alloy_consensus::{SeismicTxEnvelope, SeismicTxType};
 use std::{sync::Arc, time::SystemTime};
+use tracing::info;
 
 use crate::{purpose_keys::get_purpose_keys, seismic_evm_config};
 
@@ -382,6 +383,7 @@ where
             EthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
         let purpose_keys = get_purpose_keys().clone();
+        let node_record = ctx.node.network().local_node_record();
 
         self.inner
             .launch_add_ons_with(ctx, move |container| {
@@ -398,8 +400,8 @@ where
                     EthApiExt::new(registry.eth_api().clone(), purpose_keys.clone()).into_rpc(),
                 )?;
 
-                // Register seismic_ namespace (getTeePublicKey)
-                modules.merge_configured(SeismicApi::new(purpose_keys).into_rpc())?;
+                // Always register public Seismic node information, regardless of the configured standard RPC namespaces.
+                modules.merge_configured(SeismicApi::new(purpose_keys, node_record).into_rpc())?;
 
                 // Trace endpoints stay off on Seismic. Our traces are already sanitized
                 // (calldata, return data, memory, and stack are stripped — see
@@ -763,8 +765,11 @@ where
             ctx.config().network.transactions_manager_config(),
             policies,
         );
-        // info!(target: "reth::cli", enode=%handle.local_node_record(), "P2P networking
-        // initialized");
+        info!(
+            target: "reth::cli",
+            enode = %handle.local_node_record(),
+            "P2P networking initialized"
+        );
         Ok(handle)
     }
 }

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -383,7 +383,7 @@ where
             EthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
         let purpose_keys = get_purpose_keys().clone();
-        let node_record = ctx.node.network().local_node_record();
+        let peers_info = ctx.node.network().clone();
 
         self.inner
             .launch_add_ons_with(ctx, move |container| {
@@ -401,7 +401,7 @@ where
                 )?;
 
                 // Always register public Seismic node information, regardless of the configured standard RPC namespaces.
-                modules.merge_configured(SeismicApi::new(purpose_keys, node_record).into_rpc())?;
+                modules.merge_configured(SeismicApi::new(purpose_keys, peers_info).into_rpc())?;
 
                 // Trace endpoints stay off on Seismic. Our traces are already sanitized
                 // (calldata, return data, memory, and stack are stripped — see

--- a/crates/seismic/node/tests/e2e/testsuite.rs
+++ b/crates/seismic/node/tests/e2e/testsuite.rs
@@ -2,8 +2,26 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use eyre::Result;
+use jsonrpsee::http_client::HttpClientBuilder;
 use reth_e2e_test_utils::transaction::TransactionTestContext;
 use reth_seismic_node::utils::e2e::ensure_mock_purpose_keys;
+use reth_seismic_rpc::ext::SeismicApiClient;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_seismic_node_info() -> Result<()> {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, _wallet) = reth_seismic_node::utils::e2e::setup(1).await?;
+    let node = nodes.pop().unwrap();
+    let expected_node_record = node.network.record();
+    let client = HttpClientBuilder::default().build(node.rpc_url().as_str())?;
+
+    let node_info = SeismicApiClient::node_info(&client).await?;
+    assert_eq!(node_info.node_record, expected_node_record);
+
+    Ok(())
+}
 
 // Produces a single block on a Seismic node using the internal engine channel
 // (not the JSON-RPC engine API, which loses Prague-era fields in V3 payloads).

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -27,6 +27,7 @@ alloy-sol-types.workspace = true
 reth-evm.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
+reth-network-peers.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -27,6 +27,7 @@ alloy-sol-types.workspace = true
 reth-evm.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
+reth-network-api.workspace = true
 reth-network-peers.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -52,10 +52,10 @@ pub trait SeismicApi {
     #[method(name = "getTeePublicKey")]
     async fn get_tee_public_key(&self) -> RpcResult<PublicKey>;
 
-    /// `admin` namespace is disabled for safety, but we still need the enode exposed for new joining
-    /// nodes wanting to locate discv5 bootnodes. Operators starting new nodes who have the IP
-    /// address of bootstrap nodes can query this endpoint for their enode record and add it to
-    /// reth's startup config via `--bootnodes <ENODE>[,<ENODE>...]`.
+    /// `admin` namespace is disabled for safety, but we still need the enode exposed for new
+    /// joining nodes wanting to locate discv5 bootnodes. Operators starting new nodes who have
+    /// the IP address of bootstrap nodes can query this endpoint for their enode record and add
+    /// it to reth's startup config via `--bootnodes <ENODE>[,<ENODE>...]`.
     #[method(name = "nodeInfo")]
     async fn node_info(&self) -> RpcResult<SeismicNodeInfo>;
 }

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -24,6 +24,7 @@ use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
 };
+use reth_network_api::PeersInfo;
 use reth_network_peers::NodeRecord;
 use reth_rpc_eth_api::{
     helpers::{EthCall, EthTransactions, FullEthApi},
@@ -70,20 +71,22 @@ pub struct SeismicNodeInfo {
 
 /// Implementation of the seismic rpc api
 #[derive(Debug, Clone)]
-pub struct SeismicApi {
+pub struct SeismicApi<P> {
     purpose_keys: GetPurposeKeysResponse,
-    node_info: SeismicNodeInfo,
+    // Keep the PeersInfo provider instead of snapshotting a NodeRecord because discovery
+    // may update the externally advertised address after startup.
+    peers_info: P,
 }
 
-impl SeismicApi {
+impl<P: PeersInfo> SeismicApi<P> {
     /// Creates a new seismic api instance.
-    pub const fn new(purpose_keys: GetPurposeKeysResponse, node_record: NodeRecord) -> Self {
-        Self { purpose_keys, node_info: SeismicNodeInfo { node_record } }
+    pub const fn new(purpose_keys: GetPurposeKeysResponse, peers_info: P) -> Self {
+        Self { purpose_keys, peers_info }
     }
 }
 
 #[async_trait]
-impl SeismicApiServer for SeismicApi {
+impl<P: PeersInfo + 'static> SeismicApiServer for SeismicApi<P> {
     async fn get_tee_public_key(&self) -> RpcResult<PublicKey> {
         trace!(target: "rpc::seismic", "Serving seismic_getTeePublicKey");
         Ok(self.purpose_keys.tx_io_pk)
@@ -91,7 +94,7 @@ impl SeismicApiServer for SeismicApi {
 
     async fn node_info(&self) -> RpcResult<SeismicNodeInfo> {
         trace!(target: "rpc::seismic", "Serving seismic_nodeInfo");
-        Ok(self.node_info.clone())
+        Ok(SeismicNodeInfo { node_record: self.peers_info.local_node_record() })
     }
 }
 

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -24,6 +24,7 @@ use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
 };
+use reth_network_peers::NodeRecord;
 use reth_rpc_eth_api::{
     helpers::{EthCall, EthTransactions, FullEthApi},
     RpcBlock, RpcTypes,
@@ -38,6 +39,7 @@ use seismic_alloy_rpc_types::{
     SimBlock as SeismicSimBlock, SimulatePayload as SeismicSimulatePayload,
 };
 use seismic_enclave::{secp256k1::PublicKey, GetPurposeKeysResponse};
+use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 /// trait interface for a custom rpc namespace: `seismic`
@@ -46,21 +48,37 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "seismic"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "seismic"))]
 pub trait SeismicApi {
-    /// Returns the network public key
+    /// Returns the network public key.
     #[method(name = "getTeePublicKey")]
     async fn get_tee_public_key(&self) -> RpcResult<PublicKey>;
+
+    /// `admin` namespace is disabled for safety, but we still need the enode exposed for new joining
+    /// nodes wanting to locate discv5 bootnodes. Operators starting new nodes who have the IP
+    /// address of bootstrap nodes can query this endpoint for their enode record and add it to
+    /// reth's startup config via `--bootnodes <ENODE>[,<ENODE>...]`.
+    #[method(name = "nodeInfo")]
+    async fn node_info(&self) -> RpcResult<SeismicNodeInfo>;
+}
+
+/// Public devp2p information for a Seismic node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeismicNodeInfo {
+    /// The structured local node record, serialized as an enode URL.
+    #[serde(rename = "enode")]
+    pub node_record: NodeRecord,
 }
 
 /// Implementation of the seismic rpc api
 #[derive(Debug, Clone)]
 pub struct SeismicApi {
     purpose_keys: GetPurposeKeysResponse,
+    node_info: SeismicNodeInfo,
 }
 
 impl SeismicApi {
-    /// Creates a new seismic api instance
-    pub const fn new(purpose_keys: GetPurposeKeysResponse) -> Self {
-        Self { purpose_keys }
+    /// Creates a new seismic api instance.
+    pub const fn new(purpose_keys: GetPurposeKeysResponse, node_record: NodeRecord) -> Self {
+        Self { purpose_keys, node_info: SeismicNodeInfo { node_record } }
     }
 }
 
@@ -69,6 +87,11 @@ impl SeismicApiServer for SeismicApi {
     async fn get_tee_public_key(&self) -> RpcResult<PublicKey> {
         trace!(target: "rpc::seismic", "Serving seismic_getTeePublicKey");
         Ok(self.purpose_keys.tx_io_pk)
+    }
+
+    async fn node_info(&self) -> RpcResult<SeismicNodeInfo> {
+        trace!(target: "rpc::seismic", "Serving seismic_nodeInfo");
+        Ok(self.node_info.clone())
     }
 }
 


### PR DESCRIPTION
Add seismic_nodeInfo so operators can retrieve a node's enode and pass it to new nodes via --bootnodes for discv5 peer discovery.

The admin namespace remains disabled on public RPC because it also exposes mutating peer-management methods. The new endpoint exposes only the node record required for bootstrap through the always-available seismic namespace.

Restore the startup enode log and add an end-to-end RPC round-trip test.