### PR TITLE
chore(node): replace mock enclave server with in-process well-known keys

### DIFF
--- a/crates/node/core/src/args/enclave.rs
+++ b/crates/node/core/src/args/enclave.rs
@@ -26,7 +26,8 @@ pub struct EnclaveArgs {
     #[arg(long = "enclave.retry-seconds", default_value_t = 30)]
     pub retry_seconds: u16,
 
-    /// Spin up mock server for testing purpose
+    /// Use the built-in well-known keys (publicly known, no confidentiality) as the
+    /// node's purpose keys instead of fetching them from an enclave
     #[arg(long = "enclave.mock-server", action = clap::ArgAction::SetTrue)]
     pub mock_server: bool,
 

--- a/crates/seismic/node/src/enclave.rs
+++ b/crates/seismic/node/src/enclave.rs
@@ -1,12 +1,53 @@
-//! Tools to communicate with the seismic-enclave-server's RPC
-use std::{net::SocketAddr, time::Duration};
+//! Tools to obtain purpose keys: from the seismic-enclave-server's RPC, or built
+//! locally from the well-known keys when running without an enclave.
+use std::{str::FromStr, time::Duration};
 
 use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
 use reth_node_core::args::EnclaveArgs;
 use seismic_enclave::{
-    api::TdxQuoteRpcClient as _, mock::start_mock_server, GetPurposeKeysResponse,
+    api::TdxQuoteRpcClient as _, secp256k1, GetPurposeKeysResponse, SchnorrkelKeypair,
 };
 use tracing::{info, warn};
+
+/// The well-known rng keypair as `schnorrkel::Keypair::to_bytes()`:
+/// 64 bytes of expanded secret (key || nonce) followed by the 32-byte public key.
+/// No schnorrkel cryptography is performed anywhere with it — the RNG precompile
+/// uses only the 64 secret bytes as HKDF input key material; the schnorrkel type
+/// survives solely because `GetPurposeKeysResponse` declares it.
+const WELL_KNOWN_RNG_KEYPAIR: [u8; 96] = [
+    108, 143, 208, 128, 94, 149, 36, 232, 240, 31, 238, 111, 54, 39, 246, 163, 231, 190, 237, 137,
+    76, 19, 107, 188, 78, 133, 126, 183, 245, 50, 56, 8, 121, 108, 125, 215, 62, 231, 212, 112, 83,
+    141, 75, 154, 109, 225, 74, 71, 155, 254, 199, 42, 79, 100, 86, 93, 155, 190, 165, 181, 199,
+    249, 195, 114, 74, 169, 221, 253, 131, 199, 106, 69, 109, 34, 131, 64, 216, 213, 235, 57, 49,
+    17, 132, 159, 68, 170, 254, 50, 94, 250, 185, 128, 121, 181, 217, 54,
+];
+
+/// The well-known purpose keys, used when `--enclave.mock-server` is set (dev nodes
+/// and pre-TEE deployments, which run no enclave at all).
+///
+/// These are real keys with zero secrecy, not mocks: on pre-TEE networks every node
+/// boots with `--enclave.mock-server`, so they are the consensus-visible network
+/// keys — wallets encrypt to this `tx_io_pk`, sync decrypts history with `tx_io_sk`,
+/// and `rng_keypair` seeds the RNG precompile.
+// TODO: by mainnet launch, a pre-TEE mainnet must not run keys published on GitHub —
+// needs a per-network keypair obfuscated or provisioned outside source control,
+// while sanvil/dev networks stay on the well-known keys.
+#[allow(clippy::expect_used)] // hardcoded constants; validity is exercised by tests
+pub fn well_known_purpose_keys() -> GetPurposeKeysResponse {
+    GetPurposeKeysResponse {
+        tx_io_sk: secp256k1::SecretKey::from_str(
+            "311d54d3bf8359c70827122a44a7b4458733adce3c51c6b59d9acfce85e07505",
+        )
+        .expect("valid well-known tx_io secret key"),
+        tx_io_pk: secp256k1::PublicKey::from_str(
+            "028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0",
+        )
+        .expect("valid well-known tx_io public key"),
+        snapshot_key_bytes: [0u8; 32],
+        rng_keypair: SchnorrkelKeypair::from_bytes(&WELL_KNOWN_RNG_KEYPAIR)
+            .expect("valid well-known rng keypair"),
+    }
+}
 
 /// Builds the enclave JSON-RPC client, binding each request to the configured `enclave_timeout`.
 #[allow(clippy::expect_used)] // Intentional panic on startup failure - enclave is required
@@ -17,9 +58,10 @@ fn build_enclave_client(config: &EnclaveArgs) -> HttpClient {
         .expect("Failed to build enclave client")
 }
 
-/// Boot the enclave (or mock server) and fetch purpose keys.
+/// Fetch purpose keys: built locally when `--enclave.mock-server` is set, otherwise
+/// fetched from the enclave server over HTTP.
 /// This must be called before building the node components.
-/// Panics if the enclave cannot be booted or purpose keys cannot be fetched.
+/// Panics if purpose keys cannot be fetched from the enclave.
 ///
 /// Total fetch attempts = `config.retries` + 1 (one initial attempt plus `retries`
 /// re-attempts); the `while failures <= config.retries` loop encodes this directly.
@@ -30,18 +72,9 @@ where
     T: AsRef<EnclaveArgs>,
 {
     let config = config.as_ref();
-    // Boot enclave or start mock server
     if config.mock_server {
-        info!(target: "reth::cli", "Starting mock enclave server");
-        let addr = config.enclave_server_addr;
-        let port = config.enclave_server_port;
-        tokio::spawn(async move {
-            start_mock_server(SocketAddr::new(addr, port))
-                .await
-                .expect("Failed to start mock enclave server");
-        });
-        // Give the mock server time to start
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        info!(target: "reth::cli", "Using built-in well-known purpose keys (no enclave)");
+        return well_known_purpose_keys();
     }
     let enclave_client = build_enclave_client(config);
 
@@ -72,6 +105,38 @@ mod tests {
     use super::*;
     use std::time::Instant;
     use tokio::net::TcpListener;
+
+    /// sanvil and not-yet-upgraded testnet nodes (whose HTTP mock arm serves keys
+    /// built from `seismic_enclave`'s sample-key fns) must produce these exact
+    /// keys: `rng_keypair` is a consensus input via the RNG precompile, so drift
+    /// splits the chain, and divergence from sanvil breaks dev-tooling interop.
+    /// The mixed-fleet half of this concern is temporary — it ends once every
+    /// testnet node runs the local arm; the sanvil half holds for as long as dev
+    /// networks share keys with anvil.
+    #[test]
+    fn well_known_purpose_keys_match_enclave_crate() {
+        use seismic_enclave::{
+            get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
+            get_unsecure_sample_secp256k1_sk,
+        };
+
+        let ours = well_known_purpose_keys();
+        assert_eq!(ours.tx_io_sk, get_unsecure_sample_secp256k1_sk());
+        assert_eq!(ours.tx_io_pk, get_unsecure_sample_secp256k1_pk());
+        assert_eq!(ours.snapshot_key_bytes, [0u8; 32]);
+        assert_eq!(
+            ours.rng_keypair.to_bytes(),
+            get_unsecure_sample_schnorrkel_keypair().to_bytes()
+        );
+    }
+
+    /// The hardcoded `tx_io_pk` must actually be `tx_io_sk`'s public key — wallets
+    /// ECDH against the published key, the node decrypts with the secret one.
+    #[test]
+    fn well_known_tx_io_keypair_is_consistent() {
+        let keys = well_known_purpose_keys();
+        assert_eq!(keys.tx_io_pk, keys.tx_io_sk.public_key(&secp256k1::Secp256k1::new()));
+    }
 
     /// A stalled enclave endpoint (accepts connections but never replies) must make the fetch
     /// error within the configured `enclave_timeout`, not hang on the underlying client default.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -966,7 +966,7 @@ Trusted Execution Environment Server:
           [default: 8545]
 
       --enclave.mock-server
-          Spin up mock TEE service for testing purpose at [--enclave.endpoint-addr]:[--enclave.endpoint-port]
+          Use the built-in well-known keys (publicly known, no confidentiality) as the node's purpose keys instead of fetching them from an enclave
 
 
 Display:


### PR DESCRIPTION
We hardcode the secret keys in order to decouple reth from the enclave repo.

## Change

`--enclave.mock-server` previously spawned the seismic-enclave MockServer on --enclave.endpoint-addr (default 0.0.0.0) and immediately fetched the purpose keys back over HTTP. The flag now builds the keys in-process instead. In-process beats the server on every axis:

- No exposed key service: the listener answered getPurposeKeys — tx_io_sk included — to anyone who could reach the port, on all interfaces by default. Today these keys are well-known anyway, but the moment a network runs non-published keys (see below) such a listener becomes a real key-disclosure hole; and even now there is no reason for a node to run an unauthenticated JSON-RPC service whose only legitimate client is itself.
- No boot race: the old path slept 100ms and hoped the server was up, then leaned on the fetch retry loop; local construction cannot fail, so mock boots are deterministic and faster.
- Less machinery: no spawned server task, no port management — summit's local testnet had to allocate per-node endpoint ports purely to avoid bind collisions between mock servers. A node running without a TEE now ships no enclave-facing listener at all.

Nothing else consumed the listener: deploy templates pass only --enclave.mock-server, so removal breaks no deployment.

## Decoupling from Enclave

Just as important, this decouples reth from the enclave repo. The keys are hardcoded here rather than taken from seismic-enclave's sample-key fns because they are consensus-visible network keys on pre-TEE networks (wallets encrypt to tx_io_pk, sync decrypts history with tx_io_sk, rng_keypair seeds the RNG precompile): the node should pin its own consensus constants instead of inheriting them from a git-pinned dependency, where a pin bump could silently change them. Non-TEE networks now boot entirely from reth-local code, so work on the real enclave server and the wider TEE stack — including breaking changes — can proceed without any risk of regressing the running non-TEE networks; reth's production code depends on seismic-enclave only for the GetPurposeKeysResponse DTO, the RPC client trait, and re-exported crypto types, and picks up new enclave-repo shapes on its own schedule at a future pin bump.

All --enclave.* flags remain parseable; the non-mock HTTP arm is untouched.

## Important TODO before mainnet

Most important: figure out how to obfuscate the testnet/mainnet keys. A network with real users must not run purpose keys whose secret halves are published on GitHub — needs a per-network keypair provisioned outside source control (deploy-managed), with anvil/dev networks staying on the well-known keys (TODO in code).