### PR TITLE
docs(rpc): resolve sign_typed_data_v4 TODO — explain why it's needed

### DIFF
--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -369,7 +369,14 @@ where
 {
     /// Handler for: `eth_signTypedData_v4`
     ///
-    /// TODO: determine if this should be removed, seems the same as eth functionality
+    /// Not a duplicate of the standard `eth_signTypedData` reth already exposes: its trait
+    /// definition in `reth_rpc_eth_api::core` registers the RPC method under the un-suffixed
+    /// name (`#[method(name = "signTypedData")]`) and returns raw `Bytes`. This handler adds
+    /// the `_v4`-suffixed name, hex-encoded as a `0x`-prefixed `String`, because that's the
+    /// method name and response shape real wallets and dapp libraries call for EIP-712 signing
+    /// — MetaMask's docs recommend `eth_signTypedData_v4` specifically, and seismic-alloy's own
+    /// README documents `.eip712()` as existing for "browser wallet compatibility (MetaMask)".
+    /// Without this, the node wouldn't answer `eth_signTypedData_v4` at all.
     async fn sign_typed_data_v4(&self, from: Address, data: TypedData) -> RpcResult<String> {
         debug!(target: "reth-seismic-rpc::eth", "Serving seismic eth_signTypedData_v4 extension");
         let signature = EthTransactions::sign_typed_data(&self.eth_api, &data, from)


### PR DESCRIPTION
Closes #467.

Resolves an author TODO on `sign_typed_data_v4` ("determine if this should be removed, seems the same as eth functionality") by replacing it with the answer.

## What I found
Upstream reth's own trait definition, in `reth_rpc_eth_api::core`, registers `eth_signTypedData` (no `_v4` suffix) via `#[method(name = "signTypedData")]` and returns raw `Bytes`:
```rust
/// Signs data via EIP-712.
#[method(name = "signTypedData")]
async fn sign_typed_data(&self, address: Address, data: TypedData) -> RpcResult<Bytes>;
```

This override in `ext.rs` isn't a duplicate of that — it's additive:
- **Method name**: the un-suffixed `eth_signTypedData` is never separately registered anywhere in this crate; only `eth_signTypedData_v4` is served.
- **Response shape**: this returns a hex `String` prefixed with `0x`, not raw `Bytes`.

`_v4` is the name real wallets and dapp libraries actually call for EIP-712 signing — MetaMask's docs recommend `eth_signTypedData_v4` specifically, and other client libraries (e.g. seaport-js) explicitly fall back between the two names because support differs by node/wallet. Seismic's own `seismic-alloy` SDK README documents `.eip712()` as existing for "browser wallet compatibility (MetaMask)", which matches. Removing this handler would mean the node no longer answers `eth_signTypedData_v4` at all.

## Change
Doc comment only — no logic change. Replaces the TODO with an explanation of the naming/response-shape difference and why it's needed, so a future reader doesn't have to re-derive this.
