### PR TITLE
feat: reject block overwrites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=6ef320e281185c23eeb77a664a773f3b3b494d02#6ef320e281185c23eeb77a664a773f3b3b494d02"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=7c2072141ed851f0d38c1489b205782f87b5f9a8#7c2072141ed851f0d38c1489b205782f87b5f9a8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=6ef320e281185c23eeb77a664a773f3b3b494d02#6ef320e281185c23eeb77a664a773f3b3b494d02"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=7c2072141ed851f0d38c1489b205782f87b5f9a8#7c2072141ed851f0d38c1489b205782f87b5f9a8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=6ef320e281185c23eeb77a664a773f3b3b494d02#6ef320e281185c23eeb77a664a773f3b3b494d02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=6ef320e281185c23eeb77a664a773f3b3b494d02#6ef320e281185c23eeb77a664a773f3b3b494d02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,5 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "6ef320e281185c23eeb77a664a773f3b3b494d02" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "6ef320e281185c23eeb77a664a773f3b3b494d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,5 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "6ef320e281185c23eeb77a664a773f3b3b494d02" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "6ef320e281185c23eeb77a664a773f3b3b494d02" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "7c2072141ed851f0d38c1489b205782f87b5f9a8" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "7c2072141ed851f0d38c1489b205782f87b5f9a8" }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -74,7 +74,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
         async move {
             if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
-                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into())
+                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into());
             }
 
             let block = block.unwrap_or_default();
@@ -87,7 +87,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             } = payload;
 
             if block_state_calls.is_empty() {
-                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
+                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into());
             }
 
             let base_block =
@@ -127,10 +127,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             {
                                 return Err(
                                     EthApiError::other(EthSimulateError::GasLimitReached).into()
-                                )
+                                );
                             }
                         }
-                        apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
+                        apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env)
+                            .map_err(Self::Error::from_eth_err)?;
                     }
                     if let Some(state_overrides) = state_overrides {
                         apply_state_overrides(state_overrides, &mut db)
@@ -150,7 +151,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             return Err(EthApiError::Other(Box::new(
                                 EthSimulateError::BlockGasLimitExceeded,
                             ))
-                            .into())
+                            .into());
                         }
 
                         if txs_without_gas_limit > 0 {
@@ -423,7 +424,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         access_list,
                         gas_used: U256::from(gas_used),
                         error,
-                    })
+                    });
                 }
                 ExecutionResult::Revert { output, gas_used } => {
                     let error = Some(RevertError::new(output).to_string());
@@ -431,7 +432,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         access_list,
                         gas_used: U256::from(gas_used),
                         error,
-                    })
+                    });
                 }
                 ExecutionResult::Success { .. } => {}
             };
@@ -700,7 +701,7 @@ pub trait Call:
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
                 // reached the target transaction
-                break
+                break;
             }
 
             let tx_env = self.evm_config().tx_env(tx);
@@ -780,11 +781,11 @@ pub trait Call:
         request.as_mut().take_nonce();
 
         if let Some(block_overrides) = overrides.block {
-            apply_block_overrides(*block_overrides, db, &mut evm_env.block_env);
+            apply_block_overrides(*block_overrides, db, &mut evm_env.block_env)
+                .map_err(EthApiError::from_overrides_err)?;
         }
         if let Some(state_overrides) = overrides.state {
-            apply_state_overrides(state_overrides, db)
-                .map_err(EthApiError::from_state_overrides_err)?;
+            apply_state_overrides(state_overrides, db).map_err(EthApiError::from_overrides_err)?;
         }
 
         let request_gas = request.as_ref().gas_limit();

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -3,7 +3,7 @@
 pub mod api;
 use crate::error::api::FromEvmHalt;
 use alloy_eips::BlockId;
-use alloy_evm::{call::CallError, overrides::StateOverrideError};
+use alloy_evm::{call::CallError, overrides::OverrideError};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{error::EthRpcErrorCode, request::TransactionInputError, BlockError};
 use alloy_sol_types::{ContractError, RevertReason};
@@ -121,6 +121,9 @@ pub enum EthApiError {
     /// Storage overrides are not permitted (Seismic privacy)
     #[error("storage overrides are not permitted on Seismic (account: {0:?})")]
     StorageOverrideNotPermitted(Address),
+    /// Block overrides are not permitted (Seismic privacy)
+    #[error("block overrides are not permitted on Seismic")]
+    BlockOverrideNotPermitted,
     /// Other internal error
     #[error(transparent)]
     Internal(RethError),
@@ -227,8 +230,8 @@ impl EthApiError {
         }
     }
 
-    /// Converts the given [`StateOverrideError`] into a new [`EthApiError`] instance.
-    pub fn from_state_overrides_err<E>(err: StateOverrideError<E>) -> Self
+    /// Converts the given [`OverrideError`] into a new [`EthApiError`] instance.
+    pub fn from_overrides_err<E>(err: OverrideError<E>) -> Self
     where
         E: Into<Self>,
     {
@@ -262,6 +265,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::BothStateAndStateDiffInOverride(_) |
             EthApiError::CodeOverrideNotPermitted(_) |
             EthApiError::StorageOverrideNotPermitted(_) |
+            EthApiError::BlockOverrideNotPermitted |
             EthApiError::InvalidTracerConfig |
             EthApiError::TransactionConversionError |
             EthApiError::InvalidRewardPercentiles |
@@ -345,25 +349,26 @@ where
     }
 }
 
-impl<E> From<StateOverrideError<E>> for EthApiError
+impl<E> From<OverrideError<E>> for EthApiError
 where
     E: Into<Self>,
 {
-    fn from(value: StateOverrideError<E>) -> Self {
+    fn from(value: OverrideError<E>) -> Self {
         match value {
-            StateOverrideError::InvalidBytecode(bytecode_decode_error) => {
+            OverrideError::InvalidBytecode(bytecode_decode_error) => {
                 Self::InvalidBytecode(bytecode_decode_error.to_string())
             }
-            StateOverrideError::BothStateAndStateDiff(address) => {
+            OverrideError::BothStateAndStateDiff(address) => {
                 Self::BothStateAndStateDiffInOverride(address)
             }
-            StateOverrideError::CodeOverrideNotPermitted(address) => {
+            OverrideError::CodeOverrideNotPermitted(address) => {
                 Self::CodeOverrideNotPermitted(address)
             }
-            StateOverrideError::StorageOverrideNotPermitted(address) => {
+            OverrideError::StorageOverrideNotPermitted(address) => {
                 Self::StorageOverrideNotPermitted(address)
             }
-            StateOverrideError::Database(err) => err.into(),
+            OverrideError::BlockOverrideNotPermitted => Self::BlockOverrideNotPermitted,
+            OverrideError::Database(err) => err.into(),
         }
     }
 }

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -247,7 +247,8 @@ where
                 let mut db = CacheDB::new(StateProviderDatabase::new(state));
 
                 // apply overrides
-                apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
+                apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env)
+                    .map_err(EthApiError::from_overrides_err)?;
 
                 let initial_coinbase_balance = DatabaseRef::basic_ref(&db, coinbase)
                     .map_err(EthApiError::from_eth_err)?


### PR DESCRIPTION
Changes:
- Bump the version for `seismic-evm`
- The function `apply_block_overrides` which is imported from `seismic-evm` now returns a `Result`
- Bubble up any errors returned from `apply_block_overrides`