### PR TITLE
chore: fix feature propagation + TOML formatting, gate both in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,4 +15,3 @@ slow-timeout = { period = "2m", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = "binary(e2e_testsuite)"
 slow-timeout = { period = "2m", terminate-after = 3 }
-

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -82,6 +82,41 @@ jobs:
             -W clippy::unreachable \
             -W clippy::todo
 
+  lint-toml:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run dprint
+        uses: dprint/check@v2.3
+        with:
+          config-path: dprint.json
+
+  feature-propagation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ZEPTER_VERSION: v1.88.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: fetch deps
+        run: |
+          # Eagerly pull dependencies
+          time cargo metadata --format-version=1 --locked > /dev/null
+      - name: install zepter
+        # Pinned prebuilt binary: installs in seconds where `cargo install`
+        # compiles for minutes, and new zepter releases (with new lints) only
+        # land here by bumping ZEPTER_VERSION.
+        run: |
+          curl -sSfLO "https://github.com/ggwpez/zepter/releases/download/${ZEPTER_VERSION}/zepter-x86_64-unknown-linux-gnu.tar.xz"
+          curl -sSfLO "https://github.com/ggwpez/zepter/releases/download/${ZEPTER_VERSION}/zepter-x86_64-unknown-linux-gnu.tar.xz.sha256"
+          sha256sum -c zepter-x86_64-unknown-linux-gnu.tar.xz.sha256
+          tar -xJf zepter-x86_64-unknown-linux-gnu.tar.xz
+          sudo mv zepter-x86_64-unknown-linux-gnu/zepter /usr/local/bin/
+          zepter --version
+      - name: run zepter
+        run: time zepter run check
+
   unit-test:
     runs-on: large-github-runner
     timeout-minutes: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,10 +210,12 @@ Before committing or pushing code, run these checks locally to match what Seismi
      -W clippy::unreachable \
      -W clippy::todo
    ```
-4. **Tests Pass**: `cargo nextest run --workspace` (unit and integration)
-5. **Build Check**: `cargo check --workspace`
-6. **Documentation**: Update relevant docs and add doc comments with `cargo docs --document-private-items`
-7. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
+4. **TOML Formatting**: `dprint check` (auto-fix with `dprint fmt` / `make lint-toml`)
+5. **Feature Propagation**: `zepter run check` (auto-fix with plain `zepter`)
+6. **Tests Pass**: `cargo nextest run --workspace` (unit and integration)
+7. **Build Check**: `cargo check --workspace`
+8. **Documentation**: Update relevant docs and add doc comments with `cargo docs --document-private-items`
+9. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
 
 
 ### Opening PRs against <https://github.com/paradigmxyz/reth>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11262,6 +11262,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "arbitrary",
  "derive_more 1.0.0",
  "seismic-alloy-consensus",
  "seismic-enclave",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,6 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.dependencies]
-
 # seismic dependencies
 # reth-seismic-bin = { path = "crates/seismic/bin" }
 reth-seismic-chainspec = { path = "crates/seismic/chainspec" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -70,7 +70,6 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 backon.workspace = true
 tempfile.workspace = true
 
-
 [features]
 default = ["jemalloc", "reth-revm/portable"]
 

--- a/bin/seismic-reth/Cargo.toml
+++ b/bin/seismic-reth/Cargo.toml
@@ -41,10 +41,25 @@ tokio.workspace = true
 [features]
 default = ["jemalloc"]
 timestamp-in-seconds = ["reth-seismic-node/timestamp-in-seconds"]
-asm-keccak = ["reth-node-core/asm-keccak", "reth-primitives/asm-keccak"]
+asm-keccak = [
+    "reth-node-core/asm-keccak",
+    "reth-primitives/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-node-ethereum/asm-keccak",
+    "reth-seismic-cli/asm-keccak",
+    "reth-seismic-node/asm-keccak",
+]
 
-jemalloc = ["reth-node-core/jemalloc", "reth-node-metrics/jemalloc"]
-jemalloc-prof = ["jemalloc"]
+jemalloc = [
+    "reth-node-core/jemalloc",
+    "reth-node-metrics/jemalloc",
+    "reth-cli-util/jemalloc",
+    "reth-seismic-cli/jemalloc",
+]
+jemalloc-prof = [
+    "jemalloc",
+    "reth-cli-util/jemalloc-prof",
+]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -50,4 +50,5 @@ std = [
     "thiserror/std",
     "reth-engine-primitives/std",
     "reth-primitives-traits/std",
+    "alloy-consensus/std",
 ]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -60,6 +60,8 @@ std = [
     "derive_more?/std",
     "alloy-rpc-types-engine/std",
     "reth-storage-errors/std",
+    "secp256k1/std",
+    "serde_json/std",
 ]
 test-utils = [
     "dep:parking_lot",

--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -64,6 +64,7 @@ std = [
     "derive_more/std",
     "serde_with?/std",
     "secp256k1/std",
+    "alloy-serde?/std",
 ]
 reth-codec = [
     "std",
@@ -79,6 +80,7 @@ arbitrary = [
     "reth-codecs?/arbitrary",
     "reth-primitives-traits/arbitrary",
     "alloy-eips/arbitrary",
+    "alloy-serde?/arbitrary",
 ]
 serde-bincode-compat = [
     "dep:serde_with",

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -43,7 +43,11 @@ reth-ethereum-forks.workspace = true
 
 [features]
 default = ["std"]
-timestamp-in-seconds = ["revm/timestamp-in-seconds", "seismic-revm/timestamp-in-seconds", "alloy-evm/timestamp-in-seconds"]
+timestamp-in-seconds = [
+    "revm/timestamp-in-seconds",
+    "seismic-revm/timestamp-in-seconds",
+    "alloy-evm/timestamp-in-seconds",
+]
 std = [
     "reth-primitives-traits/std",
     "alloy-eips/std",
@@ -60,6 +64,7 @@ std = [
     "reth-storage-api/std",
     "reth-trie-common/std",
     "reth-ethereum-primitives/std",
+    "op-revm?/std",
 ]
 metrics = ["std", "dep:metrics", "dep:reth-metrics"]
 test-utils = [

--- a/crates/genesis-builder/Cargo.toml
+++ b/crates/genesis-builder/Cargo.toml
@@ -10,7 +10,7 @@ exclude.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-reqwest = { workspace = true, default-features = false, features = ["blocking"] } 
+reqwest = { workspace = true, default-features = false, features = ["blocking"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -126,6 +126,7 @@ serde = [
     "reth-network-api/serde",
     "rand_08/serde",
     "reth-storage-api/serde",
+    "seismic-alloy-consensus/serde",
 ]
 test-utils = [
     "reth-transaction-pool/test-utils",

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-
 # reth
 reth-chainspec.workspace = true
 reth-consensus.workspace = true

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -100,6 +100,8 @@ std = [
     "revm-bytecode/std",
     "revm-state/std",
     "alloy-rpc-types-eth?/std",
+    "seismic-alloy-consensus/std",
+    "seismic-alloy-genesis/std",
 ]
 secp256k1 = ["alloy-consensus/secp256k1"]
 test-utils = [
@@ -123,6 +125,7 @@ arbitrary = [
     "alloy-trie/arbitrary",
     "reth-chainspec/arbitrary",
     "alloy-rpc-types-eth?/arbitrary",
+    "seismic-alloy-consensus/arbitrary",
 ]
 serde-bincode-compat = [
     "serde",
@@ -133,6 +136,7 @@ serde-bincode-compat = [
     "op-alloy-consensus?/serde-bincode-compat",
     "alloy-genesis/serde-bincode-compat",
     "alloy-rpc-types-eth?/serde-bincode-compat",
+    "seismic-alloy-consensus/serde-bincode-compat",
 ]
 serde = [
     "dep:serde",
@@ -150,6 +154,7 @@ serde = [
     "revm-state/serde",
     "rand_08/serde",
     "alloy-rpc-types-eth?/serde",
+    "seismic-alloy-consensus/serde",
 ]
 reth-codec = [
     "dep:reth-codecs",

--- a/crates/seismic/chainspec/Cargo.toml
+++ b/crates/seismic/chainspec/Cargo.toml
@@ -66,4 +66,5 @@ std = [
     "thiserror/std",
     "serde_json/std",
     "seismic-alloy-consensus/std",
+    "reth-seismic-forks/std",
 ]

--- a/crates/seismic/cli/Cargo.toml
+++ b/crates/seismic/cli/Cargo.toml
@@ -47,6 +47,7 @@ proptest.workspace = true
 asm-keccak = [
     "reth-node-core/asm-keccak",
     "reth-seismic-node/asm-keccak",
+    "reth-node-ethereum/asm-keccak",
 ]
 
 # Jemalloc feature for vergen to generate correct env vars

--- a/crates/seismic/evm/Cargo.toml
+++ b/crates/seismic/evm/Cargo.toml
@@ -37,10 +37,10 @@ alloy-consensus.workspace = true
 reth-seismic-chainspec.workspace = true
 reth-seismic-forks.workspace = true
 reth-seismic-primitives = { workspace = true }
-reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"]}
+reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
 
 # revm
-revm = { workspace = true}
+revm = { workspace = true }
 seismic-revm.workspace = true
 
 # misc
@@ -96,5 +96,13 @@ std = [
     "alloy-evm/std",
     "reth-evm/std",
     "tracing/std",
+    "alloy-rpc-types-engine/std",
+    "k256/std",
+    "reth-ethereum-primitives/std",
+    "reth-seismic-forks/std",
+    "reth-storage-errors/std",
+    "revm-state/std",
+    "secp256k1/std",
+    "seismic-alloy-genesis/std",
 ]
 portable = ["reth-revm/portable"]

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -67,7 +67,6 @@ serde.workspace = true
 eyre.workspace = true
 tracing.workspace = true
 
-
 # test-utils dependencies
 alloy-rpc-types = { workspace = true }
 tokio = { workspace = true }
@@ -148,6 +147,7 @@ asm-keccak = [
     "revm/asm-keccak",
     "reth-seismic-node/asm-keccak",
     "reth-node-core/asm-keccak",
+    "reth-node-ethereum/asm-keccak",
 ]
 js-tracer = [
     "reth-node-builder/js-tracer",
@@ -170,6 +170,8 @@ test-utils = [
     "reth-seismic-node/test-utils",
     "reth-seismic-primitives/arbitrary",
     "reth-primitives-traits/test-utils",
+    "reth-db/test-utils",
+    "reth-node-ethereum/test-utils",
 ]
 reth-codec = [
     "reth-seismic-primitives/reth-codec",

--- a/crates/seismic/payload/Cargo.toml
+++ b/crates/seismic/payload/Cargo.toml
@@ -21,15 +21,15 @@ reth-storage-api.workspace = true
 reth-evm.workspace = true
 reth-payload-builder.workspace = true
 reth-payload-builder-primitives.workspace = true
-reth-payload-primitives = { workspace = true}
+reth-payload-primitives = { workspace = true }
 reth-basic-payload-builder.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-errors.workspace = true
 
 # seismic-reth
 reth-seismic-evm.workspace = true
-reth-seismic-primitives = {workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec", "arbitrary"] }
-reth-ethereum-primitives = {workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
+reth-seismic-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec", "arbitrary"] }
+reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
 
 # ethereum
 revm.workspace = true

--- a/crates/seismic/primitives/Cargo.toml
+++ b/crates/seismic/primitives/Cargo.toml
@@ -40,13 +40,8 @@ serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 
 # misc
-derive_more = { workspace = true, features = [
-    "deref",
-    "from",
-    "into",
-    "constructor",
-] }
-secp256k1 = { workspace = true, features = ["rand", "std", "global-context", "recovery"]}
+derive_more = { workspace = true, features = ["deref", "from", "into", "constructor"] }
+secp256k1 = { workspace = true, features = ["rand", "std", "global-context", "recovery"] }
 anyhow.workspace = true
 tracing.workspace = true
 
@@ -59,7 +54,7 @@ proptest = { workspace = true, optional = true }
 alloy-signer-local.workspace = true
 alloy-rpc-types.workspace = true
 k256.workspace = true
-enr = {workspace = true, features = ["rust-secp256k1"]}
+enr = { workspace = true, features = ["rust-secp256k1"] }
 alloy-dyn-abi.workspace = true
 seismic-alloy-rpc-types.workspace = true
 
@@ -94,6 +89,10 @@ std = [
     "serde_json/std",
     "alloy-evm/std",
     "serde_with?/std",
+    "k256/std",
+    "seismic-alloy-network/std",
+    "seismic-alloy-rpc-types/std",
+    "tracing/std",
 ]
 reth-codec = [
     "dep:reth-codecs",
@@ -117,6 +116,12 @@ serde = [
     "rand/serde",
     "secp256k1/serde",
     "revm-context/serde",
+    "enr/serde",
+    "k256/serde",
+    "rand_08?/serde",
+    "seismic-alloy-network/serde",
+    "seismic-alloy-rpc-types/serde",
+    "seismic-revm/serde",
 ]
 serde-bincode-compat = [
     "serde",
@@ -138,4 +143,7 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
     "rand_08",
+    "alloy-dyn-abi/arbitrary",
+    "alloy-rpc-types/arbitrary",
+    "seismic-alloy-rpc-types/arbitrary",
 ]

--- a/crates/seismic/reth/Cargo.toml
+++ b/crates/seismic/reth/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-primitives-traits = { workspace = true}
+reth-primitives-traits = { workspace = true }
 reth-chainspec.workspace = true
 reth-network = { workspace = true, optional = true }
 reth-provider = { workspace = true, optional = true }

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -12,7 +12,6 @@ description = "Ethereum RPC implementation for seismic."
 workspace = true
 
 [dependencies]
-
 # alloy
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
@@ -49,10 +48,7 @@ revm.workspace = true
 revm-context.workspace = true
 
 # seismic-reth
-reth-seismic-primitives = { workspace = true, features = [
-    "reth-codec",
-    "serde-bincode-compat",
-] }
+reth-seismic-primitives = { workspace = true, features = ["reth-codec", "serde-bincode-compat"] }
 alloy-seismic-evm.workspace = true
 
 seismic-alloy-consensus.workspace = true

--- a/crates/seismic/txpool/Cargo.toml
+++ b/crates/seismic/txpool/Cargo.toml
@@ -23,10 +23,10 @@ reth-chainspec.workspace = true
 reth-execution-types.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-transaction-pool = {workspace = true, features = ["serde", "reth-codec", "serde-bincode-compat"]}
+reth-transaction-pool = { workspace = true, features = ["serde", "reth-codec", "serde-bincode-compat"] }
 
 # seismic
-reth-seismic-primitives = {workspace = true, features = ["serde", "reth-codec", "serde-bincode-compat"]}
+reth-seismic-primitives = { workspace = true, features = ["serde", "reth-codec", "serde-bincode-compat"] }
 
 # misc
 c-kzg.workspace = true

--- a/crates/storage/codecs/Cargo.toml
+++ b/crates/storage/codecs/Cargo.toml
@@ -64,6 +64,9 @@ std = [
     "op-alloy-consensus?/std",
     "serde_json/std",
     "reth-zstd-compressors?/std",
+    "alloy-genesis/std",
+    "seismic-alloy-consensus/std",
+    "seismic-alloy-genesis/std",
 ]
 alloy = [
     "dep:alloy-consensus",
@@ -87,6 +90,7 @@ serde = [
     "bytes/serde",
     "op-alloy-consensus?/serde",
     "secp256k1/serde",
+    "seismic-alloy-consensus/serde",
 ]
 arbitrary = [
     "alloy-consensus?/arbitrary",
@@ -94,4 +98,5 @@ arbitrary = [
     "alloy-primitives/arbitrary",
     "alloy-trie?/arbitrary",
     "op-alloy-consensus?/arbitrary",
+    "seismic-alloy-consensus/arbitrary",
 ]

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -92,6 +92,7 @@ arbitrary = [
     # The optimism crates don't compile because of type changes we made that affects them, such as FlaggedStorage.
     # "reth-optimism-primitives?/arbitrary",
     "reth-ethereum-primitives/arbitrary",
+    "reth-seismic-primitives/arbitrary",
 ]
 op = [
     # "dep:reth-optimism-primitives",

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -51,6 +51,7 @@ std = [
     "reth-storage-errors/std",
     "reth-db-models/std",
     "reth-trie-common/std",
+    "revm-state/std",
 ]
 
 db-api = [
@@ -71,6 +72,7 @@ serde = [
     "alloy-primitives/serde",
     "alloy-consensus/serde",
     "alloy-rpc-types-engine/serde",
+    "revm-state/serde",
 ]
 
 serde-bincode-compat = [

--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -94,10 +94,16 @@ serde = [
     "reth-ethereum-primitives/serde",
     "reth-chain-state/serde",
     "reth-storage-api/serde",
+    "seismic-alloy-consensus/serde",
 ]
 serde-bincode-compat = [
     "reth-ethereum-primitives/serde-bincode-compat",
     "reth-execution-types/serde-bincode-compat",
+    "alloy-consensus/serde-bincode-compat",
+    "alloy-eips/serde-bincode-compat",
+    "reth-primitives-traits/serde-bincode-compat",
+    "reth-storage-api/serde-bincode-compat",
+    "seismic-alloy-consensus/serde-bincode-compat",
 ]
 reth-codec = ["reth-ethereum-primitives/reth-codec"]
 test-utils = [
@@ -125,8 +131,8 @@ arbitrary = [
     "revm-interpreter/arbitrary",
     "reth-ethereum-primitives/arbitrary",
     "revm-primitives/arbitrary",
+    "seismic-alloy-consensus/arbitrary",
 ]
-
 
 [[bench]]
 name = "truncate"

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -85,6 +85,7 @@ std = [
     "serde_json/std",
     "revm-database/std",
     "revm-state/std",
+    "seismic-alloy-genesis/std",
 ]
 eip1186 = ["alloy-rpc-types-eth/serde", "dep:alloy-serde"]
 serde = [

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -12,7 +12,7 @@ description = "Database integration with merkle trie implementation"
 workspace = true
 
 [dependencies]
-# Seismic 
+# Seismic
 revm.workspace = true
 revm-state.workspace = true
 
@@ -65,6 +65,8 @@ serde = [
     "reth-primitives-traits/serde",
     "revm-database/serde",
     "revm/serde",
+    "revm-primitives/serde",
+    "revm-state/serde",
 ]
 test-utils = [
     "reth-trie-common/test-utils",

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,14 +1,14 @@
 # Keep dependency declarations compact (e.g. features on one line) instead of
 # taplo's default behavior of expanding arrays/inline tables to multiline.
 # eg. taplo will default to:
-# 
+#
 # secp256k1 = { version = "0.30", default-features = false, features = [
 #   "global-context",
 #   "recovery",
 # ] }
-# 
+#
 # but with these settings, we'll keep the upstream formatting style of:
-# 
+#
 # secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
 [formatting]
 array_auto_expand = false


### PR DESCRIPTION
CLAUDE.md tells contributors to run zepter and make lint-toml, and upstream's lint.yml declares jobs for both, but seismic.yml never ran either — so the debt accumulated invisibly: dozens of missing feature-propagation entries across 18 manifests and 7 drifted TOML files at HEAD. Workspace feature unification masked the propagation holes; individual crates no longer built standalone (e.g. `cargo check -p reth-node-core`).

Run zepter to its fixpoint and dprint fmt across the workspace, and add seismic.yml jobs so the gates actually run on PRs: feature-propagation (zepter run check, pinned prebuilt binary) and lint-toml (dprint check). List both in the CLAUDE.md CI requirements.