### PR TITLE
ci: enforce MSRV 1.88 with a dedicated build job

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -37,6 +37,29 @@ jobs:
       - name: cargo check (workspace)
         run: cargo check --workspace
 
+  msrv:
+    name: MSRV (1.88)
+    runs-on: large-github-runner
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      # @master is the action's canonical ref, the only one that reads an
+      # explicit `toolchain` input. The @stable/@nightly refs the other jobs use
+      # are just shorthands that bake the toolchain into the ref itself, so they
+      # can't pin an arbitrary version. Matches upstream reth's msrv job.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88" # keep in sync with rust-version in Cargo.toml
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "msrv-cache"
+          cache-on-failure: true
+      - name: cargo build (MSRV)
+        run: cargo build --bin seismic-reth --workspace
+        env:
+          RUSTFLAGS: -D warnings
+
   warnings:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
#403 silently broke the tree on rustc 1.88 (the declared workspace rust-version) and no enforced CI job noticed, because nothing runs an old toolchain over the seismic-reth dep closure. Add an `msrv` job to the enforced seismic.yml that builds `--bin seismic-reth --workspace` on 1.88 with `-D warnings`, so #403-style regressions fail at PR time instead of surfacing later at image-build time.

- `--bin seismic-reth --workspace` pulls in the full binary dep closure (incl. reth-seismic-rpc, the crate #403 broke); upstream's msrv matrix never builds seismic-reth, so it would not have caught it.
- Own `shared-key` so 1.88 artifacts don't thrash the stable caches.
- Toolchain stays at 1.88 (seismic-reth's own floor); the 1.91.1 used by seismic-images is a summit/commonware constraint, not a reth one.

Note: if branch protection enumerates required checks per-job, the new `MSRV (1.88)` check must also be added to the required list for `seismic`.