### PR TITLE
fix: prevent panic on SystemTime::duration_since unwrap in engine_store

### DIFF
--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -60,7 +60,7 @@ impl EngineMessageStore {
         T: PayloadTypes,
     {
         fs::create_dir_all(&self.path)?; // ensure that store path had been created
-        let timestamp = received_at.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis();
+        let timestamp = received_at.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_millis();
         match msg {
             BeaconEngineMessage::ForkchoiceUpdated {
                 state,


### PR DESCRIPTION
This PR replaces an `unwrap()` call on `SystemTime::duration_since` with a safe fallback using `unwrap_or_default()`.

The original implementation could panic if `received_at` is earlier than `UNIX_EPOCH`, since `duration_since` returns a `Result`. While this scenario is unlikely, it is still possible due to clock skew or unexpected input, and should not cause the node to crash.


- This change ensures safer handling of time calculations in the engine store.
- The fallback behavior defaults to zero duration when an error occurs.
- This aligns with defensive programming practices in critical execution paths.


- The project builds successfully after the change.
- No existing tests are affected.