### PR TITLE
feat(seismic-rpc): signed-read tx-context classification + 0x6A e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=d347fbbc8ceaa36677ed36713a08c1038cb47138#d347fbbc8ceaa36677ed36713a08c1038cb47138"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=8d9f7b41215a86b0c9eb728021a61da03d80905e#8d9f7b41215a86b0c9eb728021a61da03d80905e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=d347fbbc8ceaa36677ed36713a08c1038cb47138#d347fbbc8ceaa36677ed36713a08c1038cb47138"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=8d9f7b41215a86b0c9eb728021a61da03d80905e#8d9f7b41215a86b0c9eb728021a61da03d80905e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -963,7 +963,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2973,7 +2973,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3252,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4079,7 +4079,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4097,7 +4097,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4526,7 +4526,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5554,7 +5554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5793,7 +5793,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6552,7 +6552,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6589,7 +6589,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10417,7 +10417,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10435,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10490,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "auto_impl",
  "either",
@@ -10502,7 +10502,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "auto_impl",
  "either",
@@ -10562,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10574,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10598,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10864,7 +10864,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=e80a2c739f9d53db8e3016d79cb2b7b37408d0f4#e80a2c739f9d53db8e3016d79cb2b7b37408d0f4"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -11919,7 +11919,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13140,7 +13140,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -770,18 +770,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e80a2c739f9d53db8e3016d79cb2b7b37408d0f4" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 
@@ -793,5 +793,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "d347fbbc8ceaa36677ed36713a08c1038cb47138" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "d347fbbc8ceaa36677ed36713a08c1038cb47138" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "8d9f7b41215a86b0c9eb728021a61da03d80905e" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "8d9f7b41215a86b0c9eb728021a61da03d80905e" }

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -975,6 +975,7 @@ mod tests {
             },
             tx_hash: Default::default(),
             decryption_failed: false,
+            signed_read: false,
         }
     }
 

--- a/crates/seismic/fuzz/src/tx_gen.rs
+++ b/crates/seismic/fuzz/src/tx_gen.rs
@@ -95,6 +95,7 @@ impl FuzzSeismicTx {
             },
             tx_hash: Default::default(),
             decryption_failed: false,
+            signed_read: false,
         }
     }
 

--- a/crates/seismic/fuzz/tests/flagged_storage.rs
+++ b/crates/seismic/fuzz/tests/flagged_storage.rs
@@ -41,6 +41,7 @@ fn call_tx(caller: Address, contract_addr: Address, gas_limit: u32) -> SeismicTr
         },
         tx_hash: Default::default(),
         decryption_failed: false,
+        signed_read: false,
     }
 }
 

--- a/crates/seismic/node/tests/e2e/fixtures/README.md
+++ b/crates/seismic/node/tests/e2e/fixtures/README.md
@@ -1,0 +1,21 @@
+# TXTYPE e2e test fixtures
+
+`TxTypeProbe.sol` is the source for the `TXTYPE_PROBE_DEPLOY` creation bytecode
+embedded in [`../txtype.rs`](../txtype.rs). It is stock Solidity: it reads the
+current transaction's EIP-2718 type byte and its signed-read flag from the `0x6A`
+tx-context precompile via `staticcall` — there is no compiler builtin and no
+`ssolc` change. Empty input selects the tx type; a single `0x01` byte selects the
+signed-read flag.
+
+## Reproducing the committed bytecode
+
+Compiled with the Seismic Solidity build (`ssolc`, no optimizer, Mercury):
+
+```sh
+solc --bin --evm-version mercury TxTypeProbe.sol
+```
+
+The **code** portion (everything before the trailing `a264…` CBOR metadata) is
+byte-for-byte identical to `TXTYPE_PROBE_DEPLOY`. The metadata suffix encodes
+the compiler version/source hash and is not consensus-relevant; the committed
+constant was produced with `ssolc 0.8.31-develop.2026.7.20+commit.fd5f389c`.

--- a/crates/seismic/node/tests/e2e/fixtures/TxTypeProbe.sol
+++ b/crates/seismic/node/tests/e2e/fixtures/TxTypeProbe.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Source for the `TXTYPE_PROBE_DEPLOY` bytecode used by the e2e tests in
+// `../txtype.rs`. Stock Solidity — reads the EIP-2718 tx type and the
+// signed-read flag from the 0x6A tx-context precompile via `staticcall`, no
+// compiler builtin. See `README.md` for the exact compile command that
+// reproduces the committed bytecode.
+contract TxTypeProbe {
+    address constant TX_CONTEXT = address(0x6A);
+
+    // Empty input selects the tx type; a single 0x01 byte selects the signed-read flag.
+    function _read(bytes memory selector) private view returns (uint256 v) {
+        (bool ok, bytes memory ret) = TX_CONTEXT.staticcall(selector);
+        require(ok && ret.length == 32, "TX_CONTEXT");
+        v = abi.decode(ret, (uint256));
+    }
+
+    function _txType() private view returns (uint256) {
+        return _read("");
+    }
+
+    function _signedRead() private view returns (uint256) {
+        return _read(hex"01");
+    }
+
+    // isSeismic() [selector 02ce8088]: txType() == 0x4A as an abi bool.
+    function isSeismic() external view returns (bool) {
+        return _txType() == 0x4A;
+    }
+
+    // requireSeismic() [selector c6d819f6]: reverts unless txType() == 0x4A.
+    function requireSeismic() external view {
+        require(_txType() == 0x4A);
+    }
+
+    // isSignedRead() [selector 28782220]: the signed-read flag as an abi bool.
+    function isSignedRead() external view returns (bool) {
+        return _signedRead() == 1;
+    }
+
+    // requireSignedRead() [selector 6cac1460]: reverts unless the signed-read flag is 1.
+    function requireSignedRead() external view {
+        require(_signedRead() == 1);
+    }
+
+    // requireNotSignedRead() [selector 2dfeb92e]: reverts unless the signed-read flag is 0.
+    function requireNotSignedRead() external view {
+        require(_signedRead() == 0);
+    }
+}

--- a/crates/seismic/node/tests/e2e/main.rs
+++ b/crates/seismic/node/tests/e2e/main.rs
@@ -10,6 +10,7 @@ mod pending_block;
 // roots. Currently broken from stable coin gas update not burning gas
 mod signed_read_import;
 mod testsuite;
+mod txtype;
 mod wrong_chain_import;
 
 const fn main() {}

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -270,6 +270,50 @@ async fn test_signed_read_flag_estimate_gas() {
     }
 }
 
+/// An unsigned object-form call that sets `type: 0x4a` must not be classified as Seismic: the
+/// sanitizer clears the tx type, so `requireSeismic()` reverts and `requireNotSignedRead()` passes.
+/// Regression for the sanitizer dropping `transaction_type` during the rebase.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_unsigned_type74_cannot_spoof() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+
+    // requireSeismic() must revert: the spoofed type is stripped, so isSeismicTx() is false.
+    let mut spoof = plain_call(contract, Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap());
+    spoof.inner.transaction_type = Some(0x4a);
+    let res = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TransactionRequest(spoof),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(res.is_err(), "unsigned type-0x4a call must not report as Seismic, got {res:?}");
+
+    // requireNotSignedRead() must pass: isSignedRead() is false for the same spoof.
+    let mut spoof2 = plain_call(contract, Bytes::from_hex(REQUIRE_NOT_SIGNED_READ_SELECTOR).unwrap());
+    spoof2.inner.transaction_type = Some(0x4a);
+    let res2 = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TransactionRequest(spoof2),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(res2.is_ok(), "unsigned type-0x4a call must report signed_read=0, got {res2:?}");
+}
+
 /// Deploy the probe as a standard tx via the signer's account (nonce 0) and return its address.
 async fn deploy_probe(
     client: &jsonrpsee::http_client::HttpClient,

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -1,0 +1,301 @@
+//! End-to-end coverage for tx-type RPC classification on the seismic node (precompile variant).
+//!
+//! The node must run an authenticated signed read as a Seismic tx (type 74) and a plain `eth_call`
+//! as standard, and must additionally report `signed_read` only for the former. The probe reads
+//! both fields via `staticcall` to the 0x6A tx-context precompile; its `require*()` entry points
+//! revert unless the field holds the expected value, so success-vs-revert is a **field-specific**
+//! signal that needs no response decryption and exercises the `eth_call` and `estimateGas`
+//! handlers directly (reth tags those two handlers independently).
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file.
+
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{hex::FromHex, Bytes, TxKind};
+use alloy_rpc_types::{Block, TransactionInput, TransactionRequest};
+use jsonrpsee::http_client::HttpClientBuilder;
+use reth_seismic_node::utils::e2e::{ensure_mock_purpose_keys, setup};
+use reth_seismic_test_utils::{get_signed_seismic_call_typed_data, sign_tx};
+use reth_seismic_rpc::ext::EthApiOverrideClient;
+use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
+
+// TxTypeProbe (stock solc): reads the 0x6A tx-context precompile by staticcall — empty input for
+// the tx type (requireSeismic), a single 0x01 byte for the signed-read flag (requireSignedRead /
+// requireNotSignedRead). Source + reproduce command: fixtures/TxTypeProbe.sol.
+const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b5061041e8061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610055575f3560e01c806302ce80881461005957806328782220146100775780632dfeb92e146100955780636cac14601461009f578063c6d819f6146100a9575b5f5ffd5b6100616100b3565b60405161006e9190610263565b60405180910390f35b61007f6100c4565b60405161008c9190610263565b60405180910390f35b61009d6100d5565b005b6100a76100e9565b005b6100b16100fe565b005b5f604a6100be610113565b14905090565b5f60016100cf610130565b14905090565b5f6100de610130565b146100e7575f5ffd5b565b60016100f3610130565b146100fc575f5ffd5b565b604a610108610113565b14610111575f5ffd5b565b5f61012b60405180602001604052805f815250610174565b905090565b5f61016f6040518060400160405280600181526020017f0100000000000000000000000000000000000000000000000000000000000000815250610174565b905090565b5f5f5f606a73ffffffffffffffffffffffffffffffffffffffff168460405161019d91906102ce565b5f60405180830381855afa9150503d805f81146101d5576040519150601f19603f3d011682016040523d82523d5f602084013e6101da565b606091505b50915091508180156101ed575060208151145b61022c576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016102239061033e565b60405180910390fd5b808060200190518101906102409190610393565b92505050919050565b5f8115159050919050565b61025d81610249565b82525050565b5f6020820190506102765f830184610254565b92915050565b5f81519050919050565b5f81905092915050565b8281835e5f83830152505050565b5f6102a88261027c565b6102b28185610286565b93506102c2818560208601610290565b80840191505092915050565b5f6102d9828461029e565b915081905092915050565b5f82825260208201905092915050565b7f54585f434f4e54455854000000000000000000000000000000000000000000005f82015250565b5f610328600a836102e4565b9150610333826102f4565b602082019050919050565b5f6020820190508181035f8301526103558161031c565b9050919050565b5f5ffd5b5f819050919050565b61037281610360565b811461037c575f5ffd5b50565b5f8151905061038d81610369565b92915050565b5f602082840312156103a8576103a761035c565b5b5f6103b58482850161037f565b9150509291505056fea2646970667358221220e56727fc82b547363957084e7329dccb37dde4880bce06d778cd62d7596e36d064736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
+
+const REQUIRE_SEISMIC_SELECTOR: &str = "c6d819f6";
+const REQUIRE_SIGNED_READ_SELECTOR: &str = "6cac1460";
+const REQUIRE_NOT_SIGNED_READ_SELECTOR: &str = "2dfeb92e";
+
+/// Plain standard `SeismicTransactionRequest` (no signature, no seismic elements) to `contract`.
+fn plain_call(contract: alloy_primitives::Address, calldata: Bytes) -> SeismicTransactionRequest {
+    SeismicTransactionRequest {
+        inner: TransactionRequest {
+            to: Some(TxKind::Call(contract)),
+            input: TransactionInput { input: Some(calldata), data: None },
+            ..Default::default()
+        },
+        seismic_elements: None,
+    }
+}
+
+/// The `eth_call` handler must classify a signed read as Seismic (`txtype()==74`) and a plain call
+/// as standard: `requireSeismic()` succeeds for the signed read and reverts for the plain call.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_eth_call_classifies_signed_read() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+    let recent = node.advance_block().await.unwrap().block().hash();
+    let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
+
+    // Signed read -> txtype()==74 -> requireSeismic() succeeds.
+    let signed = get_signed_seismic_call_typed_data(
+        &signer,
+        1,
+        TxKind::Call(contract),
+        chain_id,
+        selector.clone(),
+        recent,
+    )
+    .await;
+    let signed_res = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TypedData(signed),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        signed_res.is_ok(),
+        "signed eth_call to requireSeismic() should succeed (txtype()==74), got {signed_res:?}"
+    );
+
+    // Plain eth_call -> txtype()!=74 -> requireSeismic() reverts.
+    let plain_res = EthApiOverrideClient::<Block>::call(
+        &client,
+        SeismicCallRequest::TransactionRequest(plain_call(contract, selector)),
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        plain_res.is_err(),
+        "plain eth_call to requireSeismic() should revert (txtype()!=74), but it succeeded"
+    );
+}
+
+/// The `estimateGas` handler must classify a signed read as Seismic independently of `eth_call`:
+/// estimating `requireSeismic()` succeeds for the signed read and reverts for the plain call.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txtype_estimate_gas_classifies_signed_read() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+    let recent = node.advance_block().await.unwrap().block().hash();
+    let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
+
+    let signed = get_signed_seismic_call_typed_data(
+        &signer,
+        1,
+        TxKind::Call(contract),
+        chain_id,
+        selector.clone(),
+        recent,
+    )
+    .await;
+    let signed_res = EthApiOverrideClient::<Block>::estimate_gas(
+        &client,
+        SeismicCallRequest::TypedData(signed),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        signed_res.is_ok(),
+        "signed estimateGas of requireSeismic() should succeed (txtype()==74), got {signed_res:?}"
+    );
+
+    let plain_res = EthApiOverrideClient::<Block>::estimate_gas(
+        &client,
+        SeismicCallRequest::TransactionRequest(plain_call(contract, selector)),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        plain_res.is_err(),
+        "plain estimateGas of requireSeismic() should revert (txtype()!=74), but it succeeded"
+    );
+}
+
+/// `signed_read` must be set exactly on the authenticated read path, not merely on anything typed
+/// 74: `requireSignedRead()` succeeds for a signed `eth_call` and reverts for a plain one, and
+/// `requireNotSignedRead()` does the reverse. Both directions are asserted so the test fails if the
+/// flag is hardwired either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signed_read_flag_eth_call() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+
+    for (selector, signed_should_pass) in
+        [(REQUIRE_SIGNED_READ_SELECTOR, true), (REQUIRE_NOT_SIGNED_READ_SELECTOR, false)]
+    {
+        let recent = node.advance_block().await.unwrap().block().hash();
+        let calldata = Bytes::from_hex(selector).unwrap();
+
+        let signed = get_signed_seismic_call_typed_data(
+            &signer,
+            1,
+            TxKind::Call(contract),
+            chain_id,
+            calldata.clone(),
+            recent,
+        )
+        .await;
+        let signed_res = EthApiOverrideClient::<Block>::call(
+            &client,
+            SeismicCallRequest::TypedData(signed),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            signed_res.is_ok(),
+            signed_should_pass,
+            "signed eth_call to {selector}: expected pass={signed_should_pass}, got {signed_res:?}"
+        );
+
+        let plain_res = EthApiOverrideClient::<Block>::call(
+            &client,
+            SeismicCallRequest::TransactionRequest(plain_call(contract, calldata)),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            plain_res.is_ok(),
+            !signed_should_pass,
+            "plain eth_call to {selector}: expected pass={}, got {plain_res:?}",
+            !signed_should_pass
+        );
+    }
+}
+
+/// The `estimateGas` handler sets `signed_read` independently of `eth_call` (reth tags the two
+/// handlers separately), so it gets its own assertion in both directions.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signed_read_flag_estimate_gas() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+
+    for (selector, signed_should_pass) in
+        [(REQUIRE_SIGNED_READ_SELECTOR, true), (REQUIRE_NOT_SIGNED_READ_SELECTOR, false)]
+    {
+        let recent = node.advance_block().await.unwrap().block().hash();
+        let calldata = Bytes::from_hex(selector).unwrap();
+
+        let signed = get_signed_seismic_call_typed_data(
+            &signer,
+            1,
+            TxKind::Call(contract),
+            chain_id,
+            calldata.clone(),
+            recent,
+        )
+        .await;
+        let signed_res = EthApiOverrideClient::<Block>::estimate_gas(
+            &client,
+            SeismicCallRequest::TypedData(signed),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            signed_res.is_ok(),
+            signed_should_pass,
+            "signed estimateGas of {selector}: expected pass={signed_should_pass}, got {signed_res:?}"
+        );
+
+        let plain_res = EthApiOverrideClient::<Block>::estimate_gas(
+            &client,
+            SeismicCallRequest::TransactionRequest(plain_call(contract, calldata)),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            plain_res.is_ok(),
+            !signed_should_pass,
+            "plain estimateGas of {selector}: expected pass={}, got {plain_res:?}",
+            !signed_should_pass
+        );
+    }
+}
+
+/// Deploy the probe as a standard tx via the signer's account (nonce 0) and return its address.
+async fn deploy_probe(
+    client: &jsonrpsee::http_client::HttpClient,
+    node: &mut reth_seismic_node::utils::e2e::SeismicTestNode,
+    signer: &alloy_signer_local::PrivateKeySigner,
+    from: alloy_primitives::Address,
+    chain_id: u64,
+) -> alloy_primitives::Address {
+    let deploy_code = Bytes::from_hex(TXTYPE_PROBE_DEPLOY).unwrap();
+    let deploy = SeismicTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(from),
+            nonce: Some(0),
+            to: Some(TxKind::Create),
+            gas: Some(1_000_000),
+            max_fee_per_gas: Some(20e9 as u128),
+            max_priority_fee_per_gas: Some(20e9 as u128),
+            chain_id: Some(chain_id),
+            input: TransactionInput { input: Some(deploy_code), data: None },
+            ..Default::default()
+        },
+        seismic_elements: None,
+    };
+    let signed = sign_tx(signer.clone(), deploy).await;
+    let raw: Bytes = signed.encoded_2718().into();
+    EthApiOverrideClient::<Block>::send_raw_transaction(client, raw.into()).await.unwrap();
+    node.advance_block().await.unwrap();
+    from.create(0)
+}

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -13,8 +13,8 @@ use alloy_primitives::{hex::FromHex, Bytes, TxKind};
 use alloy_rpc_types::{Block, TransactionInput, TransactionRequest};
 use jsonrpsee::http_client::HttpClientBuilder;
 use reth_seismic_node::utils::e2e::{ensure_mock_purpose_keys, setup};
-use reth_seismic_test_utils::{get_signed_seismic_call_typed_data, sign_tx};
 use reth_seismic_rpc::ext::EthApiOverrideClient;
+use reth_seismic_test_utils::{get_signed_seismic_call_typed_data, sign_tx};
 use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
 
 // TxTypeProbe (stock solc): reads the 0x6A tx-context precompile by staticcall — empty input for
@@ -301,7 +301,8 @@ async fn test_txtype_unsigned_type74_cannot_spoof() {
     assert!(res.is_err(), "unsigned type-0x4a call must not report as Seismic, got {res:?}");
 
     // requireNotSignedRead() must pass: isSignedRead() is false for the same spoof.
-    let mut spoof2 = plain_call(contract, Bytes::from_hex(REQUIRE_NOT_SIGNED_READ_SELECTOR).unwrap());
+    let mut spoof2 =
+        plain_call(contract, Bytes::from_hex(REQUIRE_NOT_SIGNED_READ_SELECTOR).unwrap());
     spoof2.inner.transaction_type = Some(0x4a);
     let res2 = EthApiOverrideClient::<Block>::call(
         &client,

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -200,7 +200,7 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
             SeismicTypedTransaction::Eip7702(tx) => TxEnv::from_recovered_tx(tx, sender),
             SeismicTypedTransaction::Seismic(tx) => TxEnv::from_recovered_tx(tx, sender),
         };
-        let tx = Self { base, tx_hash, decryption_failed: false };
+        let tx = Self { base, tx_hash, decryption_failed: false, signed_read: false };
         tracing::debug!("from_recovered_tx: tx: {:?}", tx);
         tx
     }
@@ -209,7 +209,7 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
 impl FromTxWithEncoded<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
     fn from_encoded_tx(tx: &SeismicTransactionSigned, sender: Address, _encoded: Bytes) -> Self {
         let tx_env = Self::from_recovered_tx(tx, sender);
-        Self { base: tx_env.base, tx_hash: tx_env.tx_hash, decryption_failed: false }
+        Self { base: tx_env.base, tx_hash: tx_env.tx_hash, decryption_failed: false, signed_read: false }
     }
 }
 

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -209,7 +209,12 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
 impl FromTxWithEncoded<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
     fn from_encoded_tx(tx: &SeismicTransactionSigned, sender: Address, _encoded: Bytes) -> Self {
         let tx_env = Self::from_recovered_tx(tx, sender);
-        Self { base: tx_env.base, tx_hash: tx_env.tx_hash, decryption_failed: false, signed_read: false }
+        Self {
+            base: tx_env.base,
+            tx_hash: tx_env.tx_hash,
+            decryption_failed: false,
+            signed_read: false,
+        }
     }
 }
 

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -18,7 +18,7 @@ use revm::{
     context_interface::{Block, Transaction},
     Database,
 };
-use seismic_alloy_consensus::SeismicTxType;
+use seismic_alloy_consensus::{SeismicTxType, SEISMIC_TX_TYPE_ID};
 use seismic_revm::{self, SeismicTransaction};
 
 impl<N, Rpc> EthCall for SeismicEthApi<N, Rpc>
@@ -121,14 +121,18 @@ where
             return Err(RpcInvalidTransactionError::BlobTransactionMissingBlobHashes.into_eth_err());
         }
 
-        let tx_type = if request.authorization_list.is_some() {
+        // Only an explicitly Seismic-typed request (a resolved signed read, stamped in utils.rs) is
+        // Seismic; a plain eth_call must not report as an encrypted channel.
+        let tx_type = if request.transaction_type == Some(SEISMIC_TX_TYPE_ID) {
+            SeismicTxType::Seismic
+        } else if request.authorization_list.is_some() {
             SeismicTxType::Eip7702
         } else if request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some() {
             SeismicTxType::Eip1559
         } else if request.access_list.is_some() {
             SeismicTxType::Eip2930
         } else {
-            SeismicTxType::Seismic
+            SeismicTxType::Legacy
         } as u8;
 
         let TransactionRequest {
@@ -215,7 +219,12 @@ where
 
         tracing::debug!("reth-seismic-rpc::eth create_txn_env {:?}", env);
 
-        Ok(SeismicTransaction { base: env, tx_hash: Default::default(), decryption_failed: false }
-            .into())
+        Ok(SeismicTransaction {
+            base: env,
+            tx_hash: Default::default(),
+            decryption_failed: false,
+            signed_read: tx_type == SEISMIC_TX_TYPE_ID,
+        }
+        .into())
     }
 }

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -9,7 +9,7 @@ use reth_seismic_primitives::{
 };
 use reth_storage_api::BlockNumReader;
 use seismic_alloy_consensus::{
-    Decodable712, SeismicTxEnvelope, TxSeismicElements, TypedDataRequest,
+    Decodable712, SeismicTxEnvelope, TxSeismicElements, TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };
 use seismic_alloy_network::{SeismicReth, TransactionBuilder};
 use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
@@ -189,9 +189,11 @@ where
             validate_seismic_freshness(elements, provider)?;
 
             let sender = parse_request_sender(request)?;
-            request
+            let mut plaintext = request
                 .plaintext_copy(secret_key, sender)
-                .map_err(|e| ext_decryption_error(e.to_string()))
+                .map_err(|e| ext_decryption_error(e.to_string()))?;
+            plaintext.inner.transaction_type = Some(SEISMIC_TX_TYPE_ID);
+            Ok(plaintext)
         }
     }
 }

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -277,12 +277,11 @@ mod test {
     };
     use alloy_rpc_types::TransactionRequest;
     use reth_primitives_traits::SignedTransaction;
-    use seismic_alloy_consensus::SEISMIC_TX_TYPE_ID;
     use reth_seismic_primitives::SeismicTransactionSigned;
     use reth_seismic_test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx};
     use secp256k1::PublicKey;
     use seismic_alloy_consensus::{
-        SeismicTxEnvelope, TxSeismic, TxSeismicElements, TypedDataRequest,
+        SeismicTxEnvelope, TxSeismic, TxSeismicElements, TypedDataRequest, SEISMIC_TX_TYPE_ID,
     };
     use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
     use std::str::FromStr;

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -30,6 +30,7 @@ pub const fn seismic_override_call_request(request: &mut SeismicTransactionReque
     request.inner.max_priority_fee_per_gas = None; // preventing InsufficientFunds error
     request.inner.max_fee_per_blob_gas = None; // preventing InsufficientFunds error
     request.inner.value = None; // preventing InsufficientFunds error
+    request.inner.transaction_type = None; // don't let a plain call spoof the Seismic tx type
     request.seismic_elements = None; // zero out seismic elements
 }
 
@@ -276,6 +277,7 @@ mod test {
     };
     use alloy_rpc_types::TransactionRequest;
     use reth_primitives_traits::SignedTransaction;
+    use seismic_alloy_consensus::SEISMIC_TX_TYPE_ID;
     use reth_seismic_primitives::SeismicTransactionSigned;
     use reth_seismic_test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx};
     use secp256k1::PublicKey;
@@ -310,6 +312,7 @@ mod test {
                 max_priority_fee_per_gas: Some(50),
                 max_fee_per_blob_gas: Some(10),
                 value: Some(U256::from(1_000u64)),
+                transaction_type: Some(SEISMIC_TX_TYPE_ID),
                 ..Default::default()
             },
             seismic_elements,
@@ -323,6 +326,7 @@ mod test {
         assert_eq!(req.inner.max_priority_fee_per_gas, None);
         assert_eq!(req.inner.max_fee_per_blob_gas, None);
         assert_eq!(req.inner.value, None);
+        assert_eq!(req.inner.transaction_type, None, "tx type must be cleared to block spoofing");
         assert!(req.seismic_elements.is_none());
     }
 


### PR DESCRIPTION
Node-side classification for the tx-context feature — the core of it. Companion PRs: revm #227, evm #58, foundry #220, contracts #232.

- `create_txn_env` reports a resolved signed read as Seismic (tx type 74) and sets `signed_read`; a plain `eth_call` classifies as standard. A signed read is stamped type 74 only after `resolve_seismic_call` authenticates it.
- The unsigned-request sanitizer clears `transaction_type`, so an unsigned object-form call cannot spoof `isSeismicTx()`/`isSignedRead()` or receive plaintext (regression `test_txtype_unsigned_type74_cannot_spoof`).
- Carries `signed_read` at the reth `SeismicTransaction` construction sites; e2e probe `staticcall`s `0x6A`.
- rpc 27/27, e2e txtype 5/5.