### PR TITLE
fix(seismic/evm): use the payload's excess blob gas in evm_env_for_payload

### DIFF
--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -265,10 +265,14 @@ impl ConfigureEngineEvm<ExecutionData> for SeismicEvmConfig {
             .with_spec(spec_id)
             .enable_tx_chain_id_check();
 
-        let blob_excess_gas_and_price = payload
-            .payload
-            .blob_gas_used()
-            .map(|_gas| BlobExcessGasAndPrice::new_with_spec(0, spec_id.into_eth_spec()));
+        // Must match `evm_env`, which derives this from the header's `excess_blob_gas`:
+        // `PayloadValidator::evm_env_for` picks this function for a block that arrives as an
+        // engine payload and `evm_env` for the same block once it is a header, so any
+        // disagreement here makes BLOBBASEFEE (and therefore the state root) depend on which
+        // ingress path the block took.
+        let blob_excess_gas_and_price = payload.payload.excess_blob_gas().map(|excess_blob_gas| {
+            BlobExcessGasAndPrice::new_with_spec(excess_blob_gas, spec_id.into_eth_spec())
+        });
 
         let block_env = BlockEnv {
             number: U256::from(payload.payload.block_number()),
@@ -382,6 +386,72 @@ mod tests {
         // Assert that the chain ID in the `cfg_env` is correctly set to the chain ID of the
         // ChainSpec
         assert_eq!(cfg_env.chain_id, chain_spec.chain().id());
+    }
+
+    /// `PayloadValidator::evm_env_for` builds the EVM env with `evm_env_for_payload` when a
+    /// block arrives over the engine API and with `evm_env` when the same block is already a
+    /// header. Both must produce the same blob fee, otherwise BLOBBASEFEE — and the resulting
+    /// state root — would depend on which ingress path the block took.
+    ///
+    /// Regression: `evm_env_for_payload` read `blob_gas_used` and then hardcoded an excess blob
+    /// gas of 0, so the engine path always saw the minimum blob fee.
+    #[test]
+    fn engine_payload_evm_env_matches_header_evm_env_blob_fee() {
+        use alloy_consensus::{Block as ConsensusBlock, BlockBody, EMPTY_ROOT_HASH};
+        use alloy_rpc_types_engine::ExecutionPayload;
+
+        // A multiple of GAS_PER_BLOB (131_072), and large enough that the derived blob gas
+        // price sits above its 1 wei floor: that way the two paths disagree on BLOBBASEFEE
+        // itself, not merely on the raw excess value. Mainnet excess blob gas reaches this
+        // range under sustained blob congestion.
+        const EXCESS_BLOB_GAS: u64 = 256 * 131_072;
+
+        let evm_config = test_evm_config();
+
+        let header = Header {
+            number: 7,
+            timestamp: 1_700_000_000,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(7),
+            withdrawals_root: Some(EMPTY_ROOT_HASH),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(EXCESS_BLOB_GAS),
+            parent_beacon_block_root: Some(B256::ZERO),
+            ..Default::default()
+        };
+
+        let block: SeismicBlock = ConsensusBlock {
+            header: header.clone(),
+            body: BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: Some(Default::default()),
+            },
+        };
+        let sealed = SealedBlock::seal_slow(block);
+        let block_hash = sealed.hash();
+        let (payload, sidecar) =
+            ExecutionPayload::from_block_unchecked(block_hash, &sealed.into_block());
+        let execution_data = alloy_rpc_types_engine::ExecutionData { payload, sidecar };
+
+        let from_header = evm_config.evm_env(&header).block_env.blob_excess_gas_and_price;
+        let from_payload =
+            evm_config.evm_env_for_payload(&execution_data).block_env.blob_excess_gas_and_price;
+
+        assert_eq!(
+            from_payload, from_header,
+            "engine payload and header must agree on the blob fee"
+        );
+
+        let blob = from_header.expect("cancun block carries a blob fee");
+        assert_eq!(blob.excess_blob_gas, EXCESS_BLOB_GAS);
+        // Guards the point of the test: at this excess the price is off its floor, so the
+        // regression changed BLOBBASEFEE and not just the excess field.
+        assert!(
+            blob.blob_gasprice > 1,
+            "excess blob gas must move the price off its floor, got {}",
+            blob.blob_gasprice,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`SeismicEvmConfig::evm_env_for_payload` gates the blob fee on `blob_gas_used()` and then builds it from a hardcoded excess blob gas of `0`, discarding the value the payload actually carries:

```rust
let blob_excess_gas_and_price = payload
    .payload
    .blob_gas_used()
    .map(|_gas| BlobExcessGasAndPrice::new_with_spec(0, spec_id.into_eth_spec()));
```

Two separate problems: it reads the wrong field, and it throws away the value it does read.

## Why it matters

`PayloadValidator::evm_env_for` picks the constructor by ingress path:

```rust
// crates/engine/tree/src/tree/payload_validator.rs
BlockOrPayload::Payload(payload) => self.evm_config.evm_env_for_payload(payload),
BlockOrPayload::Block(block)     => self.evm_config.evm_env(block.header()),
```

`evm_env` derives the blob fee from `header.excess_blob_gas`, so the **same block** gets a different `BLOBBASEFEE` depending on whether it reached the node as an engine `newPayload` or as a header. The added test makes the gap concrete at `excess_blob_gas = 33_554_432`:

| path | `excess_blob_gas` | `blob_gasprice` |
| --- | --- | --- |
| `evm_env_for_payload` (engine) | 0 | 1 |
| `evm_env` (header) | 33_554_432 | 812 |

Any block whose execution reads `BLOBBASEFEE` can therefore settle on a different state root on the two paths. This is the live import path: `SeismicNode` wires `ConfigureEngineEvm` in `build_tree_validator`.

## Fix

Read `excess_blob_gas` from the payload, matching both `evm_env` in this same file and the upstream `EthEvmConfig::evm_env_for_payload`.

## Test

`engine_payload_evm_env_matches_header_evm_env_blob_fee` builds one sealed block, runs it through both constructors and asserts they agree on the blob fee. On `seismic` without the fix it fails with:

```
assertion `left == right` failed: engine payload and header must agree on the blob fee
  left: Some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 })
 right: Some(BlobExcessGasAndPrice { excess_blob_gas: 33554432, blob_gasprice: 812 })
```

The test asserts `blob_gasprice > 1` so it keeps covering the price, not just the raw excess value, if the constant is ever changed.

```
cargo test -p reth-seismic-evm engine_payload
test tests::engine_payload_evm_env_matches_header_evm_env_blob_fee ... ok
```
