### PR TITLE
test(seismic): fail fast on audit import hangs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,27 @@
 retries = { backoff = "exponential", count = 3, delay = "5s", jitter = true, max-delay = "30s" }
 slow-timeout = { period = "300s", terminate-after = 6 }
 
+# These Seismic audit-regression tests normally pass in about 11s: most of that is the forked
+# e2e helper's empty-payload wait before the crafted payload is submitted. 60s leaves room for CI
+# variance but fails much earlier than the 30m job timeout.
+#
+# Mainstream reth has already fixed the relevant e2e helper behavior in:
+# - https://github.com/paradigmxyz/reth/pull/23837
+# Related payload-resolution hardening also landed in:
+# - https://github.com/paradigmxyz/reth/pull/24967
+# - https://github.com/paradigmxyz/reth/pull/25242
+# There is a separate open cancellation-safety follow-up:
+# - https://github.com/paradigmxyz/reth/pull/26365
+#
+# This override only bounds these two audit tests. Other integration tests that exercise the same
+# forked helper path may still be flaky until the upstream fixes are absorbed.
+#
+# Remove this override after rebasing/syncing our fork onto a reth revision that includes those
+# upstream fixes, or cherry-picking the relevant upstream fixes if the flakiness becomes too noisy.
+[[profile.default.overrides]]
+filter = 'test(test_new_payload_rejects_signed_read_tx) | test(test_new_payload_rejects_wrong_chain_id_tx)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+
 [[profile.default.overrides]]
 filter = 'test(general_state_tests)'
 slow-timeout = { period = "2m", terminate-after = 15 }

--- a/crates/seismic/node/tests/e2e/signed_read_import.rs
+++ b/crates/seismic/node/tests/e2e/signed_read_import.rs
@@ -23,7 +23,7 @@ use reth_seismic_node::{
 use reth_seismic_primitives::{SeismicBlock, SeismicTransactionSigned};
 use secp256k1::PublicKey;
 use seismic_alloy_consensus::{SeismicTypedTransaction, TxSeismic, TxSeismicElements};
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 /// A `signed_read = true` seismic transaction. The signature is arbitrary: the consensus
 /// decoder gates on `signed_read` before any signature recovery, so a dummy signature
@@ -75,12 +75,20 @@ async fn test_new_payload_rejects_signed_read_tx() -> Result<()> {
 
     // Submit through the engine's newPayload handler. The signed-read tx must fail the
     // consensus-decode gate, so the payload is rejected rather than executed.
-    let result = node
-        .inner
-        .add_ons_handle
-        .beacon_engine_handle
-        .new_payload(SeismicPayloadTypes::block_to_payload(sealed))
-        .await;
+    //
+    // This is Seismic-owned test code, not an upstream helper edit. The invalid payload should
+    // return quickly; until our fork absorbs upstream reth#23837's e2e payload-helper fix, keep
+    // intentional waits in this regression bounded so CI reports the stuck rejection path instead
+    // of timing out the entire integration-test job.
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        node.inner
+            .add_ons_handle
+            .beacon_engine_handle
+            .new_payload(SeismicPayloadTypes::block_to_payload(sealed)),
+    )
+    .await
+    .expect("engine_newPayload timed out rejecting signed-read transaction");
 
     match result {
         Ok(status) => {

--- a/crates/seismic/node/tests/e2e/wrong_chain_import.rs
+++ b/crates/seismic/node/tests/e2e/wrong_chain_import.rs
@@ -23,6 +23,7 @@ use reth_seismic_primitives::{
     test_utils::{get_unsigned_legacy_tx_request, sign_tx},
     SeismicBlock, SeismicTransactionSigned,
 };
+use std::time::Duration;
 
 /// A block containing a transaction signed for a different chain must be rejected by
 /// `engine_newPayload`, mirroring the txpool's chain-ID admission check.
@@ -66,12 +67,20 @@ async fn test_new_payload_rejects_wrong_chain_id_tx() -> Result<()> {
     let sealed = SealedBlock::seal_slow(block);
 
     // Submit through the engine's newPayload handler (the ConfigureEngineEvm import path).
-    let status = node
-        .inner
-        .add_ons_handle
-        .beacon_engine_handle
-        .new_payload(SeismicPayloadTypes::block_to_payload(sealed))
-        .await?;
+    //
+    // This is Seismic-owned test code, not an upstream helper edit. The invalid payload should
+    // return quickly; until our fork absorbs upstream reth#23837's e2e payload-helper fix, keep
+    // intentional waits in this regression bounded so CI reports the stuck rejection path instead
+    // of timing out the entire integration-test job.
+    let status = tokio::time::timeout(
+        Duration::from_secs(15),
+        node.inner
+            .add_ons_handle
+            .beacon_engine_handle
+            .new_payload(SeismicPayloadTypes::block_to_payload(sealed)),
+    )
+    .await
+    .expect("engine_newPayload timed out rejecting wrong-chain transaction")?;
 
     assert!(
         status.is_invalid(),


### PR DESCRIPTION
Bound the two Seismic audit-regression newPayload tests with local timeouts so CI reports a stuck rejection path instead of waiting for the 30m integration-test job timeout.

Add a narrow nextest slow-timeout override for the same tests. The config comment documents the related upstream reth payload-helper fixes and notes that this override can be removed after rebasing or cherry-picking them.