### PR TITLE
chore: disable eth_callBundle RPC endpoint

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -428,7 +428,7 @@ where
                 // It lives in the Eth module (which we keep), so we drop just this one method.
                 modules.remove_method_from_configured("eth_createAccessList");
 
-                // Disable `eth_callBundle` (Flashbots bundle simulation). The endpoint executed
+                // Disable `eth_callBundle` (Flashbots bundle simulation). The endpoint executes
                 // signed transactions through the EVM and returns raw success/revert output
                 // (`CLOAD`-derived shielded-storage bytes) in plaintext. Its `from` is the recovered
                 // signer (not a spoofable field), so there is no unsigned-request path to sanitize;

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -428,6 +428,14 @@ where
                 // It lives in the Eth module (which we keep), so we drop just this one method.
                 modules.remove_method_from_configured("eth_createAccessList");
 
+                // Disable `eth_callBundle` (Flashbots bundle simulation). The endpoint executed
+                // signed transactions through the EVM and returns raw success/revert output
+                // (`CLOAD`-derived shielded-storage bytes) in plaintext. Its `from` is the recovered
+                // signer (not a spoofable field), so there is no unsigned-request path to sanitize;
+                // and its per-tx output cannot be uniformly encrypted (plain, non-seismic bundle txs
+                // carry no encryption key).
+                modules.remove_method_from_configured("eth_callBundle");
+
                 Ok(())
             })
             .await

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1781,6 +1781,33 @@ async fn test_create_access_list_disabled() -> eyre::Result<()> {
     Ok(())
 }
 
+/// `eth_callBundle` is disabled on Seismic: the Flashbots bundle simulator executes transactions
+/// through the EVM and returns raw success/revert output (including `CLOAD`-derived
+/// shielded-storage bytes) in plaintext, bypassing the signed-read output-encryption applied to
+/// `eth_call`/`callMany`. It is removed from the otherwise-served Eth namespace; see `node.rs`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_call_bundle_disabled() -> eyre::Result<()> {
+    let (_node, client, _chain_id, _wallet, _tasks) = setup_test_node().await?;
+
+    let result = client.request::<serde_json::Value, _>("eth_callBundle", rpc_params![]).await;
+    match result {
+        Err(jsonrpsee::core::client::Error::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                jsonrpsee::types::error::ErrorCode::MethodNotFound.code(),
+                "eth_callBundle must be unregistered, got error: {err}"
+            );
+        }
+        other => panic!("eth_callBundle must return method-not-found, got: {other:?}"),
+    }
+
+    // Control: a sibling Eth method we do not remove is still served.
+    let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
+    assert!(block_number.starts_with("0x"), "unexpected eth_blockNumber response: {block_number}");
+
+    Ok(())
+}
+
 /// Get the latest block number via `eth_blockNumber`.
 async fn get_block_number(client: &jsonrpsee::http_client::HttpClient) -> u64 {
     let result: serde_json::Value =


### PR DESCRIPTION
This disables the `eth_callBundle` endpoint.
The endpoint executes signed transactions through the EVM and returns raw success/revert output
(`CLOAD`-derived shielded-storage bytes) in plaintext.
We could encrypt the output, but then we can only allow Seismic transactions, because the other transaction types don't carry an encryption key.