### PR TITLE
test(e2e): cherry-pick upstream CheckPayloadAccepted header persistence fixes

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -590,12 +590,21 @@ where
                 // at least one client passes all the check, save the header in Env
                 if !accepted_check {
                     accepted_check = true;
-                    // save the header in Env
-                    env.active_node_state_mut()?.latest_header_time = next_new_payload.timestamp;
+                    // save the current block info in Env
+                    env.set_current_block_info(BlockInfo {
+                        hash: rpc_latest_header.hash,
+                        number: rpc_latest_header.inner.number,
+                        timestamp: rpc_latest_header.inner.timestamp,
+                    })?;
 
-                    // add it to header history
+                    // align latest header time and forkchoice state with the accepted canonical
+                    // head
+                    env.active_node_state_mut()?.latest_header_time =
+                        rpc_latest_header.inner.timestamp;
                     env.active_node_state_mut()?.latest_fork_choice_state.head_block_hash =
                         rpc_latest_header.hash;
+
+                    // update local copy for any further usage in this scope
                     latest_block.hash = rpc_latest_header.hash;
                     latest_block.number = rpc_latest_header.inner.number;
                 }

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -510,7 +510,7 @@ where
         Box::pin(async move {
             let mut accepted_check: bool = false;
 
-            let mut latest_block = env
+            let latest_block = env
                 .current_block_info()
                 .ok_or_else(|| eyre::eyre!("No latest block information available"))?;
 
@@ -603,10 +603,6 @@ where
                         rpc_latest_header.inner.timestamp;
                     env.active_node_state_mut()?.latest_fork_choice_state.head_block_hash =
                         rpc_latest_header.hash;
-
-                    // update local copy for any further usage in this scope
-                    latest_block.hash = rpc_latest_header.hash;
-                    latest_block.number = rpc_latest_header.inner.number;
                 }
             }
 


### PR DESCRIPTION
## Intent

Cherry-pick two upstream reth commits verbatim onto the seismic fork, replacing nothing and adding no fork-authored changes: paradigmxyz/reth#18275 (fix(e2e): persist accepted header in CheckPayloadAccepted and align timestamp) and its follow-up #18953 (fix(testsuite): remove the now-dead local latest_block writes). Both carry -x cherry-pick provenance trailers deliberately, so future upstream merges and audit tooling (git cherry, git log --cherry-pick) recognize them as upstream's commits. This is a provenance-preserving replacement for a hand-ported version of the same fix that previously lived inside the clippy-gate branch (PR #442); #442 will drop its copy and depends on this PR merging first. The end state of produce_blocks.rs is byte-identical to upstream after #18953. Ship as its own PR because the repo squash-merges and burying the picks in #442 would destroy the provenance.

## What Changed

- Cherry-picks upstream [paradigmxyz/reth#18275](https://github.com/paradigmxyz/reth/pull/18275) verbatim: `CheckPayloadAccepted` now persists the accepted block info into the test environment via `set_current_block_info` and aligns `latest_header_time` plus the forkchoice head with the accepted canonical header, instead of only mutating a local `latest_block` copy that was dropped on return.
- Cherry-picks the follow-up [paradigmxyz/reth#18953](https://github.com/paradigmxyz/reth/pull/18953) verbatim: removes the now-dead local `latest_block` writes left behind by #18275 (the binding is no longer `mut`).
- Both commits carry `-x` cherry-pick provenance trailers so `git cherry` / `git log --cherry-pick` recognize them as upstream commits, and the pipeline verified matching patch-ids against upstream 82fb54763 and 16e79888a; the end state of `produce_blocks.rs` is byte-identical to upstream after #18953. This lands as its own PR (the repo squash-merges) and replaces the hand-ported copy of the same fix in #442, which depends on this merging first.

## Risk Assessment

✅ Low: The branch is exactly two verbatim upstream cherry-picks with -x provenance trailers touching only e2e test utilities, with no fork-authored changes and an internally consistent end state matching the stated intent.

## Testing

Verified every provenance acceptance criterion with git tooling: both commits are byte-verbatim cherry-picks of upstream #18275/#18953 (matching patch-ids, -x trailers, upstream authorship), git cherry recognizes them as upstream's commits, produce_blocks.rs at HEAD is blob-identical to upstream post-#18953, and the range contains no other changes; the supplementary local e2e testsuite run was still building when reporting was forced, so its pass result was not captured (upstream CI already validated the identical code).

<details>
<summary>Evidence: Provenance verification transcript (trailers, patch-id match, git cherry, blob identity, range diff)</summary>

```text
# Provenance verification: upstream cherry-picks #18275 / #18953 onto seismic-reth

Fork branch: upstream-e2e-checkpayloadaccepted (HEAD = 600469883)
Base: af1ddc8ff

## 1. Commits carry -x cherry-pick trailers with upstream authorship preserved
`` `
commit 600469883949f44eecac1dc3c0b49544f30211e5
Author:     Brian Picciano <me@mediocregopher.com>
AuthorDate: Mon Oct 13 11:36:17 2025 +0200
Commit:     Samuel Laferriere <9342524+samlaf@users.noreply.github.com>
CommitDate: Mon Jul 20 17:24:57 2026 -0400

    fix(testsuite): Fix unused updates in e2e-test-utils (#18953)

    (cherry picked from commit 16e79888ae24f15d688a95b76fcb73b7e9acb643)

commit e2410bcbde7c9f2d7f7c14c99aa99f9f59cf9233
Author:     Snezhkko <snezhkodaria38@gmail.com>
AuthorDate: Fri Sep 12 13:41:04 2025 +0300
Commit:     Samuel Laferriere <9342524+samlaf@users.noreply.github.com>
CommitDate: Mon Jul 20 17:24:57 2026 -0400

    fix(e2e): persist accepted header in CheckPayloadAccepted and align timestamp (#18275)

    Co-authored-by: Federico Gimenez <federico.gimenez@gmail.com>
    Co-authored-by: Federico Gimenez <fgimenez@users.noreply.github.com>
    (cherry picked from commit 82fb54763c5f49c18e9b305a58aa214d51b65142)
`` `

## 2. Verbatim picks: patch-id (mechanism behind git log --cherry-pick / git cherry) matches upstream exactly
`` `
fork     e2410bcbd  patch-id 08dd49700cd3bb70a4fababb9e7c8a380ddf87fe
upstream 82fb54763c5f49c18e9b305a58aa214d51b65142  patch-id 08dd49700cd3bb70a4fababb9e7c8a380ddf87fe
=> MATCH

fork     600469883  patch-id 386becec4ccd89f11d4cfd8ca10cd5f71b383fe5
upstream 16e79888ae24f15d688a95b76fcb73b7e9acb643  patch-id 386becec4ccd89f11d4cfd8ca10cd5f71b383fe5
=> MATCH
`` `

## 3. git cherry recognizes both as upstream commits ('-' = equivalent change already in fork branch)
`` `
$ git cherry -v <fork-HEAD> 82fb5476 82fb5476~1   # upstream #18275
- 82fb54763c5f49c18e9b305a58aa214d51b65142 fix(e2e): persist accepted header in CheckPayloadAccepted and align timestamp (#18275)

$ git cherry -v <fork-HEAD> 16e79888 16e79888~2   # upstream #18953
+ 99a5da2f91188fdb8b63caf42a9163db9616dc43 fix(example): launch with debug capabilities (#18947)
- 16e79888ae24f15d688a95b76fcb73b7e9acb643 fix(testsuite): Fix unused updates in e2e-test-utils (#18953)
`` `
(The `+ 99a5da2f` line is an unrelated upstream commit inside the 2-commit
inspection window that the fork intentionally does not carry; both target
commits show `-`, i.e. patch-equivalent commits exist on the fork branch.)

## 4. End state of produce_blocks.rs is byte-identical to upstream after #18953 (same git blob hash)
`` `
$ git rev-parse 600469883:...produce_blocks.rs 16e79888:...produce_blocks.rs
74a5e2ba1d516dcfd1b94fac762f2fed629490c9
74a5e2ba1d516dcfd1b94fac762f2fed629490c9

$ git diff 600469883:...produce_blocks.rs 16e79888:...produce_blocks.rs   (empty = identical)
`` `

## 5. No fork-authored changes: entire base..HEAD diff touches only produce_blocks.rs
`` `
 .../src/testsuite/actions/produce_blocks.rs             | 17 +++++++++++------
 1 file changed, 11 insertions(+), 6 deletions(-)
`` `
```
</details>
<details>
<summary>Evidence: git cherry recognition of both upstream commits</summary>

```text
$ git cherry -v <fork-HEAD> 82fb5476 82fb5476~1 # upstream #18275
- 82fb54763c5f49c18e9b305a58aa214d51b65142 fix(e2e): persist accepted header in CheckPayloadAccepted and align timestamp (#18275)

$ git cherry -v <fork-HEAD> 16e79888 16e79888~2 # upstream #18953
- 16e79888ae24f15d688a95b76fcb73b7e9acb643 fix(testsuite): Fix unused updates in e2e-test-utils (#18953)

$ git rev-parse 600469883:...produce_blocks.rs 16e79888:...produce_blocks.rs
74a5e2ba1d516dcfd1b94fac762f2fed629490c9
74a5e2ba1d516dcfd1b94fac762f2fed629490c9 (byte-identical to upstream)
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m16s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs:594` - Byte-identity of produce_blocks.rs to upstream post-#18953 could not be confirmed against the actual upstream remote (sandbox has no network to fetch commits 82fb54763/16e79888a). Offline evidence supports the claim: the file&#39;s fork history contains only upstream PR commits with no seismic divergence, both picks applied cleanly (blob chain c20b79d9a → 9d2088c11 → 74a5e2ba1), and the patch content matches the known upstream PRs. A later pipeline step with network access (or upstream CI diff) can trivially confirm.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs` - Functional e2e confirmation is incomplete: `cargo nextest run -p reth-e2e-test-utils --test e2e_testsuite` (which exercises the modified produce_blocks.rs via ProduceBlocks/AssertMineBlock actions with real node instances) was still compiling in the background when the report was forced to finalize, so no pass/fail result was captured. Risk is low — the end state of the file is byte-identical (same git blob) to upstream reth after #18953, which upstream CI already validated — but if you want local test confirmation, re-run that command.
- <code>`git log --format=fuller af1ddc8ff..600469883` — both commits carry `(cherry picked from commit &lt;upstream-sha&gt;)` trailers with upstream author/date preserved</code>
- <code>`git show &lt;commit&gt; | git patch-id --stable` for fork e2410bcbd vs upstream 82fb54763 and fork 600469883 vs upstream 16e79888a — both patch-ids MATCH (verbatim picks, recognized by `git log --cherry-pick`)</code>
- <code>`git cherry -v 600469883 82fb54763 82fb54763~1` and `git cherry -v 600469883 16e79888a 16e79888a~2` — both upstream commits marked `-` (equivalent commit present on fork branch)</code>
- <code>`git diff 600469883:crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs 16e79888a:&lt;same path&gt;` — empty diff, identical blob hash 74a5e2ba on both sides (byte-identical to upstream after #18953)</code>
- <code>`git diff --stat af1ddc8ff..600469883` — full range diff touches only produce_blocks.rs, confirming no fork-authored changes</code>
- <code>`cargo nextest run -p reth-e2e-test-utils --test e2e_testsuite` — launched in background; still compiling when the report was finalized, no result captured</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `crates/e2e-test-utils/src/rpc.rs:58` - Pre-existing clippy errors (10) in reth-e2e-test-utils outside the changed file — useless_conversion in rpc.rs:58/72, doc_markdown and duplicate supertrait bounds in testsuite/mod.rs, testsuite/setup.rs, setup_import.rs. They predate this change (only produce_blocks.rs was touched, and it lints clean) and are not covered by the Seismic CI clippy job. Deliberately not fixed here: the user intent requires this PR to contain only the two verbatim upstream cherry-picks with no fork-authored changes. If upstream&#39;s workspace-wide lint.yml clippy job is active on fork PRs, address these in a separate follow-up PR.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
