### PR TITLE
fix!(rpc): domain-separate signed-read encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e1d5563f01acff06df80d80901eb2fd1637a7a7b#e1d5563f01acff06df80d80901eb2fd1637a7a7b"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=e1d5563f01acff06df80d80901eb2fd1637a7a7b#e1d5563f01acff06df80d80901eb2fd1637a7a7b"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "either",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "either",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -11164,7 +11164,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11180,7 +11180,7 @@ dependencies = [
  "k256",
  "rand 0.8.5",
  "secp256k1 0.30.0",
- "seismic-enclave",
+ "seismic-crypto",
  "serde",
  "serde_json",
  "serde_with",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-genesis"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -11203,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -11223,7 +11223,7 @@ dependencies = [
  "reqwest",
  "seismic-alloy-consensus",
  "seismic-alloy-rpc-types",
- "seismic-enclave",
+ "seismic-crypto",
  "serde",
  "tokio",
 ]
@@ -11231,7 +11231,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11245,14 +11245,14 @@ dependencies = [
  "seismic-alloy-consensus",
  "seismic-alloy-network",
  "seismic-alloy-rpc-types",
- "seismic-enclave",
+ "seismic-crypto",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=7545c3bfebb3520d8af5280cd5644c23def663ac#7545c3bfebb3520d8af5280cd5644c23def663ac"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11263,7 +11263,7 @@ dependencies = [
  "arbitrary",
  "derive_more 1.0.0",
  "seismic-alloy-consensus",
- "seismic-enclave",
+ "seismic-crypto",
  "serde",
  "serde_json",
 ]
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11286,7 +11286,7 @@ dependencies = [
 [[package]]
 name = "seismic-custodian-ipc"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
 dependencies = [
  "ciborium",
  "serde",
@@ -11294,17 +11294,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "zeroize",
-]
-
-[[package]]
-name = "seismic-enclave"
-version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
-dependencies = [
- "jsonrpsee 0.26.0",
- "secp256k1 0.30.0",
- "seismic-crypto",
- "serde",
 ]
 
 [[package]]
@@ -11338,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7a3dd39011f9e2566f4b8663406f48939c00bc6f#7a3dd39011f9e2566f4b8663406f48939c00bc6f"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "either",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "either",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -11164,7 +11164,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-genesis"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -11203,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
@@ -11231,7 +11231,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11252,7 +11252,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb#e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -11286,7 +11286,7 @@ dependencies = [
 [[package]]
 name = "seismic-custodian-ipc"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
 dependencies = [
  "ciborium",
  "serde",
@@ -11327,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=d6d571a5db62003530fb410cd24020896e2b1231#d6d571a5db62003530fb410cd24020896e2b1231"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
 dependencies = [
  "auto_impl",
  "hkdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -753,12 +753,9 @@ walkdir = "2.3.3"
 vergen-git2 = "1.0.5"
 
 [patch.crates-io]
-# seismic-enclave is not used anymore but still resolved transitively via the seismic-alloy crates;
-# Once we remove it from seismic-alloy we'll be able to delete this. For now this entry
-# keeps it on the same pin as its sibling crates.
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
-seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
+# enclave crates
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
+seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
 
 # seismic-alloy-core
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -772,28 +769,28 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 
 # Seismic alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
-seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "7545c3bfebb3520d8af5280cd5644c23def663ac" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e1d5563f01acff06df80d80901eb2fd1637a7a7b" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "e1d5563f01acff06df80d80901eb2fd1637a7a7b" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -754,8 +754,8 @@ vergen-git2 = "1.0.5"
 
 [patch.crates-io]
 # enclave crates
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
-seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
+seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
 
 # seismic-alloy-core
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -769,27 +769,27 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "d6d571a5db62003530fb410cd24020896e2b1231" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 
 # Seismic alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
-seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "e72ffcd2e3e47ab0c1d3dfefcab335a74510c5fb" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
 
 # evm
 alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -458,7 +458,7 @@ fn process_connection<RpcMiddleware, HttpMiddleware>(
     >,
     <<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service as Service<String>>::Future:
     Send + Unpin,
- {
+{
     let ProcessConnection {
         http_middleware,
         rpc_middleware,

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -316,7 +316,7 @@ where
                     let sender = parse_request_sender(&seismic_tx_request)?;
                     let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
                     let encrypted_output = metadata
-                        .encrypt(&self.purpose_keys.tx_io_sk, &call_result.return_data)
+                        .encrypt_response(&self.purpose_keys.tx_io_sk, &call_result.return_data)
                         .map_err(|e| ext_encryption_error(e.to_string()))?;
                     call_result.return_data = encrypted_output;
                 }
@@ -374,7 +374,7 @@ where
                         let sender = parse_request_sender(&seismic_tx_request)?;
                         let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
                         *value = metadata
-                            .encrypt(&self.purpose_keys.tx_io_sk, value)
+                            .encrypt_response(&self.purpose_keys.tx_io_sk, value)
                             .map_err(|e| ext_encryption_error(e.to_string()))?;
                     }
                 }
@@ -417,7 +417,7 @@ where
                 let sender = parse_request_sender(&seismic_tx_request)?;
                 let metadata = Self::build_metadata(&seismic_tx_request, sender)?;
                 return Ok(seismic_elements
-                    .encrypt(&self.purpose_keys.tx_io_sk, &result, &metadata)
+                    .encrypt_response(&self.purpose_keys.tx_io_sk, &result, &metadata)
                     .map_err(|e| ext_encryption_error(e.to_string()))?);
             }
         }

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -381,7 +381,7 @@ mod test {
         assert_eq!(recovered_hash, expected_tx_hash);
 
         let expected_sighash = FixedBytes::<32>::from_hex(
-            "a6bc27ff66ea25d3665afa7f617291cc523a1a04fa651213bccd4393d049a180",
+            "d84991e3c16d527e808a207b3135472c96273f93c98431ffe061de28b02555c9",
         )
         .unwrap();
         assert_eq!(signed_sighash, expected_sighash);


### PR DESCRIPTION
Bump the enclave, seismic-revm, seismic-alloy, and seismic-evm crates in repository-wide lockstep. Remove the obsolete seismic-enclave patch and encrypt signed-read RPC results with the response traffic key.

Note that this does NOT represent a consensus breaking change, but only an rpc breaking change. This is because seismic txs are still encrypted the same way. The only change for nodes/clients is that signed-read responses are now encrypted with a different key. So any seismic-reth node that upgrades to this PR will need to tell its users/clients to update to use the same keys (https://github.com/SeismicSystems/seismic/pull/215 for python/ts and https://github.com/SeismicSystems/seismic-alloy/pull/108 for rust).