### PR TITLE
fix(seismic/node): honor configured txpool limits and fee cap in the pool builder

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -583,8 +583,12 @@ where
         };
         let eth_validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
             .with_head_timestamp(head_timestamp_seconds)
+            .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
             .kzg_settings(ctx.kzg_settings()?)
             .with_local_transactions_config(pool_config.local_transactions_config.clone())
+            .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
+            .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
+            .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
             .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
             // Gas is paid in USDC on Seismic, not native ETH. Disable the native balance check
             // so transactions from accounts with zero ETH are not rejected. Actual gas payment
@@ -635,6 +639,10 @@ reth_transaction_pool::maintain::LocalTransactionBackupConfig::with_local_txs_ba
                     ctx.task_executor().clone(),
                     reth_transaction_pool::maintain::MaintainPoolConfig {
                         max_tx_lifetime: transaction_pool.config().max_queued_lifetime,
+                        no_local_exemptions: transaction_pool
+                            .config()
+                            .local_transactions_config
+                            .no_exemptions,
                         ..Default::default()
                     },
                     balance_hook,


### PR DESCRIPTION
## Problem

`SeismicPoolBuilder::build_pool` constructs its `EthTransactionValidator` without forwarding four values that are already parsed from the CLI, so the corresponding flags are accepted on the command line and then silently do nothing:

| flag | missing call |
| --- | --- |
| `--txpool.max-tx-input-bytes` | `with_max_tx_input_bytes` |
| `--txpool.max-tx-gas` | `with_max_tx_gas_limit` |
| `--txpool.minimum-priority-fee` | `with_minimum_priority_fee` |
| `--rpc.txfeecap` | `set_tx_fee_cap` |

The upstream `EthereumPoolBuilder` forwards all four.

The maintenance task has the same gap: `MaintainPoolConfig` is built with only `max_tx_lifetime` set, so `no_local_exemptions` stays at its `false` default and the eviction half of `--txpool.nolocals` never takes effect. `spawn_maintenance_task` in `crates/node/builder/src/components/pool.rs` passes it through.

Worth noting for `--txpool.max-tx-input-bytes` specifically: `SeismicRpcArgs` documents `--seismic.rpc.max-signed-read-input-bytes` as holding a signed read to "that same size" limit real transactions obey. That parity holds at the default but breaks as soon as an operator overrides the txpool limit, since only the signed-read side reads the configured value.

## Fix

Forward the four values, and set `no_local_exemptions` from the pool config.

## Risk

None at default settings. The validator builder already defaults to `DEFAULT_MAX_TX_INPUT_BYTES`, a 1 ETH fee cap, and no gas or priority-fee limit, and `MaintainPoolConfig::default()` already sets `no_local_exemptions: false`. This change only makes operator overrides take effect.

## Tests

No new test. These are config pass-throughs with no observable surface below `build_pool`: `EthTransactionValidatorBuilder` exposes no getters for the four fields, and reaching them from a test would need a `BuilderContext` carrying a custom `NodeConfig`, which the Seismic e2e harness (`setup_engine` with `Default::default()`) does not currently support.

That the validator honours the settings once they are set is already covered upstream in `crates/transaction-pool/src/validate/eth.rs` (`invalid_on_max_tx_gas_limit_exceeded`, `valid_on_max_tx_gas_limit_within_limit`, `valid_on_max_tx_gas_limit_disabled`). The only thing missing was handing them the value.

Happy to add an e2e test if you would like the harness extended to take a custom `NodeConfig`.
