### PR TITLE
chore(deps): bump seismic-evm pin past the overrides feature removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e844531f59f6821482984731b570323601e32eb4#e844531f59f6821482984731b570323601e32eb4"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=597ec26f8ba26ea88ed626b87d97e89810c9be70#597ec26f8ba26ea88ed626b87d97e89810c9be70"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e844531f59f6821482984731b570323601e32eb4#e844531f59f6821482984731b570323601e32eb4"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=597ec26f8ba26ea88ed626b87d97e89810c9be70#597ec26f8ba26ea88ed626b87d97e89810c9be70"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -791,5 +791,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e844531f59f6821482984731b570323601e32eb4" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e844531f59f6821482984731b570323601e32eb4" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "597ec26f8ba26ea88ed626b87d97e89810c9be70" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "597ec26f8ba26ea88ed626b87d97e89810c9be70" }

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -32,7 +32,7 @@ reth-node-api.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
 
 # ethereum
-alloy-evm = { workspace = true, features = ["overrides", "call-util"] }
+alloy-evm = { workspace = true, features = ["call-util"] }
 alloy-rlp.workspace = true
 alloy-serde.workspace = true
 alloy-eips.workspace = true

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -31,7 +31,7 @@ reth-trie.workspace = true
 
 # ethereum
 alloy-eips.workspace = true
-alloy-evm = { workspace = true, features = ["overrides", "call-util"] }
+alloy-evm = { workspace = true, features = ["call-util"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -43,7 +43,7 @@ reth-node-api.workspace = true
 reth-trie-common.workspace = true
 
 # ethereum
-alloy-evm = { workspace = true, features = ["overrides"] }
+alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true


### PR DESCRIPTION
[seismic-evm#55](https://github.com/SeismicSystems/seismic-evm/pull/55) removed alloy-evm's `overrides` feature — the override apply machinery is now unconditional, with the Seismic account-override security policy centralized in its `seismic_security` module — so the rpc crates' explicit feature requests fail cargo resolution against any newer pin. Pin at exactly that commit (597ec26) and drop the feature requests from the three rpc manifests. No code changes.