### PR TITLE
ci: add a timestamp-in-seconds build/test lane

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -194,6 +194,78 @@ jobs:
         # see profile.default in .config/nextest.toml for filtered tests
         run: cargo nextest run --workspace -E '!kind(test)' --no-fail-fast
 
+  timestamp-in-seconds:
+    name: timestamp-in-seconds feature
+    runs-on: large-github-runner
+    timeout-minutes: 30
+    env:
+      SEISMIC_CI: 1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo build (timestamp-in-seconds)
+        # Explicit package list, not the `reth-seismic*` glob clippy-seismic uses above:
+        # that glob also matches Seismic crates that DON'T declare this feature (cli,
+        # fuzz, genesis-builder, hardforks, txpool), and it's untested whether
+        # `--features` silently no-ops on a selected package that lacks the named
+        # feature or hard-errors. Listing exactly the ~10 crates #420 names (the ones
+        # that carry `timestamp-in-seconds` in their own `[features]` table) avoids
+        # relying on that. If a new Seismic crate gains this feature, add it here.
+        run: |
+          cargo build \
+            -p seismic-reth \
+            -p reth-seismic-chainspec \
+            -p reth-seismic-primitives \
+            -p reth-seismic-evm \
+            -p reth-seismic-payload-builder \
+            -p reth-seismic-node \
+            -p reth-seismic-rpc \
+            -p reth-chainspec \
+            -p reth-transaction-pool \
+            -p reth-payload-builder \
+            -p reth-e2e-test-utils \
+            --features timestamp-in-seconds
+      - name: cargo clippy (timestamp-in-seconds)
+        run: |
+          cargo clippy \
+            -p seismic-reth \
+            -p reth-seismic-chainspec \
+            -p reth-seismic-primitives \
+            -p reth-seismic-evm \
+            -p reth-seismic-payload-builder \
+            -p reth-seismic-node \
+            -p reth-seismic-rpc \
+            -p reth-chainspec \
+            -p reth-transaction-pool \
+            -p reth-payload-builder \
+            -p reth-e2e-test-utils \
+            --features timestamp-in-seconds \
+            --all-targets \
+            -- -D warnings
+      - name: cargo nextest (timestamp-in-seconds)
+        # No kind(test) filter, unlike unit-test/integration-test above: this lane exists
+        # specifically to run the seconds-only assertions wherever they live (unit or e2e),
+        # e.g. crates/seismic/node/tests/e2e/pending_block.rs.
+        run: |
+          cargo nextest run \
+            -p seismic-reth \
+            -p reth-seismic-chainspec \
+            -p reth-seismic-primitives \
+            -p reth-seismic-evm \
+            -p reth-seismic-payload-builder \
+            -p reth-seismic-node \
+            -p reth-seismic-rpc \
+            -p reth-chainspec \
+            -p reth-transaction-pool \
+            -p reth-payload-builder \
+            -p reth-e2e-test-utils \
+            --features timestamp-in-seconds \
+            --no-fail-fast
+
   integration-test:
     runs-on: large-github-runner
     timeout-minutes: 30


### PR DESCRIPTION
Closes #420.

Adds a `timestamp-in-seconds` job to `.github/workflows/seismic.yml` that builds, clippy-lints (`-D warnings`), and nextest-runs the crates that declare the `timestamp-in-seconds` feature.

## Why
Seconds-mode is a supported build configuration but nothing in CI exercises it, so it can silently break (compile errors, warnings, behavioral regressions) while CI stays green. This also covers seconds-only test assertions (e.g. the pending-block timestamp check in `crates/seismic/node/tests/e2e/pending_block.rs` from #408) that currently never run.

## Scope
Explicit package list (not a glob) — the same ~10 crates #420 names, each of which declares `timestamp-in-seconds` in its own `[features]` table:
- `seismic-reth`, `reth-seismic-{chainspec,primitives,evm,payload-builder,node,rpc}`
- `reth-chainspec`, `reth-transaction-pool`, `reth-payload-builder`, `reth-e2e-test-utils`

A glob like the existing `clippy-seismic` job's `-p 'reth-seismic*'` would also sweep in Seismic crates that don't declare this feature (cli, fuzz, genesis-builder, hardforks, txpool), and I wasn't able to confirm locally whether `cargo ... --features X` silently no-ops on a selected package lacking that feature or hard-errors — so I kept the explicit list to stay on verified-safe ground. Happy to switch to the glob if a maintainer confirms that's fine.

## Acceptance criteria (from #420)
- [x] CI job builds the affected crates with `--features timestamp-in-seconds`
- [x] Job runs clippy with `-D warnings` (should be clean post-#418, which already resolved the `unused mut` seconds-mode warnings in `crates/seismic/chainspec/src/lib.rs`)
- [x] Job runs unit/e2e tests in seconds-mode, no `kind(test)` filter, so both are exercised

Opened after confirming #418 (the stated dependency) is already merged, and after checking the issue's timeline showed no existing PR referencing it.
