### PR TITLE
fix: encrypt revert/output data leaked by signed-read calls

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -50,6 +50,14 @@ use tracing::{trace, warn};
 /// Result type for `eth_simulateV1` RPC method.
 pub type SimulatedBlocksResult<N, E> = Result<Vec<SimulatedBlock<RpcBlock<N>>>, E>;
 
+/// Raw execution result type for `eth_simulateV1` before RPC response conversion.
+///
+/// Exposing this lets callers rebuild the response transactions from different bytes than were
+/// actually executed (see [`simulate::build_simulated_block_with_transactions`]) — e.g. to
+/// restore ciphertext input for a confidential-execution wrapper.
+pub type SimulatedBlocksRawResult<P, Halt, E> =
+    Result<Vec<simulate::SimulatedBlockExecution<P, Halt>>, E>;
+
 /// Execution related functions for the [`EthApiServer`](crate::EthApiServer) trait in
 /// the `eth_` namespace.
 pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthApiTypes {
@@ -73,6 +81,33 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         block: Option<BlockId>,
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
         async move {
+            let return_full_transactions = payload.return_full_transactions;
+            let raw_blocks = self.simulate_v1_raw(payload, block).await?;
+
+            raw_blocks
+                .into_iter()
+                .map(|execution| {
+                    simulate::build_simulated_block(
+                        execution.block,
+                        execution.results,
+                        return_full_transactions.into(),
+                        self.tx_resp_builder(),
+                    )
+                })
+                .collect()
+        }
+    }
+
+    /// Same execution as [`EthCall::simulate_v1`], but returns raw executed blocks and per-call
+    /// execution results before they are converted into RPC response objects.
+    fn simulate_v1_raw(
+        &self,
+        payload: SimulatePayload<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>,
+        block: Option<BlockId>,
+    ) -> impl Future<
+        Output = SimulatedBlocksRawResult<Self::Primitives, HaltReasonFor<Self::Evm>, Self::Error>,
+    > + Send {
+        async move {
             if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
                 return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into());
             }
@@ -83,7 +118,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 block_state_calls,
                 trace_transfers,
                 validation,
-                return_full_transactions,
+                return_full_transactions: _,
             } = payload;
 
             if block_state_calls.is_empty() {
@@ -98,8 +133,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             self.spawn_with_state_at_block(block, move |state| {
                 let mut db =
                     State::builder().with_database(StateProviderDatabase::new(state)).build();
-                let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
-                    Vec::with_capacity(block_state_calls.len());
+                let mut blocks = Vec::<
+                    simulate::SimulatedBlockExecution<Self::Primitives, HaltReasonFor<Self::Evm>>,
+                >::with_capacity(block_state_calls.len());
                 for block in block_state_calls {
                     let mut evm_env = this
                         .evm_config()
@@ -192,15 +228,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     };
 
                     parent = result.block.clone_sealed_header();
-
-                    let block = simulate::build_simulated_block(
-                        result.block,
-                        results,
-                        return_full_transactions.into(),
-                        this.tx_resp_builder(),
-                    )?;
-
-                    blocks.push(block);
+                    blocks.push(simulate::SimulatedBlockExecution { block: result.block, results });
                 }
 
                 Ok(blocks)
@@ -230,8 +258,40 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         &self,
         bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
-        mut state_override: Option<StateOverride>,
+        state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send {
+        async move {
+            let all_results = self.call_many_raw(bundles, state_context, state_override).await?;
+            Ok(all_results
+                .into_iter()
+                .map(|bundle_results| {
+                    bundle_results
+                        .into_iter()
+                        .map(|result| match result {
+                            Ok(output) => EthCallResponse { value: Some(output), error: None },
+                            Err(err) => {
+                                EthCallResponse { value: None, error: Some(err.to_string()) }
+                            }
+                        })
+                        .collect()
+                })
+                .collect())
+        }
+    }
+
+    /// Same execution as [`EthCall::call_many`], but returns the per-call [`Result`] before it
+    /// is downgraded to [`EthCallResponse`]'s `String` error representation.
+    ///
+    /// This lets callers (e.g. a confidential-execution wrapper) inspect and transform a
+    /// structured error — such as re-encrypting [`RevertError`] output — before any information
+    /// it carries is irreversibly flattened into a display string.
+    fn call_many_raw(
+        &self,
+        bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
+        state_context: Option<StateContext>,
+        mut state_override: Option<StateOverride>,
+    ) -> impl Future<Output = Result<Vec<Vec<Result<Bytes, Self::Error>>>, Self::Error>> + Send
+    {
         async move {
             // Check if the vector of bundles is empty
             if bundles.is_empty() {
@@ -317,18 +377,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             this.prepare_call_env(evm_env.clone(), tx, &mut db, overrides)?;
                         let res = this.transact(&mut db, current_evm_env, prepared_tx)?;
 
-                        match ensure_success::<_, Self::Error>(res.result) {
-                            Ok(output) => {
-                                bundle_results
-                                    .push(EthCallResponse { value: Some(output), error: None });
-                            }
-                            Err(err) => {
-                                bundle_results.push(EthCallResponse {
-                                    value: None,
-                                    error: Some(err.to_string()),
-                                });
-                            }
-                        }
+                        bundle_results.push(ensure_success::<_, Self::Error>(res.result));
 
                         // Commit state changes after each transaction to allow subsequent calls to
                         // see the updates

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -58,6 +58,9 @@ pub type SimulatedBlocksResult<N, E> = Result<Vec<SimulatedBlock<RpcBlock<N>>>, 
 pub type SimulatedBlocksRawResult<P, Halt, E> =
     Result<Vec<simulate::SimulatedBlockExecution<P, Halt>>, E>;
 
+/// Raw result type for `eth_callMany` before per-call errors are flattened into strings.
+pub type CallManyRawResult<E> = Result<Vec<Vec<Result<Bytes, E>>>, E>;
+
 /// Execution related functions for the [`EthApiServer`](crate::EthApiServer) trait in
 /// the `eth_` namespace.
 pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthApiTypes {
@@ -290,7 +293,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
         mut state_override: Option<StateOverride>,
-    ) -> impl Future<Output = Result<Vec<Vec<Result<Bytes, Self::Error>>>, Self::Error>> + Send
+    ) -> impl Future<Output = CallManyRawResult<Self::Error>> + Send
     {
         async move {
             // Check if the vector of bundles is empty

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -293,8 +293,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
         mut state_override: Option<StateOverride>,
-    ) -> impl Future<Output = CallManyRawResult<Self::Error>> + Send
-    {
+    ) -> impl Future<Output = CallManyRawResult<Self::Error>> + Send {
         async move {
             // Check if the vector of bundles is empty
             if bundles.is_empty() {

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -861,6 +861,14 @@ impl RevertError {
     pub const fn error_code(&self) -> i32 {
         EthRpcErrorCode::ExecutionError.code()
     }
+
+    /// Returns the raw revert output bytes, if any.
+    ///
+    /// This is intended for callers that need to inspect or transform the revm output
+    /// (e.g. to re-encrypt it for a networks whose calls may return confidential data).
+    pub fn output(&self) -> Option<&Bytes> {
+        self.output.as_ref()
+    }
 }
 
 impl std::fmt::Display for RevertError {

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -866,7 +866,7 @@ impl RevertError {
     ///
     /// This is intended for callers that need to inspect or transform the revm output
     /// (e.g. to re-encrypt it for a networks whose calls may return confidential data).
-    pub fn output(&self) -> Option<&Bytes> {
+    pub const fn output(&self) -> Option<&Bytes> {
         self.output.as_ref()
     }
 }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -10,9 +10,10 @@ use crate::{
 use alloy_consensus::{BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_network::TransactionBuilder;
+use alloy_primitives::{Sealable, B256};
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
-    BlockTransactionsKind,
+    Block, BlockTransactions, BlockTransactionsKind, TransactionInfo,
 };
 use jsonrpsee_types::ErrorObject;
 use reth_evm::{
@@ -55,6 +56,19 @@ impl ToRpcError for EthSimulateError {
     fn to_rpc_error(&self) -> ErrorObject<'static> {
         rpc_err(self.error_code(), self.to_string(), None)
     }
+}
+
+/// Raw execution output for a single simulated block before it is converted into an RPC response.
+///
+/// Exposing this lets callers rebuild the response transactions from different bytes than were
+/// actually executed (see [`build_simulated_block_with_transactions`]) — e.g. to restore
+/// ciphertext input for a confidential-execution wrapper.
+#[derive(Debug)]
+pub struct SimulatedBlockExecution<P: NodePrimitives, Halt> {
+    /// Executed block with the transactions that were actually run.
+    pub block: RecoveredBlock<BlockTy<P>>,
+    /// Per-transaction execution results in block order.
+    pub results: Vec<ExecutionResult<Halt>>,
 }
 
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
@@ -196,10 +210,40 @@ pub fn build_simulated_block<T, Halt: Clone>(
 where
     T: RpcConvert<Error: FromEthApiError + FromEvmHalt<Halt>>,
 {
+    let response_transactions = block.clone_transactions_recovered().collect();
+    build_simulated_block_with_transactions(
+        &block,
+        response_transactions,
+        results,
+        txs_kind,
+        tx_resp_builder,
+    )
+}
+
+/// Handles outputs of the calls execution and builds a [`SimulatedBlock`] using explicit
+/// response transactions.
+pub fn build_simulated_block_with_transactions<T, Halt: Clone>(
+    block: &RecoveredBlock<BlockTy<T::Primitives>>,
+    response_transactions: Vec<Recovered<<T::Primitives as NodePrimitives>::SignedTx>>,
+    results: Vec<ExecutionResult<Halt>>,
+    txs_kind: BlockTransactionsKind,
+    tx_resp_builder: &T,
+) -> Result<SimulatedBlock<RpcBlock<T::Network>>, T::Error>
+where
+    T: RpcConvert<Error: FromEthApiError + FromEvmHalt<Halt>>,
+{
+    // `response_transactions` must be positionally 1:1 with `block.body().transactions()`:
+    // logs, call results, and transaction indices below are associated by index, not by hash.
+    debug_assert_eq!(results.len(), block.body().transactions().len());
+    debug_assert_eq!(response_transactions.len(), block.body().transactions().len());
+
+    let tx_hashes: Vec<B256> = response_transactions.iter().map(|tx| *tx.tx_hash()).collect();
     let mut calls: Vec<SimCallResult> = Vec::with_capacity(results.len());
 
     let mut log_index = 0;
-    for (index, (result, tx)) in results.into_iter().zip(block.body().transactions()).enumerate() {
+    for (index, ((result, tx), tx_hash)) in
+        results.into_iter().zip(block.body().transactions()).zip(tx_hashes.iter()).enumerate()
+    {
         let call = match result {
             ExecutionResult::Halt { reason, gas_used } => {
                 let error = T::Error::from_evm_halt(reason, tx.gas_limit());
@@ -239,7 +283,7 @@ where
                             inner: log,
                             log_index: Some(log_index - 1),
                             transaction_index: Some(index as u64),
-                            transaction_hash: Some(*tx.tx_hash()),
+                            transaction_hash: Some(*tx_hash),
                             block_number: Some(block.header().number()),
                             block_timestamp: Some(block.header().timestamp()),
                             ..Default::default()
@@ -253,10 +297,36 @@ where
         calls.push(call);
     }
 
-    let block = block.into_rpc_block(
-        txs_kind,
-        |tx, tx_info| tx_resp_builder.fill(tx, tx_info),
-        |header, size| tx_resp_builder.convert_header(header, size),
-    )?;
+    let block_hash = Some(block.hash());
+    let block_number = block.header().number();
+    let base_fee = block.header().base_fee_per_gas();
+    let rlp_length = block.rlp_length();
+    let header = tx_resp_builder.convert_header(block.clone_sealed_header(), rlp_length)?;
+    let withdrawals = block.body().withdrawals().cloned();
+    let uncles = block.body().ommers().unwrap_or(&[]).iter().map(|h| h.hash_slow()).collect();
+
+    let transactions = match txs_kind {
+        BlockTransactionsKind::Hashes => BlockTransactions::Hashes(tx_hashes),
+        BlockTransactionsKind::Full => {
+            let transactions = response_transactions
+                .into_iter()
+                .enumerate()
+                .map(|(index, tx)| {
+                    let tx_info = TransactionInfo {
+                        hash: Some(*tx.tx_hash()),
+                        block_hash,
+                        block_number: Some(block_number),
+                        base_fee,
+                        index: Some(index as u64),
+                    };
+
+                    tx_resp_builder.fill(tx, tx_info)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            BlockTransactions::Full(transactions)
+        }
+    };
+
+    let block = Block { header, uncles, transactions, withdrawals };
     Ok(SimulatedBlock { inner: block, calls })
 }

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -345,7 +345,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
 where
     N: SeismicFullNode,
     EthB: EthApiBuilder<N>,
-    EthB::EthApi: FullEthApi + Send + Sync + 'static,
+    EthB::EthApi: FullEthApi<Primitives = SeismicPrimitives> + Send + Sync + 'static,
     <EthB::EthApi as reth_rpc_eth_api::EthApiTypes>::Error: Send + Sync + 'static,
     jsonrpsee::types::ErrorObject<'static>:
         From<<EthB::EthApi as reth_rpc_eth_api::EthApiTypes>::Error>,
@@ -355,8 +355,6 @@ where
             + Send
             + Sync
             + 'static,
-    <EthB::EthApi as reth_rpc_eth_api::RpcNodeCore>::Primitives:
-        reth_node_api::NodePrimitives<SignedTx = reth_seismic_primitives::SeismicTransactionSigned>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -454,7 +452,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RethRpcAddOns<N>
 where
     N: SeismicFullNode,
     EthB: EthApiBuilder<N>,
-    EthB::EthApi: FullEthApi + Send + Sync + 'static,
+    EthB::EthApi: FullEthApi<Primitives = SeismicPrimitives> + Send + Sync + 'static,
     <EthB::EthApi as reth_rpc_eth_api::EthApiTypes>::Error: Send + Sync + 'static,
     jsonrpsee::types::ErrorObject<'static>:
         From<<EthB::EthApi as reth_rpc_eth_api::EthApiTypes>::Error>,
@@ -464,8 +462,6 @@ where
             + Send
             + Sync
             + 'static,
-    <EthB::EthApi as reth_rpc_eth_api::RpcNodeCore>::Primitives:
-        reth_node_api::NodePrimitives<SignedTx = reth_seismic_primitives::SeismicTransactionSigned>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -355,6 +355,8 @@ where
             + Send
             + Sync
             + 'static,
+    <EthB::EthApi as reth_rpc_eth_api::RpcNodeCore>::Primitives:
+        reth_node_api::NodePrimitives<SignedTx = reth_seismic_primitives::SeismicTransactionSigned>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -462,6 +464,8 @@ where
             + Send
             + Sync
             + 'static,
+    <EthB::EthApi as reth_rpc_eth_api::RpcNodeCore>::Primitives:
+        reth_node_api::NodePrimitives<SignedTx = reth_seismic_primitives::SeismicTransactionSigned>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -113,10 +113,11 @@ pub mod test_utils {
     pub use reth_seismic_primitives::test_utils::{
         client_decrypt, client_encrypt, get_ciphertext, get_client_io_sk, get_encryption_nonce,
         get_network_public_key, get_plaintext, get_seismic_elements, get_seismic_metadata,
-        get_seismic_tx, get_signed_seismic_tx, get_signed_seismic_tx_bytes,
+        get_seismic_tx, get_signed_read_seismic_metadata, get_signed_seismic_call_bytes,
+        get_signed_seismic_call_typed_data, get_signed_seismic_tx, get_signed_seismic_tx_bytes,
         get_signed_seismic_tx_encoding, get_signed_seismic_tx_typed_data, get_signing_private_key,
-        get_unsigned_seismic_tx_request, get_unsigned_seismic_tx_typed_data, get_wrong_private_key,
-        sign_seismic_tx, sign_tx,
+        get_unsigned_seismic_call_request, get_unsigned_seismic_tx_request,
+        get_unsigned_seismic_tx_typed_data, get_wrong_private_key, sign_seismic_tx, sign_tx,
     };
 
     /// Get the nonce from the client

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -6,7 +6,7 @@
 //! on dev-mode auto-mining with `thread::sleep`.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, clippy::panic)] // Test file - panics are acceptable
 
-use alloy_consensus::{Transaction as _, TxEnvelope};
+use alloy_consensus::{proofs::calculate_transaction_root, Transaction as _, TxEnvelope};
 use alloy_dyn_abi::EventExt;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_json_abi::{Event, EventParam};
@@ -1363,6 +1363,7 @@ async fn test_simulate_v1_full_transactions_keep_signed_read_calldata_encrypted(
     let simulated_block = result.remove(0);
     assert_eq!(simulated_block.calls.len(), 1, "expected one simulated call result");
 
+    let returned_transactions_root = simulated_block.inner.header.transactions_root;
     let mut transactions = simulated_block.inner.into_transactions_vec();
     assert_eq!(transactions.len(), 1, "return_full_transactions should return full tx objects");
 
@@ -1377,6 +1378,12 @@ async fn test_simulate_v1_full_transactions_keep_signed_read_calldata_encrypted(
     assert_eq!(
         returned_hash, recomputed_hash,
         "simulateV1 full transaction hash should match the restored ciphertext input"
+    );
+    let recomputed_transactions_root =
+        calculate_transaction_root(std::slice::from_ref(&returned_tx.inner));
+    assert_eq!(
+        returned_transactions_root, recomputed_transactions_root,
+        "simulateV1 transaction root should match the restored ciphertext transaction"
     );
 
     Ok(())

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -6,11 +6,11 @@
 //! on dev-mode auto-mining with `thread::sleep`.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, clippy::panic)] // Test file - panics are acceptable
 
-use alloy_consensus::TxEnvelope;
+use alloy_consensus::{Transaction as _, TxEnvelope};
 use alloy_dyn_abi::EventExt;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_json_abi::{Event, EventParam};
-use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
+use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{
     aliases::{B96, U96},
     hex,
@@ -1317,6 +1317,328 @@ async fn test_usdc_only_eth_simulate_v1() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_full_transactions_keep_signed_read_calldata_encrypted() -> eyre::Result<()>
+{
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let contract_addr = flagged_storage_deploy_and_write(
+        &mut node,
+        &client,
+        chain_id,
+        &wallet,
+        FLAGGED_STORAGE_SET_PRIVATE,
+        U256::from(42),
+    )
+    .await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let set_private_calldata =
+        get_input_data(FLAGGED_STORAGE_SET_PRIVATE, B256::from(U256::from(99)));
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        get_nonce(&client, wallet.inner.address()).await,
+        TxKind::Call(contract_addr),
+        chain_id,
+        set_private_calldata.clone(),
+        block_hash,
+    )
+    .await;
+
+    let payload = SimulatePayload::<SeismicCallRequest> {
+        block_state_calls: vec![SimBlock {
+            block_overrides: None,
+            state_overrides: None,
+            calls: vec![SeismicCallRequest::Bytes(tx_bytes)],
+        }],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: true,
+    };
+
+    let mut result = EthApiOverrideClient::<Block>::simulate_v1(&client, payload, None)
+        .await
+        .expect("simulate_v1 must succeed for signed encrypted calldata");
+    assert_eq!(result.len(), 1, "expected one simulated block");
+
+    let simulated_block = result.remove(0);
+    assert_eq!(simulated_block.calls.len(), 1, "expected one simulated call result");
+
+    let mut transactions = simulated_block.inner.into_transactions_vec();
+    assert_eq!(transactions.len(), 1, "return_full_transactions should return full tx objects");
+
+    let returned_tx = transactions.remove(0);
+    let returned_input = returned_tx.input();
+    assert_ne!(
+        returned_input, &set_private_calldata,
+        "simulateV1 full transaction input leaked decrypted signed-read calldata"
+    );
+    let returned_hash = TransactionResponse::tx_hash(&returned_tx);
+    let recomputed_hash = alloy_primitives::keccak256(returned_tx.inner.encoded_2718());
+    assert_eq!(
+        returned_hash, recomputed_hash,
+        "simulateV1 full transaction hash should match the restored ciphertext input"
+    );
+
+    Ok(())
+}
+
+// RevertLeak test contract: reverts with a decimal-formatted private (`suint256`) value baked
+// into the revert reason string, simulating a contract author accidentally leaking a private
+// value via a custom revert (e.g. `revert InsufficientBalance(actualBalance)`).
+//
+// Solidity source (compiled with seismic solc, evm-version=mercury):
+//
+//   contract RevertLeak {
+//       suint256 private secret;
+//       function setSecret(suint256 value) public { secret = value; }
+//       function revertWithSecret() public view {
+//           uint256 revealed = uint256(secret);
+//           revert(string(abi.encodePacked("secret=", toString(revealed))));
+//       }
+//       function toString(uint256 value) internal pure returns (string memory) { ... }
+//   }
+const REVERT_LEAK_DEPLOY_BYTECODE: &[u8] = &hex!("6080604052348015600e575f5ffd5b506105e78061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c80638987b12814610038578063e0f7bec414610054575b5f5ffd5b610052600480360381019061004d9190610260565b61005e565b005b61005c610067565b005b805f8190b15050565b5f5fb09050610075816100d0565b6040516020016100859190610327565b6040516020818303038152906040526040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016100c791906103a0565b60405180910390fd5b60605f8203610116576040518060400160405280600181526020017f30000000000000000000000000000000000000000000000000000000000000008152509050610224565b5f8290505f5b5f821461014557808061012e906103f6565b915050600a8261013e919061046a565b915061011c565b5f8167ffffffffffffffff8111156101605761015f61049a565b5b6040519080825280601f01601f1916602001820160405280156101925781602001600182028036833780820191505090505b5090505b5f851461021d576001826101aa91906104c7565b9150600a856101b991906104fa565b60306101c5919061052a565b60f81b8183815181106101db576101da61055d565b5b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff191690815f1a905350600a85610216919061046a565b9450610196565b8093505050505b919050565b5f5ffd5b5f819050919050565b61023f8161022d565b8114610249575f5ffd5b50565b5f8135905061025a81610236565b92915050565b5f6020828403121561027557610274610229565b5b5f6102828482850161024c565b91505092915050565b5f81905092915050565b7f7365637265743d000000000000000000000000000000000000000000000000005f82015250565b5f6102c960078361028b565b91506102d482610295565b600782019050919050565b5f81519050919050565b8281835e5f83830152505050565b5f610301826102df565b61030b818561028b565b935061031b8185602086016102e9565b80840191505092915050565b5f610331826102bd565b915061033d82846102f7565b915081905092915050565b5f82825260208201905092915050565b5f601f19601f8301169050919050565b5f610372826102df565b61037c8185610348565b935061038c8185602086016102e9565b61039581610358565b840191505092915050565b5f6020820190508181035f8301526103b88184610368565b905092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f819050919050565b5f610400826103ed565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610432576104316103c0565b5b600182019050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b5f610474826103ed565b915061047f836103ed565b92508261048f5761048e61043d565b5b828204905092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b5f6104d1826103ed565b91506104dc836103ed565b92508282039050818111156104f4576104f36103c0565b5b92915050565b5f610504826103ed565b915061050f836103ed565b92508261051f5761051e61043d565b5b828206905092915050565b5f610534826103ed565b915061053f836103ed565b9250828201905080821115610557576105566103c0565b5b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffdfea2646970667358221220efc2a5dedbd6d373c0639d2ee3f210d4206d14702d22025bd9da8b583389b2f664736f6c637829302e382e33312d646576656c6f702e323032352e31312e31322b636f6d6d69742e3464313362633133005a");
+const REVERT_LEAK_SET_SECRET: &str = "8987b128"; // setSecret(suint256)
+const REVERT_LEAK_REVERT_WITH_SECRET: &str = "e0f7bec4"; // revertWithSecret()
+
+/// Deploy the `RevertLeak` test contract and set its private `secret` field via a signed
+/// (encrypted) seismic write transaction, returning the contract address.
+async fn revert_leak_deploy_and_set_secret(
+    node: &mut SeismicTestNode,
+    client: &jsonrpsee::http_client::HttpClient,
+    chain_id: u64,
+    wallet: &Wallet,
+    secret: U256,
+) -> eyre::Result<Address> {
+    let tx_hash = EthApiOverrideClient::<Block>::send_raw_transaction(
+        client,
+        get_signed_deploy_tx_bytes(
+            wallet.inner.clone(),
+            get_nonce(client, wallet.inner.address()).await,
+            chain_id,
+            Bytes::from_static(REVERT_LEAK_DEPLOY_BYTECODE),
+        )
+        .await
+        .into(),
+    )
+    .await
+    .unwrap();
+    node.advance_block().await?;
+
+    let receipt = EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::transaction_receipt(client, tx_hash)
+    .await
+    .unwrap()
+    .unwrap();
+    let contract_addr = receipt.contract_address.unwrap();
+    assert!(receipt.status());
+
+    let block_hash = get_recent_block_hash(client).await;
+    let set_data = get_input_data(REVERT_LEAK_SET_SECRET, B256::from(secret));
+    EthApiClient::<
+        SeismicTransactionRequest,
+        SeismicTransactionSigned,
+        SeismicBlock,
+        SeismicTransactionReceipt,
+        Header,
+    >::send_raw_transaction(
+        client,
+        get_signed_seismic_tx_bytes(
+            &wallet.inner,
+            get_nonce(client, wallet.inner.address()).await,
+            TxKind::Call(contract_addr),
+            chain_id,
+            set_data,
+            block_hash,
+        )
+        .await,
+    )
+    .await
+    .unwrap();
+    node.advance_block().await?;
+
+    Ok(contract_addr)
+}
+
+/// `eth_call`: a signed (encrypted) read that reverts must not leak the private value embedded
+/// in the revert reason in cleartext. The signer proved possession of the decryption key by
+/// submitting a signed request, so revert output deserves the same encryption guarantee as a
+/// successful return value.
+///
+/// Regression test for an audit finding: `eth_call` needs to encrypt revert data if it exists.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_call_signed_read_revert_leaks_private_data() -> eyre::Result<()> {
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let secret = U256::from(1337);
+    let contract_addr =
+        revert_leak_deploy_and_set_secret(&mut node, &client, chain_id, &wallet, secret).await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        nonce,
+        TxKind::Call(contract_addr),
+        chain_id,
+        revert_calldata,
+        block_hash,
+    )
+    .await;
+
+    let result =
+        EthApiOverrideClient::<Block>::call(&client, tx_bytes.into(), None, None, None).await;
+
+    let err = result.expect_err("revertWithSecret() must revert");
+    let err_msg = err.to_string();
+    assert!(
+        !err_msg.contains(&secret.to_string()),
+        "eth_call leaked private value {secret} in signed-read revert message: {err_msg}"
+    );
+    Ok(())
+}
+
+/// `eth_callMany`: same leak as `eth_call`, but via the bundled path — the per-call `error`
+/// string in `EthCallResponse` embeds the decoded revert reason in cleartext for signed reads.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_call_many_signed_read_revert_leaks_private_data() -> eyre::Result<()> {
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let secret = U256::from(2024);
+    let contract_addr =
+        revert_leak_deploy_and_set_secret(&mut node, &client, chain_id, &wallet, secret).await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        nonce,
+        TxKind::Call(contract_addr),
+        chain_id,
+        revert_calldata,
+        block_hash,
+    )
+    .await;
+
+    let bundle = Bundle::from(vec![SeismicCallRequest::Bytes(tx_bytes)]);
+    let mut results = EthApiOverrideClient::<Block>::call_many(&client, vec![bundle], None, None)
+        .await
+        .expect("callMany RPC call should return per-call results, not a top-level error");
+
+    assert_eq!(results.len(), 1, "expected one bundle result");
+    let mut bundle_results = results.remove(0);
+    assert_eq!(bundle_results.len(), 1, "expected one call result");
+    let call_result = bundle_results.remove(0);
+
+    let err_msg =
+        call_result.error.expect("revertWithSecret() must produce a per-call error via callMany");
+    assert!(
+        !err_msg.contains(&secret.to_string()),
+        "eth_callMany leaked private value {secret} in signed-read revert message: {err_msg}"
+    );
+    Ok(())
+}
+
+/// `eth_estimateGas`: same leak — a signed read that would revert on execution surfaces the
+/// decoded revert reason (with the private value embedded) in cleartext.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_estimate_gas_signed_read_revert_leaks_private_data() -> eyre::Result<()> {
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let secret = U256::from(5551234);
+    let contract_addr =
+        revert_leak_deploy_and_set_secret(&mut node, &client, chain_id, &wallet, secret).await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        nonce,
+        TxKind::Call(contract_addr),
+        chain_id,
+        revert_calldata,
+        block_hash,
+    )
+    .await;
+
+    let result =
+        EthApiOverrideClient::<Block>::estimate_gas(&client, tx_bytes.into(), None, None).await;
+
+    let err = result.expect_err("revertWithSecret() must revert during gas estimation");
+    let err_msg = err.to_string();
+    assert!(
+        !err_msg.contains(&secret.to_string()),
+        "eth_estimateGas leaked private value {secret} in signed-read revert message: {err_msg}"
+    );
+    Ok(())
+}
+
+/// `eth_simulateV1`: the per-call `error.message` for a signed-read revert embeds the decoded
+/// revert reason in cleartext, independent of `return_data` (which is already re-encrypted).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_signed_read_revert_message_leaks_private_data() -> eyre::Result<()> {
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let secret = U256::from(9988776);
+    let contract_addr =
+        revert_leak_deploy_and_set_secret(&mut node, &client, chain_id, &wallet, secret).await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let tx_bytes = get_signed_seismic_tx_bytes(
+        &wallet.inner,
+        nonce,
+        TxKind::Call(contract_addr),
+        chain_id,
+        revert_calldata,
+        block_hash,
+    )
+    .await;
+
+    let payload = SimulatePayload::<SeismicCallRequest> {
+        block_state_calls: vec![SimBlock {
+            block_overrides: None,
+            state_overrides: None,
+            calls: vec![SeismicCallRequest::Bytes(tx_bytes)],
+        }],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: false,
+    };
+
+    let mut result = EthApiOverrideClient::<Block>::simulate_v1(&client, payload, None)
+        .await
+        .expect("simulate_v1 must succeed at the top level even if the call reverts");
+    assert_eq!(result.len(), 1, "expected one simulated block");
+
+    let simulated_block = result.remove(0);
+    assert_eq!(simulated_block.calls.len(), 1, "expected one simulated call result");
+    let call_result = &simulated_block.calls[0];
+
+    assert!(!call_result.status, "revertWithSecret() call should not succeed");
+    let err_msg = call_result
+        .error
+        .as_ref()
+        .expect("revertWithSecret() must produce a SimulateError")
+        .message
+        .clone();
+    assert!(
+        !err_msg.contains(&secret.to_string()),
+        "eth_simulateV1 leaked private value {secret} in signed-read revert message: {err_msg}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_usdc_only_eth_estimate_gas_typed_data() -> eyre::Result<()> {
     let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
     let (contract_addr, recent_block_hash) =
@@ -1664,6 +1986,63 @@ async fn test_eth_call_many_allows_signed_cload_on_private_storage() -> eyre::Re
     assert_eq!(results.len(), 1, "expected one bundle result");
     let mut bundle_results = results.remove(0);
     assert_eq!(bundle_results.len(), 1, "expected one call result");
+    let call_result = bundle_results.remove(0);
+    let value = call_result.value.expect("call should have produced a value");
+
+    let metadata =
+        get_seismic_metadata(wallet.inner.address(), chain_id, nonce, to, U256::ZERO, block_hash);
+    let decrypted = client_decrypt(metadata, &value).unwrap();
+    assert_eq!(U256::from_be_slice(&decrypted), U256::from(42));
+    Ok(())
+}
+
+/// `eth_callMany` must preserve later bundle results even when an earlier bundle is empty.
+///
+/// Upstream skips empty bundles entirely, so the non-empty bundle below should still produce the
+/// same single successful signed-read result as
+/// `test_eth_call_many_allows_signed_cload_on_private_storage`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_call_many_skips_empty_bundle_without_dropping_later_results() -> eyre::Result<()>
+{
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+
+    let contract_addr = flagged_storage_deploy_and_write(
+        &mut node,
+        &client,
+        chain_id,
+        &wallet,
+        FLAGGED_STORAGE_SET_PRIVATE,
+        U256::from(42),
+    )
+    .await?;
+
+    let block_hash = get_recent_block_hash(&client).await;
+    let read_calldata: Bytes = hex::decode(FLAGGED_STORAGE_READ_PRIVATE_CLOAD).unwrap().into();
+    let nonce = get_nonce(&client, wallet.inner.address()).await;
+    let to = TxKind::Call(contract_addr);
+
+    let signed_bytes =
+        get_signed_seismic_tx_bytes(&wallet.inner, nonce, to, chain_id, read_calldata, block_hash)
+            .await;
+
+    let empty_bundle = Bundle::<SeismicCallRequest>::default();
+    let value_bundle = Bundle::from(vec![SeismicCallRequest::Bytes(signed_bytes)]);
+    let mut results = EthApiOverrideClient::<Block>::call_many(
+        &client,
+        vec![empty_bundle, value_bundle],
+        None,
+        None,
+    )
+    .await
+    .expect("callMany should ignore empty bundles without dropping later bundle results");
+
+    assert_eq!(
+        results.len(),
+        1,
+        "empty bundles should be skipped rather than consuming later bundle results"
+    );
+    let mut bundle_results = results.remove(0);
+    assert_eq!(bundle_results.len(), 1, "expected one call result from the non-empty bundle");
     let call_result = bundle_results.remove(0);
     let value = call_result.value.expect("call should have produced a value");
 

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1543,6 +1543,29 @@ async fn test_eth_call_many_signed_read_revert_leaks_private_data() -> eyre::Res
         !err_msg.contains(&secret.to_string()),
         "eth_callMany leaked private value {secret} in signed-read revert message: {err_msg}"
     );
+
+    // The error string carries the encrypted revert output as hex; the signer must be able to
+    // decrypt it and recover the plaintext revert reason.
+    let ciphertext_hex = err_msg
+        .strip_prefix("execution reverted: 0x")
+        .expect("signed-read revert error should embed the encrypted revert output");
+    let ciphertext: Bytes = hex::decode(ciphertext_hex).unwrap().into();
+    let metadata = get_seismic_metadata(
+        wallet.inner.address(),
+        chain_id,
+        nonce,
+        TxKind::Call(contract_addr),
+        U256::ZERO,
+        block_hash,
+    );
+    let decrypted = client_decrypt(metadata, &ciphertext).unwrap();
+    let reason = alloy_sol_types::RevertReason::decode(&decrypted)
+        .expect("decrypted revert output should decode")
+        .to_string();
+    assert!(
+        reason.contains(&format!("secret={secret}")),
+        "decrypted revert reason should contain the secret, got: {reason}"
+    );
     Ok(())
 }
 

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -32,8 +32,9 @@ use reth_rpc_eth_api::EthApiClient;
 use reth_seismic_node::utils::{
     e2e::{ensure_mock_purpose_keys, setup, SeismicTestNode},
     test_utils::{
-        client_decrypt, get_nonce, get_plaintext, get_seismic_metadata,
-        get_signed_seismic_tx_bytes, get_signed_seismic_tx_typed_data,
+        client_decrypt, get_nonce, get_plaintext, get_signed_read_seismic_metadata,
+        get_signed_seismic_call_bytes, get_signed_seismic_call_typed_data,
+        get_signed_seismic_tx_bytes, get_unsigned_seismic_call_request,
         get_unsigned_seismic_tx_request,
     },
 };
@@ -184,7 +185,7 @@ async fn rpc_test_check_parity(
     let to = TxKind::Call(contract_addr);
     let output = EthApiOverrideClient::<Block>::call(
         client,
-        get_signed_seismic_tx_bytes(
+        get_signed_seismic_call_bytes(
             &wallet.inner,
             nonce,
             to,
@@ -200,7 +201,7 @@ async fn rpc_test_check_parity(
     )
     .await
     .unwrap();
-    let metadata = get_seismic_metadata(
+    let metadata = get_signed_read_seismic_metadata(
         wallet.inner.address(),
         chain_id,
         nonce,
@@ -278,7 +279,7 @@ async fn rpc_test_gas_and_call_variants(
     // test eth_estimateGas with signed bytes (unsigned requests have `from` sanitized)
     let gas = EthApiOverrideClient::<Block>::estimate_gas(
         client,
-        get_signed_seismic_tx_bytes(
+        get_signed_seismic_call_bytes(
             &wallet.inner,
             get_nonce(client, wallet.inner.address()).await,
             TxKind::Call(contract_addr),
@@ -306,7 +307,7 @@ async fn rpc_test_gas_and_call_variants(
         "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e".parse().unwrap();
     let usdc_gas = EthApiOverrideClient::<Block>::estimate_gas(
         client,
-        get_signed_seismic_tx_bytes(
+        get_signed_seismic_call_bytes(
             &usdc_only_signer,
             get_nonce(client, usdc_only_signer.address()).await,
             TxKind::Call(contract_addr),
@@ -513,7 +514,7 @@ async fn test_seismic_reth_rpc_with_typed_data() -> eyre::Result<()> {
     let to = TxKind::Call(contract_addr);
     let output = EthApiOverrideClient::<Block>::call(
         &client,
-        get_signed_seismic_tx_typed_data(
+        get_signed_seismic_call_typed_data(
             &wallet.inner,
             nonce,
             to,
@@ -529,7 +530,7 @@ async fn test_seismic_reth_rpc_with_typed_data() -> eyre::Result<()> {
     )
     .await
     .unwrap();
-    let metadata = get_seismic_metadata(
+    let mut metadata = get_signed_read_seismic_metadata(
         wallet.inner.address(),
         chain_id,
         nonce,
@@ -537,6 +538,7 @@ async fn test_seismic_reth_rpc_with_typed_data() -> eyre::Result<()> {
         U256::ZERO,
         recent_block_hash,
     );
+    metadata.seismic_elements.message_version = 2;
     let decrypted_output = client_decrypt(metadata, &output).unwrap();
     assert_eq!(U256::from_be_slice(&decrypted_output), U256::ZERO);
 
@@ -891,7 +893,7 @@ async fn test_eth_call_allows_cload_on_public_storage() -> eyre::Result<()> {
     let nonce = get_nonce(&client, wallet.inner.address()).await;
     let result = EthApiOverrideClient::<Block>::call(
         &client,
-        get_signed_seismic_tx_bytes(
+        get_signed_seismic_call_bytes(
             &wallet.inner,
             nonce,
             TxKind::Call(contract_addr),
@@ -931,9 +933,16 @@ async fn test_eth_call_allows_cload_on_private_storage() -> eyre::Result<()> {
     let to = TxKind::Call(contract_addr);
     let output = EthApiOverrideClient::<Block>::call(
         &client,
-        get_signed_seismic_tx_bytes(&wallet.inner, nonce, to, chain_id, read_calldata, block_hash)
-            .await
-            .into(),
+        get_signed_seismic_call_bytes(
+            &wallet.inner,
+            nonce,
+            to,
+            chain_id,
+            read_calldata,
+            block_hash,
+        )
+        .await
+        .into(),
         None,
         None,
         None,
@@ -941,8 +950,14 @@ async fn test_eth_call_allows_cload_on_private_storage() -> eyre::Result<()> {
     .await
     .expect("CLOAD on private storage should succeed");
 
-    let metadata =
-        get_seismic_metadata(wallet.inner.address(), chain_id, nonce, to, U256::ZERO, block_hash);
+    let metadata = get_signed_read_seismic_metadata(
+        wallet.inner.address(),
+        chain_id,
+        nonce,
+        to,
+        U256::ZERO,
+        block_hash,
+    );
     let decrypted = client_decrypt(metadata, &output).unwrap();
     assert_eq!(U256::from_be_slice(&decrypted), U256::from(42));
     Ok(())
@@ -1180,7 +1195,7 @@ async fn test_eth_simulate_v1_rejects_code_override() -> eyre::Result<()> {
         },
     );
 
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         get_nonce(&client, wallet.inner.address()).await,
         TxKind::Call(victim_addr),
@@ -1235,7 +1250,7 @@ async fn get_signed_seismic_tx_bytes_with_gas_price(
     recent_block_hash: B256,
     gas_price: u128,
 ) -> Bytes {
-    let mut tx = get_unsigned_seismic_tx_request(
+    let mut tx = get_unsigned_seismic_call_request(
         sk_wallet,
         nonce,
         to,
@@ -1258,7 +1273,7 @@ async fn test_usdc_only_eth_call_signed_bytes() -> eyre::Result<()> {
     let signer = usdc_only_signer();
     let output = EthApiOverrideClient::<Block>::call(
         &client,
-        get_signed_seismic_tx_bytes(
+        get_signed_seismic_call_bytes(
             &signer,
             get_nonce(&client, signer.address()).await,
             TxKind::Call(contract_addr),
@@ -1288,7 +1303,7 @@ async fn test_usdc_only_eth_simulate_v1() -> eyre::Result<()> {
         rpc_test_deploy_contract(&mut node, &client, chain_id, &wallet).await?;
 
     let signer = usdc_only_signer();
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &signer,
         get_nonce(&client, signer.address()).await,
         TxKind::Call(contract_addr),
@@ -1334,7 +1349,7 @@ async fn test_simulate_v1_full_transactions_keep_signed_read_calldata_encrypted(
     let block_hash = get_recent_block_hash(&client).await;
     let set_private_calldata =
         get_input_data(FLAGGED_STORAGE_SET_PRIVATE, B256::from(U256::from(99)));
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         get_nonce(&client, wallet.inner.address()).await,
         TxKind::Call(contract_addr),
@@ -1489,7 +1504,7 @@ async fn test_eth_call_signed_read_revert_leaks_private_data() -> eyre::Result<(
     let block_hash = get_recent_block_hash(&client).await;
     let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         nonce,
         TxKind::Call(contract_addr),
@@ -1524,7 +1539,7 @@ async fn test_eth_call_many_signed_read_revert_leaks_private_data() -> eyre::Res
     let block_hash = get_recent_block_hash(&client).await;
     let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         nonce,
         TxKind::Call(contract_addr),
@@ -1557,7 +1572,7 @@ async fn test_eth_call_many_signed_read_revert_leaks_private_data() -> eyre::Res
         .strip_prefix("execution reverted: 0x")
         .expect("signed-read revert error should embed the encrypted revert output");
     let ciphertext: Bytes = hex::decode(ciphertext_hex).unwrap().into();
-    let metadata = get_seismic_metadata(
+    let metadata = get_signed_read_seismic_metadata(
         wallet.inner.address(),
         chain_id,
         nonce,
@@ -1589,7 +1604,7 @@ async fn test_eth_estimate_gas_signed_read_revert_leaks_private_data() -> eyre::
     let block_hash = get_recent_block_hash(&client).await;
     let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         nonce,
         TxKind::Call(contract_addr),
@@ -1624,7 +1639,7 @@ async fn test_simulate_v1_signed_read_revert_message_leaks_private_data() -> eyr
     let block_hash = get_recent_block_hash(&client).await;
     let revert_calldata: Bytes = hex::decode(REVERT_LEAK_REVERT_WITH_SECRET).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         nonce,
         TxKind::Call(contract_addr),
@@ -1675,7 +1690,7 @@ async fn test_usdc_only_eth_estimate_gas_typed_data() -> eyre::Result<()> {
         rpc_test_deploy_contract(&mut node, &client, chain_id, &wallet).await?;
 
     let signer = usdc_only_signer();
-    let typed = get_signed_seismic_tx_typed_data(
+    let typed = get_signed_seismic_call_typed_data(
         &signer,
         get_nonce(&client, signer.address()).await,
         TxKind::Call(contract_addr),
@@ -1740,6 +1755,15 @@ async fn test_usdc_only_susdc_transfer_e2e() -> eyre::Result<()> {
     let recent = get_recent_block_hash(&client).await;
     let nonce = get_nonce(&client, signer.address()).await;
 
+    let estimate_bytes = get_signed_seismic_call_bytes(
+        &signer,
+        nonce,
+        TxKind::Call(usdc),
+        chain_id,
+        plaintext.clone(),
+        recent,
+    )
+    .await;
     let signed_bytes = get_signed_seismic_tx_bytes(
         &signer,
         nonce,
@@ -1749,14 +1773,10 @@ async fn test_usdc_only_susdc_transfer_e2e() -> eyre::Result<()> {
         recent,
     )
     .await;
-    let estimate = EthApiOverrideClient::<Block>::estimate_gas(
-        &client,
-        signed_bytes.clone().into(),
-        None,
-        None,
-    )
-    .await
-    .expect("eth_estimateGas must succeed for USDC-only wallet");
+    let estimate =
+        EthApiOverrideClient::<Block>::estimate_gas(&client, estimate_bytes.into(), None, None)
+            .await
+            .expect("eth_estimateGas must succeed for USDC-only wallet");
     assert!(estimate > U256::ZERO);
 
     let tx_hash = EthApiOverrideClient::<Block>::send_raw_transaction(&client, signed_bytes.into())
@@ -1886,7 +1906,7 @@ async fn test_eth_simulate_v1_rejects_storage_override() -> eyre::Result<()> {
     state_overrides
         .insert(victim_addr, AccountOverride { state_diff: Some(storage), ..Default::default() });
 
-    let tx_bytes = get_signed_seismic_tx_bytes(
+    let tx_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         get_nonce(&client, wallet.inner.address()).await,
         TxKind::Call(victim_addr),
@@ -2004,9 +2024,15 @@ async fn test_eth_call_many_allows_signed_cload_on_private_storage() -> eyre::Re
     let nonce = get_nonce(&client, wallet.inner.address()).await;
     let to = TxKind::Call(contract_addr);
 
-    let signed_bytes =
-        get_signed_seismic_tx_bytes(&wallet.inner, nonce, to, chain_id, read_calldata, block_hash)
-            .await;
+    let signed_bytes = get_signed_seismic_call_bytes(
+        &wallet.inner,
+        nonce,
+        to,
+        chain_id,
+        read_calldata,
+        block_hash,
+    )
+    .await;
 
     let bundle = Bundle::from(vec![SeismicCallRequest::Bytes(signed_bytes)]);
     let mut results = EthApiOverrideClient::<Block>::call_many(&client, vec![bundle], None, None)
@@ -2019,8 +2045,14 @@ async fn test_eth_call_many_allows_signed_cload_on_private_storage() -> eyre::Re
     let call_result = bundle_results.remove(0);
     let value = call_result.value.expect("call should have produced a value");
 
-    let metadata =
-        get_seismic_metadata(wallet.inner.address(), chain_id, nonce, to, U256::ZERO, block_hash);
+    let metadata = get_signed_read_seismic_metadata(
+        wallet.inner.address(),
+        chain_id,
+        nonce,
+        to,
+        U256::ZERO,
+        block_hash,
+    );
     let decrypted = client_decrypt(metadata, &value).unwrap();
     assert_eq!(U256::from_be_slice(&decrypted), U256::from(42));
     Ok(())
@@ -2051,9 +2083,15 @@ async fn test_eth_call_many_skips_empty_bundle_without_dropping_later_results() 
     let nonce = get_nonce(&client, wallet.inner.address()).await;
     let to = TxKind::Call(contract_addr);
 
-    let signed_bytes =
-        get_signed_seismic_tx_bytes(&wallet.inner, nonce, to, chain_id, read_calldata, block_hash)
-            .await;
+    let signed_bytes = get_signed_seismic_call_bytes(
+        &wallet.inner,
+        nonce,
+        to,
+        chain_id,
+        read_calldata,
+        block_hash,
+    )
+    .await;
 
     let empty_bundle = Bundle::<SeismicCallRequest>::default();
     let value_bundle = Bundle::from(vec![SeismicCallRequest::Bytes(signed_bytes)]);
@@ -2076,8 +2114,14 @@ async fn test_eth_call_many_skips_empty_bundle_without_dropping_later_results() 
     let call_result = bundle_results.remove(0);
     let value = call_result.value.expect("call should have produced a value");
 
-    let metadata =
-        get_seismic_metadata(wallet.inner.address(), chain_id, nonce, to, U256::ZERO, block_hash);
+    let metadata = get_signed_read_seismic_metadata(
+        wallet.inner.address(),
+        chain_id,
+        nonce,
+        to,
+        U256::ZERO,
+        block_hash,
+    );
     let decrypted = client_decrypt(metadata, &value).unwrap();
     assert_eq!(U256::from_be_slice(&decrypted), U256::from(42));
     Ok(())
@@ -2104,7 +2148,7 @@ async fn test_eth_call_many_rejects_signed_read_with_stale_recent_block_hash() -
     let stale_block_hash = B256::ZERO;
     let read_calldata: Bytes = hex::decode(FLAGGED_STORAGE_READ_PRIVATE_CLOAD).unwrap().into();
     let nonce = get_nonce(&client, wallet.inner.address()).await;
-    let signed_bytes = get_signed_seismic_tx_bytes(
+    let signed_bytes = get_signed_seismic_call_bytes(
         &wallet.inner,
         nonce,
         TxKind::Call(contract_addr),

--- a/crates/seismic/primitives/src/test_utils.rs
+++ b/crates/seismic/primitives/src/test_utils.rs
@@ -221,6 +221,45 @@ pub fn get_seismic_metadata(
     }
 }
 
+/// Get signed-read seismic transaction metadata for testing.
+pub fn get_signed_read_seismic_metadata(
+    sender: Address,
+    chain_id: u64,
+    nonce: u64,
+    to: TxKind,
+    value: U256,
+    recent_block_hash: B256,
+) -> TxSeismicMetadata {
+    let mut metadata = get_seismic_metadata(sender, chain_id, nonce, to, value, recent_block_hash);
+    metadata.seismic_elements.signed_read = true;
+    metadata
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn get_unsigned_seismic_tx_request_with_options(
+    sk_wallet: &PrivateKeySigner,
+    nonce: u64,
+    to: TxKind,
+    chain_id: u64,
+    plaintext: Bytes,
+    recent_block_hash: B256,
+    signed_read: bool,
+    message_version: u8,
+) -> SeismicTransactionRequest {
+    let mut plaintext_req = get_plaintext_tx_request(sk_wallet, nonce, to, chain_id, &plaintext);
+    let mut metadata = get_metadata(&plaintext_req, recent_block_hash);
+    metadata.seismic_elements.signed_read = signed_read;
+    metadata.seismic_elements.message_version = message_version;
+    let ciphertext = metadata
+        .client_encrypt(&plaintext, &get_network_public_key(), &get_client_io_sk())
+        .unwrap();
+    plaintext_req.input = TransactionInput { input: Some(ciphertext), data: None };
+    SeismicTransactionRequest {
+        inner: plaintext_req,
+        seismic_elements: Some(metadata.seismic_elements),
+    }
+}
+
 /// Get an unsigned seismic transaction request
 pub async fn get_unsigned_seismic_tx_request(
     sk_wallet: &PrivateKeySigner,
@@ -230,16 +269,39 @@ pub async fn get_unsigned_seismic_tx_request(
     plaintext: Bytes,
     recent_block_hash: B256,
 ) -> SeismicTransactionRequest {
-    let mut plaintext_req = get_plaintext_tx_request(sk_wallet, nonce, to, chain_id, &plaintext);
-    let metadata = get_metadata(&plaintext_req, recent_block_hash);
-    let ciphertext = metadata
-        .client_encrypt(&plaintext, &get_network_public_key(), &get_client_io_sk())
-        .unwrap();
-    plaintext_req.input = TransactionInput { input: Some(ciphertext), data: None };
-    SeismicTransactionRequest {
-        inner: plaintext_req,
-        seismic_elements: Some(metadata.seismic_elements),
-    }
+    get_unsigned_seismic_tx_request_with_options(
+        sk_wallet,
+        nonce,
+        to,
+        chain_id,
+        plaintext,
+        recent_block_hash,
+        false,
+        0,
+    )
+    .await
+}
+
+/// Get an unsigned call-only seismic transaction request.
+pub async fn get_unsigned_seismic_call_request(
+    sk_wallet: &PrivateKeySigner,
+    nonce: u64,
+    to: TxKind,
+    chain_id: u64,
+    plaintext: Bytes,
+    recent_block_hash: B256,
+) -> SeismicTransactionRequest {
+    get_unsigned_seismic_tx_request_with_options(
+        sk_wallet,
+        nonce,
+        to,
+        chain_id,
+        plaintext,
+        recent_block_hash,
+        true,
+        0,
+    )
+    .await
 }
 
 /// Get an unsigned seismic transaction request
@@ -287,6 +349,28 @@ pub async fn get_signed_seismic_tx_bytes(
     <SeismicTxEnvelope as Encodable2718>::encoded_2718(&signed_inner).into()
 }
 
+/// Create a signed call-only seismic transaction.
+pub async fn get_signed_seismic_call_bytes(
+    sk_wallet: &PrivateKeySigner,
+    nonce: u64,
+    to: TxKind,
+    chain_id: u64,
+    plaintext: Bytes,
+    recent_block_hash: B256,
+) -> Bytes {
+    let tx = get_unsigned_seismic_call_request(
+        sk_wallet,
+        nonce,
+        to,
+        chain_id,
+        plaintext,
+        recent_block_hash,
+    )
+    .await;
+    let signed_inner = sign_tx(sk_wallet.clone(), tx).await;
+    <SeismicTxEnvelope as Encodable2718>::encoded_2718(&signed_inner).into()
+}
+
 /// Get an unsigned seismic transaction typed data
 #[allow(clippy::panic)] // Test util function - panic on failure is acceptable
 pub async fn get_unsigned_seismic_tx_typed_data(
@@ -297,13 +381,15 @@ pub async fn get_unsigned_seismic_tx_typed_data(
     decrypted_input: Bytes,
     recent_block_hash: B256,
 ) -> TypedData {
-    let tx_request = get_unsigned_seismic_tx_request(
+    let tx_request = get_unsigned_seismic_tx_request_with_options(
         sk_wallet,
         nonce,
         to,
         chain_id,
         decrypted_input,
         recent_block_hash,
+        false,
+        2,
     )
     .await;
     let typed_tx = tx_request.build_typed_tx().unwrap();
@@ -323,16 +409,46 @@ pub async fn get_signed_seismic_tx_typed_data(
     plaintext: Bytes,
     recent_block_hash: B256,
 ) -> TypedDataRequest {
-    let tx = get_unsigned_seismic_tx_request(
+    let tx = get_unsigned_seismic_tx_request_with_options(
         sk_wallet,
         nonce,
         to,
         chain_id,
         plaintext,
         recent_block_hash,
+        false,
+        2,
     )
     .await;
-    tx.seismic_elements.unwrap().message_version = 2;
+    let signed = sign_tx(sk_wallet.clone(), tx).await;
+
+    match signed {
+        SeismicTxEnvelope::Seismic(tx) => tx.into(),
+        _ => panic!("Signed transaction is not a seismic transaction"),
+    }
+}
+
+/// Create a signed call-only seismic transaction with typed data.
+#[allow(clippy::panic)] // Test util function - panic on failure is acceptable
+pub async fn get_signed_seismic_call_typed_data(
+    sk_wallet: &PrivateKeySigner,
+    nonce: u64,
+    to: TxKind,
+    chain_id: u64,
+    plaintext: Bytes,
+    recent_block_hash: B256,
+) -> TypedDataRequest {
+    let tx = get_unsigned_seismic_tx_request_with_options(
+        sk_wallet,
+        nonce,
+        to,
+        chain_id,
+        plaintext,
+        recent_block_hash,
+        true,
+        2,
+    )
+    .await;
     let signed = sign_tx(sk_wallet.clone(), tx).await;
 
     match signed {

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -27,15 +27,18 @@ use jsonrpsee::{
 };
 use reth_network_api::PeersInfo;
 use reth_network_peers::NodeRecord;
+use reth_primitives_traits::{NodePrimitives, Recovered};
 use reth_rpc_eth_api::{
     helpers::{EthCall, EthState, EthTransactions, FullEthApi},
-    RpcBlock, RpcTypes,
+    AsEthApiError, FromEthApiError, RpcBlock, RpcTypes,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{EthApiError, RevertError, RpcInvalidTransactionError};
+use reth_seismic_primitives::SeismicTransactionSigned;
 use reth_seismic_txpool::usdc::effective_balance;
 use reth_tracing::tracing::*;
 use seismic_alloy_consensus::{
-    Decodable712, InputDecryptionElements, SeismicTxEnvelope, TxSeismicMetadata,
+    Decodable712, InputDecryptionElements, SeismicTxEnvelope, SeismicTypedTransaction,
+    TxSeismicMetadata,
 };
 use seismic_alloy_rpc_types::{
     SeismicCallRequest, SeismicRawTxRequest, SeismicTransactionRequest,
@@ -232,6 +235,66 @@ impl<Eth> EthApiExt<Eth> {
             Ok(effective_balance(&*state, &address, native))
         })
     }
+
+    /// Re-encrypts the output bytes of a reverted call for a signed-read caller.
+    ///
+    /// A contract's revert data can embed arbitrary values from private state (e.g. a custom
+    /// error like `revert InsufficientBalance(actualBalance)`), just like a successful return
+    /// value can. For signed reads, `err` is re-wrapped with the revert output bytes encrypted
+    /// under the caller's key (mirroring the encryption already applied to successful output),
+    /// so a revert can't be used to exfiltrate private state in cleartext.
+    ///
+    /// Non-revert errors, and reverts with empty output, are returned unchanged.
+    fn reencrypt_revert_output<E>(
+        &self,
+        err: E,
+        seismic_tx_request: &SeismicTransactionRequest,
+    ) -> Result<E, EthApiError>
+    where
+        E: AsEthApiError + FromEthApiError,
+    {
+        let Some(EthApiError::InvalidTransaction(RpcInvalidTransactionError::Revert(revert))) =
+            err.as_err()
+        else {
+            return Ok(err);
+        };
+        let Some(output) = revert.output() else {
+            return Ok(err);
+        };
+
+        let sender = parse_request_sender(seismic_tx_request)?;
+        let metadata = Self::build_metadata(seismic_tx_request, sender)?;
+        let encrypted = metadata
+            .encrypt_response(&self.purpose_keys.tx_io_sk, output)
+            .map_err(|e| ext_encryption_error(e.to_string()))?;
+
+        Ok(E::from_eth_err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::Revert(
+            RevertError::new(encrypted),
+        ))))
+    }
+}
+
+/// Rebuilds a simulated signed-read transaction with its original ciphertext input so the
+/// response hash is recomputed from the bytes returned to the client.
+fn rebuild_simulated_signed_read_tx(
+    tx: Recovered<SeismicTransactionSigned>,
+    ciphertext_input: Bytes,
+) -> Result<Recovered<SeismicTransactionSigned>, EthApiError> {
+    let (signed_tx, signer) = tx.into_parts();
+    let (mut typed_tx, signature) = signed_tx.split();
+    match &mut typed_tx {
+        SeismicTypedTransaction::Legacy(tx) => tx.input = ciphertext_input,
+        SeismicTypedTransaction::Eip2930(tx) => tx.input = ciphertext_input,
+        SeismicTypedTransaction::Eip1559(tx) => tx.input = ciphertext_input,
+        SeismicTypedTransaction::Eip4844(tx) => tx.input = ciphertext_input,
+        SeismicTypedTransaction::Eip7702(tx) => tx.input = ciphertext_input,
+        SeismicTypedTransaction::Seismic(tx) => tx.input = ciphertext_input,
+    }
+
+    Ok(Recovered::new_unchecked(
+        SeismicTransactionSigned::new_unhashed(typed_tx, signature),
+        signer,
+    ))
 }
 
 #[async_trait]
@@ -239,6 +302,7 @@ impl<Eth> EthApiOverrideServer<RpcBlock<Eth::NetworkTypes>> for EthApiExt<Eth>
 where
     Eth: FullEthApi + Send + Sync + 'static,
     Eth::Error: Send + Sync + 'static,
+    Eth::Primitives: NodePrimitives<SignedTx = SeismicTransactionSigned>,
     jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
     <Eth::NetworkTypes as RpcTypes>::TransactionRequest:
         From<TransactionRequest> + AsRef<TransactionRequest> + Send + Sync + 'static,
@@ -262,6 +326,9 @@ where
     ) -> RpcResult<Vec<SimulatedBlock<RpcBlock<Eth::NetworkTypes>>>> {
         debug!(target: "reth-seismic-rpc::eth", "Serving seismic eth_simulateV1 extension");
 
+        let trace_transfers = payload.trace_transfers;
+        let validation = payload.validation;
+        let return_full_transactions = payload.return_full_transactions;
         let seismic_sim_blocks: Vec<SeismicSimBlock<SeismicCallRequest>> =
             payload.block_state_calls.clone();
 
@@ -290,28 +357,71 @@ where
             eth_simulated_blocks.push(prepared_block);
         }
 
-        // Call Eth simulate_v1, which only takes EthSimPayload/EthSimBlock
-        let mut result = EthCall::simulate_v1(
+        // Execute the simulated blocks while keeping the structured block/results form so the
+        // Seismic wrapper can rebuild the response transactions from ciphertext-backed inputs.
+        let raw_results = EthCall::simulate_v1_raw(
             &self.eth_api,
             EthSimulatePayload {
-                block_state_calls: eth_simulated_blocks.clone(),
-                trace_transfers: payload.trace_transfers,
-                validation: payload.validation,
-                return_full_transactions: payload.return_full_transactions,
+                block_state_calls: eth_simulated_blocks,
+                trace_transfers,
+                validation,
+                return_full_transactions,
             },
             block_number,
         )
         .await?;
 
-        // Convert Eth Blocks back to Seismic blocks
-        for (block, result) in seismic_sim_blocks.iter().zip(result.iter_mut()) {
-            let SeismicSimBlock::<SeismicCallRequest> { calls, .. } = block;
-            let SimulatedBlock { calls: call_results, .. } = result;
+        let mut result = Vec::with_capacity(raw_results.len());
 
+        // Convert Eth blocks back to Seismic blocks.
+        for (block, execution) in seismic_sim_blocks.iter().zip(raw_results) {
+            let SeismicSimBlock::<SeismicCallRequest> { calls, .. } = block;
+            let mut response_transactions = Vec::with_capacity(calls.len());
+            for (call, executed_tx) in
+                calls.iter().zip(execution.block.clone_transactions_recovered())
+            {
+                let (seismic_tx_request, signed_read) =
+                    convert_seismic_call_to_tx_request(call.clone())?;
+                let tx = if signed_read {
+                    let ciphertext_input =
+                        seismic_tx_request.inner.input.input.clone().ok_or_else(|| {
+                            EthApiError::InvalidParams(
+                                "signed-read simulate transaction missing input".to_string(),
+                            )
+                        })?;
+                    rebuild_simulated_signed_read_tx(executed_tx, ciphertext_input)?
+                } else {
+                    executed_tx
+                };
+                response_transactions.push(tx);
+            }
+
+            let mut simulated_block =
+                reth_rpc_eth_types::simulate::build_simulated_block_with_transactions(
+                    &execution.block,
+                    response_transactions,
+                    execution.results,
+                    return_full_transactions.into(),
+                    self.eth_api.tx_resp_builder(),
+                )?;
+            let SimulatedBlock { calls: call_results, .. } = &mut simulated_block;
+
+            // Encrypt signed-read outputs and replace plaintext revert messages with the generic
+            // form after the response block has been rebuilt with ciphertext-backed tx hashes.
             for (call_result, call) in call_results.iter_mut().zip(calls.iter()) {
                 let (seismic_tx_request, signed_read) =
                     convert_seismic_call_to_tx_request(call.clone())?;
                 if signed_read {
+                    // `build_simulated_block` sets a non-empty `return_data` only for
+                    // `ExecutionResult::Revert` (halts always leave it empty), and derives
+                    // `error.message` by decoding that same output as a revert reason. That
+                    // decoded reason can embed private state (e.g. a custom error like
+                    // `revert InsufficientBalance(actualBalance)`), so it must not reach the
+                    // client in cleartext. Replace it with a generic message: the caller can
+                    // still recover the real reason by decrypting `return_data` below.
+                    let is_revert_with_reason =
+                        !call_result.status && !call_result.return_data.is_empty();
+
                     // if there are seismic elements, encrypt the output
                     let sender = parse_request_sender(&seismic_tx_request)?;
                     let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
@@ -319,8 +429,16 @@ where
                         .encrypt_response(&self.purpose_keys.tx_io_sk, &call_result.return_data)
                         .map_err(|e| ext_encryption_error(e.to_string()))?;
                     call_result.return_data = encrypted_output;
+
+                    if is_revert_with_reason {
+                        if let Some(error) = call_result.error.as_mut() {
+                            error.message = "execution reverted".to_string();
+                        }
+                    }
                 }
             }
+
+            result.push(simulated_block);
         }
 
         Ok(result)
@@ -359,26 +477,47 @@ where
             prepared_bundles.push(Bundle { transactions: prepared, block_override });
         }
 
-        let mut result =
-            EthCall::call_many(&self.eth_api, prepared_bundles, state_context, state_override)
+        // Use the raw per-call `Result` form so a revert's structured `RevertError` (and its
+        // output bytes) is still available to re-encrypt below — the public `call_many` method
+        // downgrades errors to a `String` immediately, which would discard them.
+        let raw_results =
+            EthCall::call_many_raw(&self.eth_api, prepared_bundles, state_context, state_override)
                 .await?;
 
-        // Encrypt return data for signed-read calls so the response is readable only by the
-        // signer (matches the single-call `eth_call` behavior).
-        for (bundle, bundle_results) in seismic_bundles.iter().zip(result.iter_mut()) {
-            for (call, call_result) in bundle.transactions.iter().zip(bundle_results.iter_mut()) {
+        // Encrypt return data (and re-encrypt revert output) for signed-read calls so the
+        // response is readable only by the signer (matches the single-call `eth_call` behavior).
+        let mut result: Vec<Vec<EthCallResponse>> = Vec::with_capacity(raw_results.len());
+        for (bundle, bundle_results) in
+            seismic_bundles.iter().filter(|bundle| !bundle.transactions.is_empty()).zip(raw_results)
+        {
+            let mut encrypted_bundle_results = Vec::with_capacity(bundle_results.len());
+            for (call, call_result) in bundle.transactions.iter().zip(bundle_results) {
                 let (seismic_tx_request, signed_read) =
                     convert_seismic_call_to_tx_request(call.clone())?;
-                if signed_read {
-                    if let Some(value) = call_result.value.as_mut() {
-                        let sender = parse_request_sender(&seismic_tx_request)?;
-                        let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
-                        *value = metadata
-                            .encrypt_response(&self.purpose_keys.tx_io_sk, value)
-                            .map_err(|e| ext_encryption_error(e.to_string()))?;
+
+                let response = match call_result {
+                    Ok(mut value) => {
+                        if signed_read {
+                            let sender = parse_request_sender(&seismic_tx_request)?;
+                            let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
+                            value = metadata
+                                .encrypt_response(&self.purpose_keys.tx_io_sk, &value)
+                                .map_err(|e| ext_encryption_error(e.to_string()))?;
+                        }
+                        EthCallResponse { value: Some(value), error: None }
                     }
-                }
+                    Err(err) => {
+                        let err = if signed_read {
+                            self.reencrypt_revert_output(err, &seismic_tx_request)?
+                        } else {
+                            err
+                        };
+                        EthCallResponse { value: None, error: Some(err.to_string()) }
+                    }
+                };
+                encrypted_bundle_results.push(response);
             }
+            result.push(encrypted_bundle_results);
         }
 
         Ok(result)
@@ -409,7 +548,15 @@ where
             block_number,
             EvmOverrides::new(state_overrides, block_overrides),
         )
-        .await?;
+        .await;
+
+        // On revert, re-encrypt the output bytes before they reach the client: a contract's
+        // revert data can embed private state just like a successful return value can.
+        let result = match result {
+            Err(err) if signed_read => Err(self.reencrypt_revert_output(err, &seismic_tx_request)?),
+            other => other,
+        };
+        let result = result?;
 
         // encrypt result - only for signed reads with seismic elements
         if signed_read {
@@ -465,19 +612,28 @@ where
         // authenticate the sender cryptographically and are processed normally.
         let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
         let decrypted_req = signed_read_to_plaintext_tx(
-            (seismic_tx_request, signed_read),
+            (seismic_tx_request.clone(), signed_read),
             &self.purpose_keys.tx_io_sk,
             self.eth_api.provider(),
         )?;
 
         // call inner
-        Ok(EthCall::estimate_gas_at(
+        let result = EthCall::estimate_gas_at(
             &self.eth_api,
             decrypted_req.inner.into(),
             block_number.unwrap_or_default(),
             state_override,
         )
-        .await?)
+        .await;
+
+        // On revert, re-encrypt the output bytes before they reach the client: a contract's
+        // revert data can embed private state just like a successful return value can.
+        let result = match result {
+            Err(err) if signed_read => Err(self.reencrypt_revert_output(err, &seismic_tx_request)?),
+            other => other,
+        };
+
+        Ok(result?)
     }
 
     async fn get_balance(

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -8,6 +8,7 @@
 use crate::utils::{
     convert_seismic_call_to_tx_request, parse_request_sender, signed_read_to_plaintext_tx,
 };
+use alloy_consensus::proofs::calculate_transaction_root;
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_json_rpc::RpcObject;
@@ -27,13 +28,15 @@ use jsonrpsee::{
 };
 use reth_network_api::PeersInfo;
 use reth_network_peers::NodeRecord;
-use reth_primitives_traits::{NodePrimitives, Recovered};
+use reth_primitives_traits::{Recovered, RecoveredBlock};
 use reth_rpc_eth_api::{
     helpers::{EthCall, EthState, EthTransactions, FullEthApi},
     AsEthApiError, FromEthApiError, RpcBlock, RpcTypes,
 };
-use reth_rpc_eth_types::{EthApiError, RevertError, RpcInvalidTransactionError};
-use reth_seismic_primitives::SeismicTransactionSigned;
+use reth_rpc_eth_types::{
+    simulate::SimulatedBlockExecution, EthApiError, RevertError, RpcInvalidTransactionError,
+};
+use reth_seismic_primitives::{SeismicPrimitives, SeismicTransactionSigned};
 use reth_seismic_txpool::usdc::effective_balance;
 use reth_tracing::tracing::*;
 use seismic_alloy_consensus::{
@@ -297,12 +300,71 @@ fn rebuild_simulated_signed_read_tx(
     ))
 }
 
+/// Reconstructs raw simulated blocks so their bodies and headers commit to the ciphertext-backed
+/// transactions returned to signed-read callers.
+///
+/// Execution results remain those produced by the plaintext transactions. For consecutive
+/// simulated blocks, each reconstructed header is linked to the hash of the preceding
+/// reconstructed block.
+fn reconstruct_simulated_blocks<Halt>(
+    seismic_sim_blocks: &[SeismicSimBlock<SeismicCallRequest>],
+    raw_results: Vec<SimulatedBlockExecution<SeismicPrimitives, Halt>>,
+) -> Result<Vec<SimulatedBlockExecution<SeismicPrimitives, Halt>>, EthApiError> {
+    if seismic_sim_blocks.len() != raw_results.len() {
+        return Err(EthApiError::InternalEthError)
+    }
+
+    let mut reconstructed = Vec::with_capacity(raw_results.len());
+    let mut parent_hash = None;
+
+    for (sim_block, execution) in seismic_sim_blocks.iter().zip(raw_results) {
+        if sim_block.calls.len() != execution.block.body().transactions.len() {
+            return Err(EthApiError::InternalEthError)
+        }
+
+        let mut response_transactions = Vec::with_capacity(sim_block.calls.len());
+        for (call, executed_tx) in
+            sim_block.calls.iter().zip(execution.block.clone_transactions_recovered())
+        {
+            let (seismic_tx_request, signed_read) =
+                convert_seismic_call_to_tx_request(call.clone())?;
+            let response_tx = if signed_read {
+                let ciphertext_input =
+                    seismic_tx_request.inner.input.input.clone().ok_or_else(|| {
+                        EthApiError::InvalidParams(
+                            "signed-read simulate transaction missing input".to_string(),
+                        )
+                    })?;
+                rebuild_simulated_signed_read_tx(executed_tx, ciphertext_input)?
+            } else {
+                executed_tx
+            };
+            response_transactions.push(response_tx);
+        }
+
+        let (mut response_block, senders) = execution.block.split();
+        response_block.body.transactions =
+            response_transactions.into_iter().map(|tx| tx.into_parts().0).collect();
+        if let Some(parent_hash) = parent_hash {
+            response_block.header.parent_hash = parent_hash;
+        }
+        response_block.header.transactions_root =
+            calculate_transaction_root(&response_block.body.transactions);
+
+        let response_block = RecoveredBlock::new_unhashed(response_block, senders);
+        parent_hash = Some(response_block.hash());
+        reconstructed
+            .push(SimulatedBlockExecution { block: response_block, results: execution.results });
+    }
+
+    Ok(reconstructed)
+}
+
 #[async_trait]
 impl<Eth> EthApiOverrideServer<RpcBlock<Eth::NetworkTypes>> for EthApiExt<Eth>
 where
-    Eth: FullEthApi + Send + Sync + 'static,
+    Eth: FullEthApi<Primitives = SeismicPrimitives> + Send + Sync + 'static,
     Eth::Error: Send + Sync + 'static,
-    Eth::Primitives: NodePrimitives<SignedTx = SeismicTransactionSigned>,
     jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
     <Eth::NetworkTypes as RpcTypes>::TransactionRequest:
         From<TransactionRequest> + AsRef<TransactionRequest> + Send + Sync + 'static,
@@ -371,39 +433,19 @@ where
         )
         .await?;
 
+        let raw_results = reconstruct_simulated_blocks(&seismic_sim_blocks, raw_results)?;
+
         let mut result = Vec::with_capacity(raw_results.len());
 
-        // Convert Eth blocks back to Seismic blocks.
+        // Convert reconstructed Seismic blocks into RPC blocks.
         for (block, execution) in seismic_sim_blocks.iter().zip(raw_results) {
             let SeismicSimBlock::<SeismicCallRequest> { calls, .. } = block;
-            let mut response_transactions = Vec::with_capacity(calls.len());
-            for (call, executed_tx) in
-                calls.iter().zip(execution.block.clone_transactions_recovered())
-            {
-                let (seismic_tx_request, signed_read) =
-                    convert_seismic_call_to_tx_request(call.clone())?;
-                let tx = if signed_read {
-                    let ciphertext_input =
-                        seismic_tx_request.inner.input.input.clone().ok_or_else(|| {
-                            EthApiError::InvalidParams(
-                                "signed-read simulate transaction missing input".to_string(),
-                            )
-                        })?;
-                    rebuild_simulated_signed_read_tx(executed_tx, ciphertext_input)?
-                } else {
-                    executed_tx
-                };
-                response_transactions.push(tx);
-            }
-
-            let mut simulated_block =
-                reth_rpc_eth_types::simulate::build_simulated_block_with_transactions(
-                    &execution.block,
-                    response_transactions,
-                    execution.results,
-                    return_full_transactions.into(),
-                    self.eth_api.tx_resp_builder(),
-                )?;
+            let mut simulated_block = reth_rpc_eth_types::simulate::build_simulated_block(
+                execution.block,
+                execution.results,
+                return_full_transactions.into(),
+                self.eth_api.tx_resp_builder(),
+            )?;
             let SimulatedBlock { calls: call_results, .. } = &mut simulated_block;
 
             // Encrypt signed-read outputs and replace plaintext revert messages with the generic

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -507,12 +507,25 @@ where
                         EthCallResponse { value: Some(value), error: None }
                     }
                     Err(err) => {
-                        let err = if signed_read {
-                            self.reencrypt_revert_output(err, &seismic_tx_request)?
+                        // `EthCallResponse.error` is a plain string with no `data` field, so for
+                        // signed reads the encrypted revert output is appended as hex; otherwise
+                        // the ciphertext would be dropped and the signer couldn't decrypt the
+                        // revert reason.
+                        let err_str = if signed_read {
+                            let err = self.reencrypt_revert_output(err, &seismic_tx_request)?;
+                            match err.as_err() {
+                                Some(EthApiError::InvalidTransaction(
+                                    RpcInvalidTransactionError::Revert(revert),
+                                )) => match revert.output() {
+                                    Some(output) => format!("execution reverted: {output}"),
+                                    None => err.to_string(),
+                                },
+                                _ => err.to_string(),
+                            }
                         } else {
-                            err
+                            err.to_string()
                         };
-                        EthCallResponse { value: None, error: Some(err.to_string()) }
+                        EthCallResponse { value: None, error: Some(err_str) }
                     }
                 };
                 encrypted_bundle_results.push(response);

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -6,7 +6,7 @@
 //! See that function's docs for more details
 
 use crate::utils::{
-    convert_seismic_call_to_tx_request, parse_request_sender, signed_read_to_plaintext_tx,
+    parse_request_sender, resolve_seismic_call, seismic_call_to_plaintext_tx, SeismicCall,
 };
 use alloy_consensus::proofs::calculate_transaction_root;
 use alloy_dyn_abi::TypedData;
@@ -326,18 +326,16 @@ fn reconstruct_simulated_blocks<Halt>(
         for (call, executed_tx) in
             sim_block.calls.iter().zip(execution.block.clone_transactions_recovered())
         {
-            let (seismic_tx_request, signed_read) =
-                convert_seismic_call_to_tx_request(call.clone())?;
-            let response_tx = if signed_read {
-                let ciphertext_input =
-                    seismic_tx_request.inner.input.input.clone().ok_or_else(|| {
+            let response_tx = match resolve_seismic_call(call.clone())? {
+                SeismicCall::Transparent(_) => executed_tx,
+                SeismicCall::SignedRead(request) => {
+                    let ciphertext_input = request.inner.input.input.clone().ok_or_else(|| {
                         EthApiError::InvalidParams(
                             "signed-read simulate transaction missing input".to_string(),
                         )
                     })?;
-                rebuild_simulated_signed_read_tx(executed_tx, ciphertext_input)?
-            } else {
-                executed_tx
+                    rebuild_simulated_signed_read_tx(executed_tx, ciphertext_input)?
+                }
             };
             response_transactions.push(response_tx);
         }
@@ -403,9 +401,9 @@ where
             let mut prepared_calls = Vec::with_capacity(calls.len());
 
             for call in calls {
-                let tx_req = convert_seismic_call_to_tx_request(call)?;
-                let plaintext_tx_req = signed_read_to_plaintext_tx(
-                    tx_req,
+                let call = resolve_seismic_call(call)?;
+                let plaintext_tx_req = seismic_call_to_plaintext_tx(
+                    &call,
                     &self.purpose_keys.tx_io_sk,
                     self.eth_api.provider(),
                 )?;
@@ -451,31 +449,30 @@ where
             // Encrypt signed-read outputs and replace plaintext revert messages with the generic
             // form after the response block has been rebuilt with ciphertext-backed tx hashes.
             for (call_result, call) in call_results.iter_mut().zip(calls.iter()) {
-                let (seismic_tx_request, signed_read) =
-                    convert_seismic_call_to_tx_request(call.clone())?;
-                if signed_read {
-                    // `build_simulated_block` sets a non-empty `return_data` only for
-                    // `ExecutionResult::Revert` (halts always leave it empty), and derives
-                    // `error.message` by decoding that same output as a revert reason. That
-                    // decoded reason can embed private state (e.g. a custom error like
-                    // `revert InsufficientBalance(actualBalance)`), so it must not reach the
-                    // client in cleartext. Replace it with a generic message: the caller can
-                    // still recover the real reason by decrypting `return_data` below.
-                    let is_revert_with_reason =
-                        !call_result.status && !call_result.return_data.is_empty();
+                let SeismicCall::SignedRead(request) = resolve_seismic_call(call.clone())? else {
+                    continue
+                };
 
-                    // if there are seismic elements, encrypt the output
-                    let sender = parse_request_sender(&seismic_tx_request)?;
-                    let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
-                    let encrypted_output = metadata
-                        .encrypt_response(&self.purpose_keys.tx_io_sk, &call_result.return_data)
-                        .map_err(|e| ext_encryption_error(e.to_string()))?;
-                    call_result.return_data = encrypted_output;
+                // `build_simulated_block` sets a non-empty `return_data` only for
+                // `ExecutionResult::Revert` (halts always leave it empty), and derives
+                // `error.message` by decoding that same output as a revert reason. That
+                // decoded reason can embed private state (e.g. a custom error like
+                // `revert InsufficientBalance(actualBalance)`), so it must not reach the
+                // client in cleartext. Replace it with a generic message: the caller can
+                // still recover the real reason by decrypting `return_data` below.
+                let is_revert_with_reason =
+                    !call_result.status && !call_result.return_data.is_empty();
 
-                    if is_revert_with_reason {
-                        if let Some(error) = call_result.error.as_mut() {
-                            error.message = "execution reverted".to_string();
-                        }
+                let sender = parse_request_sender(&request)?;
+                let metadata = Self::build_metadata(&request, sender)?;
+                let encrypted_output = metadata
+                    .encrypt_response(&self.purpose_keys.tx_io_sk, &call_result.return_data)
+                    .map_err(|e| ext_encryption_error(e.to_string()))?;
+                call_result.return_data = encrypted_output;
+
+                if is_revert_with_reason {
+                    if let Some(error) = call_result.error.as_mut() {
+                        error.message = "execution reverted".to_string();
                     }
                 }
             }
@@ -500,16 +497,16 @@ where
 
         // Convert each Bundle<SeismicCallRequest> into the upstream Bundle<TransactionRequest>:
         // unsigned requests are sanitized; signed requests have their freshness validated and
-        // calldata decrypted by `signed_read_to_plaintext_tx`.
+        // calldata decrypted by `seismic_call_to_plaintext_tx`.
         let mut prepared_bundles: Vec<Bundle<<Eth::NetworkTypes as RpcTypes>::TransactionRequest>> =
             Vec::with_capacity(bundles.len());
         for bundle in bundles {
             let Bundle { transactions, block_override } = bundle;
             let mut prepared = Vec::with_capacity(transactions.len());
             for call in transactions {
-                let tx_req = convert_seismic_call_to_tx_request(call)?;
-                let plaintext_tx_req = signed_read_to_plaintext_tx(
-                    tx_req,
+                let call = resolve_seismic_call(call)?;
+                let plaintext_tx_req = seismic_call_to_plaintext_tx(
+                    &call,
                     &self.purpose_keys.tx_io_sk,
                     self.eth_api.provider(),
                 )?;
@@ -534,38 +531,36 @@ where
         {
             let mut encrypted_bundle_results = Vec::with_capacity(bundle_results.len());
             for (call, call_result) in bundle.transactions.iter().zip(bundle_results) {
-                let (seismic_tx_request, signed_read) =
-                    convert_seismic_call_to_tx_request(call.clone())?;
+                let call = resolve_seismic_call(call.clone())?;
 
-                let response = match call_result {
-                    Ok(mut value) => {
-                        if signed_read {
-                            let sender = parse_request_sender(&seismic_tx_request)?;
-                            let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
-                            value = metadata
-                                .encrypt_response(&self.purpose_keys.tx_io_sk, &value)
-                                .map_err(|e| ext_encryption_error(e.to_string()))?;
-                        }
+                let response = match (call, call_result) {
+                    (SeismicCall::Transparent(_), Ok(value)) => {
                         EthCallResponse { value: Some(value), error: None }
                     }
-                    Err(err) => {
-                        // `EthCallResponse.error` is a plain string with no `data` field, so for
-                        // signed reads the encrypted revert output is appended as hex; otherwise
-                        // the ciphertext would be dropped and the signer couldn't decrypt the
-                        // revert reason.
-                        let err_str = if signed_read {
-                            let err = self.reencrypt_revert_output(err, &seismic_tx_request)?;
-                            match err.as_err() {
-                                Some(EthApiError::InvalidTransaction(
-                                    RpcInvalidTransactionError::Revert(revert),
-                                )) => match revert.output() {
-                                    Some(output) => format!("execution reverted: {output}"),
-                                    None => err.to_string(),
-                                },
-                                _ => err.to_string(),
-                            }
-                        } else {
-                            err.to_string()
+                    (SeismicCall::Transparent(_), Err(err)) => {
+                        EthCallResponse { value: None, error: Some(err.to_string()) }
+                    }
+                    (SeismicCall::SignedRead(request), Ok(mut value)) => {
+                        let sender = parse_request_sender(&request)?;
+                        let metadata = Self::build_metadata(&request, sender)?;
+                        value = metadata
+                            .encrypt_response(&self.purpose_keys.tx_io_sk, &value)
+                            .map_err(|e| ext_encryption_error(e.to_string()))?;
+                        EthCallResponse { value: Some(value), error: None }
+                    }
+                    (SeismicCall::SignedRead(request), Err(err)) => {
+                        // `EthCallResponse.error` is a plain string with no `data` field, so the
+                        // encrypted revert output is appended as hex; otherwise the ciphertext
+                        // would be dropped and the signer couldn't decrypt the revert reason.
+                        let err = self.reencrypt_revert_output(err, &request)?;
+                        let err_str = match err.as_err() {
+                            Some(EthApiError::InvalidTransaction(
+                                RpcInvalidTransactionError::Revert(revert),
+                            )) => match revert.output() {
+                                Some(output) => format!("execution reverted: {output}"),
+                                None => err.to_string(),
+                            },
+                            _ => err.to_string(),
                         };
                         EthCallResponse { value: None, error: Some(err_str) }
                     }
@@ -588,10 +583,9 @@ where
     ) -> RpcResult<Bytes> {
         debug!(target: "reth-seismic-rpc::eth", ?request, ?block_number, ?state_overrides, ?block_overrides, "Serving seismic eth_call extension");
 
-        // process different CallRequest types
-        let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
-        let plaintext_tx_req = signed_read_to_plaintext_tx(
-            (seismic_tx_request.clone(), signed_read),
+        let call = resolve_seismic_call(request)?;
+        let plaintext_tx_req = seismic_call_to_plaintext_tx(
+            &call,
             &self.purpose_keys.tx_io_sk,
             self.eth_api.provider(),
         )?;
@@ -605,26 +599,23 @@ where
         )
         .await;
 
-        // On revert, re-encrypt the output bytes before they reach the client: a contract's
-        // revert data can embed private state just like a successful return value can.
-        let result = match result {
-            Err(err) if signed_read => Err(self.reencrypt_revert_output(err, &seismic_tx_request)?),
-            other => other,
-        };
-        let result = result?;
+        match call {
+            SeismicCall::Transparent(_) => Ok(result?),
+            SeismicCall::SignedRead(request) => {
+                // On revert, re-encrypt the output bytes before they reach the client: a contract's
+                // revert data can embed private state just like a successful return value can.
+                let result = match result {
+                    Err(err) => Err(self.reencrypt_revert_output(err, &request)?),
+                    Ok(result) => Ok(result),
+                }?;
 
-        // encrypt result - only for signed reads with seismic elements
-        if signed_read {
-            if let Some(seismic_elements) = seismic_tx_request.seismic_elements {
-                let sender = parse_request_sender(&seismic_tx_request)?;
-                let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
-                return Ok(seismic_elements
-                    .encrypt_response(&self.purpose_keys.tx_io_sk, &result, &metadata)
-                    .map_err(|e| ext_encryption_error(e.to_string()))?);
+                let sender = parse_request_sender(&request)?;
+                let metadata = Self::build_metadata(&request, sender)?;
+                Ok(metadata
+                    .encrypt_response(&self.purpose_keys.tx_io_sk, &result)
+                    .map_err(|e| ext_encryption_error(e.to_string()))?)
             }
         }
-
-        Ok(result)
     }
 
     /// Handler for: `eth_sendRawTransaction`
@@ -664,10 +655,10 @@ where
         // Same sanitization as eth_call: unsigned requests have `from`,
         // gas/value fields, and seismic_elements cleared to prevent caller
         // spoofing that could leak private state. Signed requests (TypedData/Bytes)
-        // authenticate the sender cryptographically and are processed normally.
-        let (seismic_tx_request, signed_read) = convert_seismic_call_to_tx_request(request)?;
-        let decrypted_req = signed_read_to_plaintext_tx(
-            (seismic_tx_request.clone(), signed_read),
+        // authenticate the sender cryptographically and must be call-only.
+        let call = resolve_seismic_call(request)?;
+        let decrypted_req = seismic_call_to_plaintext_tx(
+            &call,
             &self.purpose_keys.tx_io_sk,
             self.eth_api.provider(),
         )?;
@@ -681,14 +672,18 @@ where
         )
         .await;
 
-        // On revert, re-encrypt the output bytes before they reach the client: a contract's
-        // revert data can embed private state just like a successful return value can.
-        let result = match result {
-            Err(err) if signed_read => Err(self.reencrypt_revert_output(err, &seismic_tx_request)?),
-            other => other,
-        };
-
-        Ok(result?)
+        match call {
+            SeismicCall::Transparent(_) => Ok(result?),
+            SeismicCall::SignedRead(request) => {
+                // On revert, re-encrypt the output bytes before they reach the client: a contract's
+                // revert data can embed private state just like a successful return value can.
+                let result = match result {
+                    Err(err) => Err(self.reencrypt_revert_output(err, &request)?),
+                    Ok(result) => Ok(result),
+                }?;
+                Ok(result)
+            }
+        }
     }
 
     async fn get_balance(

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -49,17 +49,25 @@ pub fn recover_typed_data_request<T: SignedTransaction + Decodable712>(
         .or(Err(EthApiError::InvalidTransactionSignature))
 }
 
-/// Convert a [`SeismicCallRequest`] to a [`SeismicTransactionRequest`].
+/// A resolved Seismic call, classified by its authenticated execution semantics.
+#[derive(Clone, Debug)]
+pub enum SeismicCall {
+    /// An unsigned object-form request. Sender-sensitive fields have been sanitized.
+    Transparent(SeismicTransactionRequest),
+    /// A signed, call-only request whose `signed_read` intent is covered by its signature.
+    SignedRead(SeismicTransactionRequest),
+}
+
+/// Resolve a wire-format [`SeismicCallRequest`] into a [`SeismicCall`].
 ///
-/// If the call requests simulates a transaction without a signature from msg.sender,
-/// we null out the fields that may reveal sensitive information.
-pub fn convert_seismic_call_to_tx_request(
-    request: SeismicCallRequest,
-) -> Result<(SeismicTransactionRequest, bool), EthApiError> {
+/// Unsigned object-form requests are sanitized. Signed typed-data and raw-byte requests must carry
+/// an authenticated `signed_read = true` intent so mempool-admissible write transactions cannot be
+/// replayed through simulation RPCs.
+pub fn resolve_seismic_call(request: SeismicCallRequest) -> Result<SeismicCall, EthApiError> {
     match request {
         SeismicCallRequest::TransactionRequest(mut tx_request) => {
             seismic_override_call_request(&mut tx_request); // null fields that may reveal sensitive information
-            Ok((tx_request, false))
+            Ok(SeismicCall::Transparent(tx_request))
         }
 
         SeismicCallRequest::TypedData(typed_request) => {
@@ -73,16 +81,34 @@ pub fn convert_seismic_call_to_tx_request(
             // Bound the calldata before the downstream ECDH/AES decrypt — same limit as the bytes
             // path, so the guard can't be bypassed by submitting via TypedData instead of Bytes.
             check_signed_read_input_size(req.inner.input.input().map_or(0, |b| b.len()))?;
-            Ok((req, true))
+            ensure_signed_read_request(&req)?;
+            Ok(SeismicCall::SignedRead(req))
         }
 
         SeismicCallRequest::Bytes(bytes) => {
             let tx = recover_raw_seismic_call_tx(&bytes)?;
             let mut req: SeismicTransactionRequest = tx.inner().clone().into();
             TransactionBuilder::<SeismicReth>::set_from(&mut req, tx.signer());
-            Ok((req, true))
+            ensure_signed_read_request(&req)?;
+            Ok(SeismicCall::SignedRead(req))
         }
     }
+}
+
+/// Ensure a signed simulation request is authenticated and explicitly call-only.
+fn ensure_signed_read_request(request: &SeismicTransactionRequest) -> Result<(), EthApiError> {
+    parse_request_sender(request)?;
+
+    let elements = request.seismic_elements.as_ref().ok_or_else(|| {
+        EthApiError::InvalidParams("signed read missing seismic_elements".to_string())
+    })?;
+    if !elements.signed_read {
+        return Err(EthApiError::InvalidParams(
+            "signed simulation request must set signedRead=true".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Reject a signed read whose payload exceeds the configured size cap, before any of the unmetered
@@ -139,41 +165,33 @@ pub fn parse_request_sender(request: &SeismicTransactionRequest) -> Result<Addre
     })
 }
 
-/// Conditionally decrypt a seismic transaction request based on whether it's a signed read.
+/// Convert a resolved Seismic call into the plaintext transaction request executed by the EVM.
 ///
-/// For non-seismic transactions (`signed_read = false`), returns the request unchanged.
-/// For seismic transactions (`signed_read = true`), validates the freshness fields
-/// (`recent_block_hash` and `expires_at_block`) against the live chain tip, then decrypts
-/// the request using the provided secret key.
-pub fn signed_read_to_plaintext_tx<P>(
-    (seismic_tx_request, signed_read): (SeismicTransactionRequest, bool),
+/// Transparent calls are already plaintext. Signed reads have their freshness fields validated
+/// before their calldata is decrypted with the node's secret key.
+pub fn seismic_call_to_plaintext_tx<P>(
+    call: &SeismicCall,
     secret_key: &SecretKey,
     provider: &P,
 ) -> Result<SeismicTransactionRequest, EthApiError>
 where
     P: BlockNumReader,
 {
-    match signed_read {
-        false => Ok(seismic_tx_request),
-        true => {
-            // A signed read must carry seismic_elements: they hold the freshness fields validated
-            // below and the encryption metadata `plaintext_copy` needs to decrypt. Treating them as
-            // optional here would silently skip both checks.
-            let Some(elements) = seismic_tx_request.seismic_elements.as_ref() else {
-                return Err(EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
-                    -32602,
-                    "signed read missing seismic_elements",
-                    None::<String>,
-                ))));
-            };
+    match call {
+        SeismicCall::Transparent(request) => Ok(request.clone()),
+        SeismicCall::SignedRead(request) => {
+            // Keep this defensive check even though `resolve_seismic_call` establishes the enum's
+            // invariant, so direct construction cannot silently skip freshness validation.
+            let elements = request.seismic_elements.as_ref().ok_or_else(|| {
+                EthApiError::InvalidParams("signed read missing seismic_elements".to_string())
+            })?;
             // Reject stale or expired signed reads before doing any ECDH work.
             validate_seismic_freshness(elements, provider)?;
 
-            let sender = parse_request_sender(&seismic_tx_request)?;
-            let seismic_tx_request = seismic_tx_request
+            let sender = parse_request_sender(request)?;
+            request
                 .plaintext_copy(secret_key, sender)
-                .map_err(|e| ext_decryption_error(e.to_string()))?;
-            Ok(seismic_tx_request)
+                .map_err(|e| ext_decryption_error(e.to_string()))
         }
     }
 }
@@ -243,7 +261,12 @@ fn seismic_recent_block_hash_error(hash: B256) -> EthApiError {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 mod test {
-    use crate::utils::{recover_typed_data_request, seismic_override_call_request};
+    use crate::utils::{
+        recover_typed_data_request, resolve_seismic_call, seismic_override_call_request,
+        SeismicCall,
+    };
+    use alloy_consensus::SignableTransaction;
+    use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{
         aliases::U96,
         hex::{self, FromHex},
@@ -251,12 +274,15 @@ mod test {
     };
     use alloy_rpc_types::TransactionRequest;
     use reth_primitives_traits::SignedTransaction;
-    use reth_seismic_primitives::SeismicTransactionSigned;
+    use reth_seismic_primitives::{
+        test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx},
+        SeismicTransactionSigned,
+    };
     use secp256k1::PublicKey;
     use seismic_alloy_consensus::{
         SeismicTxEnvelope, TxSeismic, TxSeismicElements, TypedDataRequest,
     };
-    use seismic_alloy_rpc_types::SeismicTransactionRequest;
+    use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
     use std::str::FromStr;
 
     fn dummy_seismic_elements() -> TxSeismicElements {
@@ -300,6 +326,27 @@ mod test {
         assert!(req.seismic_elements.is_none());
     }
 
+    fn signed_seismic_request(signed_read: bool, typed_data: bool) -> SeismicCallRequest {
+        let signing_key = get_signing_private_key();
+        let sender = Address::from_public_key(signing_key.verifying_key());
+        let mut tx = get_seismic_tx(sender, B256::ZERO);
+        tx.seismic_elements.signed_read = signed_read;
+        if typed_data {
+            tx.seismic_elements.message_version = 2;
+        }
+        let signature = sign_seismic_tx(&tx, &signing_key);
+
+        if typed_data {
+            SeismicCallRequest::TypedData(TypedDataRequest {
+                data: tx.eip712_to_type_data(),
+                signature,
+            })
+        } else {
+            let envelope = SeismicTxEnvelope::Seismic(tx.into_signed(signature));
+            SeismicCallRequest::Bytes(envelope.encoded_2718().into())
+        }
+    }
+
     #[test]
     fn seismic_override_clears_from_with_seismic_elements() {
         let mut req = spoofed_request(Some(dummy_seismic_elements()));
@@ -317,6 +364,43 @@ mod test {
         let mut req = spoofed_request(None);
         seismic_override_call_request(&mut req);
         assert_sanitized(&req);
+    }
+
+    #[test]
+    fn resolves_object_request_as_sanitized_transparent_call() {
+        let mut elements = dummy_seismic_elements();
+        elements.signed_read = true;
+        let request = SeismicCallRequest::TransactionRequest(spoofed_request(Some(elements)));
+
+        let call = resolve_seismic_call(request).unwrap();
+        assert!(matches!(call, SeismicCall::Transparent(_)));
+        if let SeismicCall::Transparent(request) = call {
+            assert_sanitized(&request);
+        }
+    }
+
+    #[test]
+    fn resolves_signed_read_bytes() {
+        let call = resolve_seismic_call(signed_seismic_request(true, false)).unwrap();
+        assert!(matches!(call, SeismicCall::SignedRead(_)));
+    }
+
+    #[test]
+    fn rejects_write_intent_bytes() {
+        let err = resolve_seismic_call(signed_seismic_request(false, false)).unwrap_err();
+        assert!(err.to_string().contains("must set signedRead=true"), "{err}");
+    }
+
+    #[test]
+    fn resolves_signed_read_typed_data() {
+        let call = resolve_seismic_call(signed_seismic_request(true, true)).unwrap();
+        assert!(matches!(call, SeismicCall::SignedRead(_)));
+    }
+
+    #[test]
+    fn rejects_write_intent_typed_data() {
+        let err = resolve_seismic_call(signed_seismic_request(false, true)).unwrap_err();
+        assert!(err.to_string().contains("must set signedRead=true"), "{err}");
     }
 
     #[test]
@@ -604,7 +688,7 @@ mod test {
             // A signed read carries its freshness fields + decryption metadata in
             // `seismic_elements`; if it's absent the request must be rejected outright rather than
             // silently skipping freshness validation and proceeding to decrypt.
-            use crate::utils::signed_read_to_plaintext_tx;
+            use crate::utils::{seismic_call_to_plaintext_tx, SeismicCall};
             use alloy_seismic_evm::secp256k1::SecretKey;
 
             let secret_key = SecretKey::from_slice(&[1u8; 32]).unwrap();
@@ -612,8 +696,12 @@ mod test {
             let provider = MockProvider::default();
             let request = super::spoofed_request(None);
 
-            let err =
-                signed_read_to_plaintext_tx((request, true), &secret_key, &provider).unwrap_err();
+            let err = seismic_call_to_plaintext_tx(
+                &SeismicCall::SignedRead(request),
+                &secret_key,
+                &provider,
+            )
+            .unwrap_err();
             assert!(err.to_string().contains("signed read missing seismic_elements"), "{err}");
         }
     }


### PR DESCRIPTION
This PR fixes multiple signed-read confidentiality leaks across the RPC by preserving structured call/simulate results long enough to re-encrypt revert/output data before it is flattened into RPC responses.

Changes:
 - Expose raw revert bytes via `RevertError::output()` so callers can inspect and re-encrypt revert output.
  - Add raw execution helpers for `eth_callMany` and `eth_simulateV1` (`call_many_raw`, `simulate_v1_raw`) plus simulate response builders that support reconstructing returned transactions.
  - Re-encrypt signed-read revert/output data for `eth_call`, `eth_callMany`, and `eth_estimateGas`.
  - Sanitize `eth_simulateV1` signed-read revert messages to return a generic "execution reverted" string while keeping the real revert data encrypted in `return_data`.
  - Rebuild `eth_simulateV1` full-transaction responses from the original ciphertext input so returned calldata stays encrypted and the returned transaction hash/log associations remain consistent with the bytes sent to the client.
  - Fix `eth_callMany` bundle/result alignment when upstream skips empty bundles.

  Tests
  - Adds e2e regression coverage for signed-read leaks in `eth_call`, `eth_callMany`, `eth_estimateGas`, and `eth_simulateV1`.
  - Adds regression coverage for `eth_simulateV1` full-transaction ciphertext/hash consistency.
  - Adds regression coverage for `eth_callMany` empty-bundle alignment.