### PR TITLE
test(seismic): use the shared e2e helpers in hardfork_config

### DIFF
--- a/crates/seismic/node/tests/e2e/hardfork_config.rs
+++ b/crates/seismic/node/tests/e2e/hardfork_config.rs
@@ -8,45 +8,16 @@
 //! in the `eth_config` RPC response.
 
 use alloy_eips::eip7910::EthConfig;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
-use alloy_rpc_types_engine::PayloadAttributes;
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_seismic_evm::PurposeKeys;
 use reth_chainspec::{EthChainSpec, Hardforks, Head};
 use reth_e2e_test_utils::setup;
-use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_seismic_chainspec::SEISMIC_DEV;
-use reth_seismic_node::{node::SeismicNode, purpose_keys::init_purpose_keys};
-use seismic_crypto::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk,
+use reth_seismic_node::{
+    node::SeismicNode,
+    utils::e2e::{ensure_mock_purpose_keys, seismic_payload_attributes},
 };
-use std::sync::Once;
-
-/// Ensure mock purpose keys are initialized exactly once per test binary.
-static INIT_KEYS: Once = Once::new();
-fn ensure_mock_purpose_keys() {
-    INIT_KEYS.call_once(|| {
-        init_purpose_keys(PurposeKeys {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            rng_ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes(),
-        });
-    });
-}
-
-/// Helper function to create a new eth payload attributes
-fn eth_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = PayloadAttributes {
-        timestamp,
-        prev_randao: B256::ZERO,
-        suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
-        parent_beacon_block_root: Some(B256::ZERO),
-    };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
-}
 
 /// Validates that the Mercury hardfork is correctly configured and reported via `eth_config` RPC.
 ///
@@ -66,7 +37,7 @@ async fn test_mercury_hardfork_config() -> eyre::Result<()> {
     let chain_spec = SEISMIC_DEV.clone();
 
     let (mut nodes, _tasks, wallet) =
-        setup::<SeismicNode>(1, chain_spec.clone(), false, eth_payload_attributes).await?;
+        setup::<SeismicNode>(1, chain_spec.clone(), false, seismic_payload_attributes).await?;
     let mut node = nodes.pop().unwrap();
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))


### PR DESCRIPTION
## What's wrong

`crates/seismic/node/tests/e2e/hardfork_config.rs` redefines two helpers that already exist in `reth_seismic_node::utils::e2e`, and its local copy of the payload-attributes helper drops the millisecond conversion:

```rust
// utils::e2e::seismic_payload_attributes
timestamp: timestamp * SEISMIC_TIMESTAMP_MULTIPLIER,

// hardfork_config.rs::eth_payload_attributes  (local copy)
timestamp,
```

The two function bodies are otherwise identical. The local one is what the test feeds to the node:

```rust
setup::<SeismicNode>(1, chain_spec.clone(), false, eth_payload_attributes).await?;
```

So this test drives a `SeismicNode` with second-valued payload timestamps, while Seismic treats block timestamps as milliseconds — the node divides by 1000 for the `TIMESTAMP` opcode and for every fork-activation check (`timestamp_seconds()`).

Both of these are called out in this repo's own `.claude/skills/pr-review/SKILL.md`, under **Known Antipatterns** ("These patterns are always bugs in Seismic code"):

> - Raw `timestamp` in payload attributes without multiplying by `SEISMIC_TIMESTAMP_MULTIPLIER` (1000) — Seismic uses millisecond timestamps
> - Duplicated `ensure_mock_purpose_keys()` — should use the shared helper from `utils.rs`

## Why this file specifically

Every other Seismic e2e test already imports the shared helpers; this was the only one carrying its own copies:

| Test file | `ensure_mock_purpose_keys` | Payload attributes |
| --- | --- | --- |
| `fuzz.rs` | `utils::e2e` | — |
| `integration.rs` | `utils::e2e` | — |
| `p2p.rs` | `utils::e2e` | — |
| `ops.rs` | `utils::e2e` | local, but applies `* SEISMIC_TIMESTAMP_MULTIPLIER` |
| **`hardfork_config.rs`** | **local copy** | **local copy, no multiplier** |

So the multiplier isn't ambiguous — `utils::e2e` and `ops.rs` both apply it; this file is the single outlier.

## The change

Import both helpers from `reth_seismic_node::utils::e2e` and delete the local copies, which also removes the imports they were the only users of (`PayloadAttributes`, `PurposeKeys`, `EthPayloadBuilderAttributes`, `init_purpose_keys`, the `seismic_crypto` sample-key trio, `Once`, and `B256`).

`test-utils` is already enabled for this crate in `dev-dependencies`, so `utils::e2e` is in scope without any Cargo change:

```toml
reth-seismic-node = { workspace = true, features = ["test-utils"] }
```

Net: 5 insertions, 34 deletions, one file.

## Verification

- `cargo +nightly fmt --check` on the touched file is clean (matches the `rustfmt` CI job, which is the one job that runs on `ubuntu-latest`).
- I checked each removed import individually to confirm nothing else in the file uses it — the remaining ones (`EthConfig`, `Address`, the provider trio, `TransactionRequest`, `EthChainSpec`/`Hardforks`/`Head`, `setup`, `SEISMIC_DEV`, `SeismicNode`) are all still used by the test body.
- `seismic_payload_attributes` has the same `fn(u64) -> EthPayloadBuilderAttributes` signature as the helper it replaces, so the `setup` call is unchanged apart from the name.

I could not run the test suite: the `unit-test` / `integration-test` jobs in `seismic.yml` require `large-github-runner`, which isn't available on a fork. Happy to iterate if CI surfaces anything.
