### PR TITLE
fix(seismic-rpc): only report Seismic tx type for signed reads, not plain eth_call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4110,7 +4110,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4539,7 +4539,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5579,7 +5579,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6616,7 +6616,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "either",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "either",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10875,7 +10875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11327,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=cc149a640c44b558eccd6ec9ad81d34b723f0516#cc149a640c44b558eccd6ec9ad81d34b723f0516"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -11937,7 +11937,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13158,7 +13158,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,18 +769,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "cc149a640c44b558eccd6ec9ad81d34b723f0516" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 

--- a/crates/seismic/node/tests/e2e/main.rs
+++ b/crates/seismic/node/tests/e2e/main.rs
@@ -10,6 +10,7 @@ mod pending_block;
 // roots. Currently broken from stable coin gas update not burning gas
 mod signed_read_import;
 mod testsuite;
+mod txtype;
 mod wrong_chain_import;
 
 const fn main() {}

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -1,0 +1,176 @@
+//! End-to-end coverage for the TXTYPE opcode's RPC classification on the seismic node.
+//!
+//! The node must run an authenticated signed read as a Seismic tx (`txtype() == 74`) and a plain
+//! `eth_call` as standard (`txtype() != 74`). The probe's `requireSeismic()` reverts unless
+//! `txtype() == 74`, so success-vs-revert is a **74-specific** signal (no other type passes) that
+//! needs no response decryption and exercises the `eth_call` and `estimateGas` handlers directly
+//! (reth tags those two handlers independently).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file.
+
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{hex::FromHex, Bytes, TxKind};
+use alloy_rpc_types::{Block, TransactionInput, TransactionRequest};
+use jsonrpsee::http_client::HttpClientBuilder;
+use reth_seismic_node::utils::{
+    e2e::{ensure_mock_purpose_keys, setup},
+    test_utils::get_signed_seismic_tx_typed_data,
+};
+use reth_seismic_primitives::test_utils::sign_tx;
+use reth_seismic_rpc::ext::EthApiOverrideClient;
+use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
+
+// TxTypeProbe (compiled with ssolc, --evm-version mercury):
+//   requireSeismic() [c6d819f6] -> reverts unless txtype() == 0x4A
+const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b50609f80601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063c6d819f614602a575b5f5ffd5b60306032565b005b604ab214603d575f5ffd5b56fea26469706673582212208b35e1118a8dc0dc3236014d69bd3f0d2b56b74698c4f84649930d9e14726b3664736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
+
+const REQUIRE_SEISMIC_SELECTOR: &str = "c6d819f6";
+
+/// Plain standard `SeismicTransactionRequest` (no signature, no seismic elements) to `contract`.
+fn plain_call(contract: alloy_primitives::Address, calldata: Bytes) -> SeismicTransactionRequest {
+    SeismicTransactionRequest {
+        inner: TransactionRequest {
+            to: Some(TxKind::Call(contract)),
+            input: TransactionInput { input: Some(calldata), data: None },
+            ..Default::default()
+        },
+        seismic_elements: None,
+    }
+}
+
+/// The `eth_call` handler must classify a signed read as Seismic (`txtype()==74`) and a plain call
+/// as standard: `requireSeismic()` succeeds for the signed read and reverts for the plain call.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_eth_call_classifies_signed_read() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+    let recent = node.advance_block().await.unwrap().block().hash();
+    let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
+
+    // Signed read -> txtype()==74 -> requireSeismic() succeeds.
+    let signed = get_signed_seismic_tx_typed_data(
+        &signer,
+        1,
+        TxKind::Call(contract),
+        chain_id,
+        selector.clone(),
+        recent,
+    )
+    .await;
+    let signed_res = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TypedData(signed),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        signed_res.is_ok(),
+        "signed eth_call to requireSeismic() should succeed (txtype()==74), got {signed_res:?}"
+    );
+
+    // Plain eth_call -> txtype()!=74 -> requireSeismic() reverts.
+    let plain_res = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TransactionRequest(plain_call(contract, selector)),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        plain_res.is_err(),
+        "plain eth_call to requireSeismic() should revert (txtype()!=74), but it succeeded"
+    );
+}
+
+/// The `estimateGas` handler must classify a signed read as Seismic independently of `eth_call`:
+/// estimating `requireSeismic()` succeeds for the signed read and reverts for the plain call.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_estimate_gas_classifies_signed_read() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+    let recent = node.advance_block().await.unwrap().block().hash();
+    let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
+
+    let signed = get_signed_seismic_tx_typed_data(
+        &signer,
+        1,
+        TxKind::Call(contract),
+        chain_id,
+        selector.clone(),
+        recent,
+    )
+    .await;
+    let signed_res = EthApiOverrideClient::<Block>::estimate_gas(
+        &client,
+        SeismicCallRequest::TypedData(signed),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        signed_res.is_ok(),
+        "signed estimateGas of requireSeismic() should succeed (txtype()==74), got {signed_res:?}"
+    );
+
+    let plain_res = EthApiOverrideClient::<Block>::estimate_gas(
+        &client,
+        SeismicCallRequest::TransactionRequest(plain_call(contract, selector)),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        plain_res.is_err(),
+        "plain estimateGas of requireSeismic() should revert (txtype()!=74), but it succeeded"
+    );
+}
+
+/// Deploy the probe as a standard tx via the signer's account (nonce 0) and return its address.
+async fn deploy_probe(
+    client: &jsonrpsee::http_client::HttpClient,
+    node: &mut reth_seismic_node::utils::e2e::SeismicTestNode,
+    signer: &alloy_signer_local::PrivateKeySigner,
+    from: alloy_primitives::Address,
+    chain_id: u64,
+) -> alloy_primitives::Address {
+    let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
+    let deploy = SeismicTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(from),
+            nonce: Some(0),
+            to: Some(TxKind::Create),
+            gas: Some(1_000_000),
+            max_fee_per_gas: Some(20e9 as u128),
+            max_priority_fee_per_gas: Some(20e9 as u128),
+            chain_id: Some(chain_id),
+            input: TransactionInput { input: Some(deploy_code), data: None },
+            ..Default::default()
+        },
+        seismic_elements: None,
+    };
+    let signed = sign_tx(signer.clone(), deploy).await;
+    let raw: Bytes = signed.encoded_2718().into();
+    EthApiOverrideClient::<Block>::send_raw_transaction(client, raw.into()).await.unwrap();
+    node.advance_block().await.unwrap();
+    from.create(0)
+}

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -18,7 +18,7 @@ use revm::{
     context_interface::{Block, Transaction},
     Database,
 };
-use seismic_alloy_consensus::SeismicTxType;
+use seismic_alloy_consensus::{SeismicTxType, SEISMIC_TX_TYPE_ID};
 use seismic_revm::{self, SeismicTransaction};
 
 impl<N, Rpc> EthCall for SeismicEthApi<N, Rpc>
@@ -121,14 +121,18 @@ where
             return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err());
         }
 
-        let tx_type = if request.authorization_list.is_some() {
+        // Only an explicitly Seismic-typed call (a signed read, set in ext.rs) is Seismic;
+        // a plain eth_call must not report as an encrypted channel.
+        let tx_type = if request.transaction_type == Some(SEISMIC_TX_TYPE_ID) {
+            SeismicTxType::Seismic
+        } else if request.authorization_list.is_some() {
             SeismicTxType::Eip7702
         } else if request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some() {
             SeismicTxType::Eip1559
         } else if request.access_list.is_some() {
             SeismicTxType::Eip2930
         } else {
-            SeismicTxType::Seismic
+            SeismicTxType::Legacy
         } as u8;
 
         let TransactionRequest {

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -35,7 +35,7 @@ use reth_rpc_eth_types::EthApiError;
 use reth_seismic_txpool::usdc::effective_balance;
 use reth_tracing::tracing::*;
 use seismic_alloy_consensus::{
-    Decodable712, InputDecryptionElements, SeismicTxEnvelope, TxSeismicMetadata,
+    Decodable712, InputDecryptionElements, SeismicTxEnvelope, TxSeismicMetadata, SEISMIC_TX_TYPE_ID,
 };
 use seismic_alloy_rpc_types::{
     SeismicCallRequest, SeismicRawTxRequest, SeismicTransactionRequest,
@@ -347,12 +347,15 @@ where
             let Bundle { transactions, block_override } = bundle;
             let mut prepared = Vec::with_capacity(transactions.len());
             for call in transactions {
-                let tx_req = convert_seismic_call_to_tx_request(call)?;
-                let plaintext_tx_req = signed_read_to_plaintext_tx(
-                    tx_req,
+                let (seismic_req, signed_read) = convert_seismic_call_to_tx_request(call)?;
+                let mut plaintext_tx_req = signed_read_to_plaintext_tx(
+                    (seismic_req, signed_read),
                     &self.purpose_keys.tx_io_sk,
                     self.eth_api.provider(),
                 )?;
+                if signed_read {
+                    plaintext_tx_req.inner.transaction_type = Some(SEISMIC_TX_TYPE_ID);
+                }
                 let tx_request: TransactionRequest = plaintext_tx_req.inner;
                 prepared.push(tx_request.into());
             }
@@ -396,11 +399,14 @@ where
 
         // process different CallRequest types
         let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
-        let plaintext_tx_req = signed_read_to_plaintext_tx(
+        let mut plaintext_tx_req = signed_read_to_plaintext_tx(
             (seismic_tx_request.clone(), signed_read),
             &self.purpose_keys.tx_io_sk,
             self.eth_api.provider(),
         )?;
+        if signed_read {
+            plaintext_tx_req.inner.transaction_type = Some(SEISMIC_TX_TYPE_ID);
+        }
 
         // call inner
         let result = EthCall::call(
@@ -464,11 +470,14 @@ where
         // spoofing that could leak private state. Signed requests (TypedData/Bytes)
         // authenticate the sender cryptographically and are processed normally.
         let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
-        let decrypted_req = signed_read_to_plaintext_tx(
+        let mut decrypted_req = signed_read_to_plaintext_tx(
             (seismic_tx_request, signed_read),
             &self.purpose_keys.tx_io_sk,
             self.eth_api.provider(),
         )?;
+        if signed_read {
+            decrypted_req.inner.transaction_type = Some(SEISMIC_TX_TYPE_ID);
+        }
 
         // call inner
         Ok(EthCall::estimate_gas_at(

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -274,12 +274,15 @@ where
             let mut prepared_calls = Vec::with_capacity(calls.len());
 
             for call in calls {
-                let tx_req = convert_seismic_call_to_tx_request(call)?;
-                let plaintext_tx_req = signed_read_to_plaintext_tx(
-                    tx_req,
+                let (seismic_req, signed_read) = convert_seismic_call_to_tx_request(call)?;
+                let mut plaintext_tx_req = signed_read_to_plaintext_tx(
+                    (seismic_req, signed_read),
                     &self.purpose_keys.tx_io_sk,
                     self.eth_api.provider(),
                 )?;
+                if signed_read {
+                    plaintext_tx_req.inner.transaction_type = Some(SEISMIC_TX_TYPE_ID);
+                }
                 let tx_request: TransactionRequest = plaintext_tx_req.inner;
                 prepared_calls.push(tx_request.into());
             }

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -30,6 +30,7 @@ pub const fn seismic_override_call_request(request: &mut SeismicTransactionReque
     request.inner.max_priority_fee_per_gas = None; // preventing InsufficientFunds error
     request.inner.max_fee_per_blob_gas = None; // preventing InsufficientFunds error
     request.inner.value = None; // preventing InsufficientFunds error
+    request.inner.transaction_type = None; // don't let a plain call spoof the Seismic tx type
     request.seismic_elements = None; // zero out seismic elements
 }
 


### PR DESCRIPTION
## Summary

`create_txn_env` derived the `eth_call` tx type by defaulting to `SeismicTxType::Seismic`
whenever no 1559/2930/7702 fee fields were present, and ignored `transaction_type`. As a
result a **plain, unauthenticated `eth_call`** executed as the Seismic type — so the
`TXTYPE` opcode / `isSeismicTx()` helper reported an *encrypted channel* for an
unauthenticated read. That's a confidentiality footgun: a contract gating a reveal on
`isSeismicTx()` would leak to any `eth_call`.

Fix (three coordinated changes):
- `create_txn_env`: mark Seismic only when the request is explicitly typed `0x4A`; default
  to `Legacy` otherwise.
- `ext.rs` (`call`, `call_many`, `estimate_gas`): a **signed read** carries
  `SEISMIC_TX_TYPE_ID` explicitly (the authoritative `signed_read` signal).
- `seismic_override_call_request`: strip a plain call's `transaction_type` so it can't spoof
  the Seismic type.

Real Seismic write txs are unaffected — they get their type from the decoded envelope in
the block executor, not `create_txn_env`.

## Testing (local sreth, dev + built-in keys, against a TXTYPE-capable revm)
- signed read → `isSeismic()` **true**
- plain `eth_call` → `isSeismic()` **false** (was **true** before this fix)
- seismic write (0x4A) → `txtype()` **74**
- legacy write → `txtype()` **2**

## Context
Part of the TXTYPE feature. Pairs with the equivalent sanvil fix (seismic-foundry) and the
opcode/builtin PRs (seismic-revm, seismic-solidity). "Piece 1": makes `isSeismicTx()` true
for signed reads and false for plain reads. See TXTYPE_REVIEW_HANDOFF.md.
