### PR TITLE
feat(seismic/rpc): assign distinct JSON-RPC error codes to Seismic-specific errors

### DIFF
--- a/crates/seismic/rpc/src/eth/error_codes.rs
+++ b/crates/seismic/rpc/src/eth/error_codes.rs
@@ -1,0 +1,23 @@
+//! Named JSON-RPC error codes for Seismic-specific `eth_` errors.
+//!
+//! These previously all shared the generic server-error code `-32000`,
+//! which made it impossible for clients to distinguish one Seismic error
+//! from another without parsing the (unstable) message string. Each error
+//! now gets its own code in the reserved-for-implementation-defined-errors
+//! range (JSON-RPC 2.0 reserves `-32000` to `-32099` for server errors).
+
+/// Seismic-specific JSON-RPC error codes.
+///
+/// Client SDKs can match on these to handle each error case programmatically,
+/// e.g. `if err.code == seismic_error_codes::DECRYPTION_ERROR`.
+pub mod seismic_error_codes {
+    /// Returned when decrypting a Seismic shielded payload fails.
+    pub const DECRYPTION_ERROR: i32 = -39001;
+    /// Returned when encrypting a Seismic shielded payload fails.
+    pub const ENCRYPTION_ERROR: i32 = -39002;
+    /// Returned when a signed read's `expires_at_block` has already passed.
+    pub const TRANSACTION_EXPIRED: i32 = -39003;
+    /// Returned when a signed read's `recent_block_hash` is not found among
+    /// the last `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` canonical blocks.
+    pub const RECENT_BLOCK_HASH_NOT_FOUND: i32 = -39004;
+}

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -728,7 +728,7 @@ where
 /// Creates an [`EthApiError`] that says that seismic decryption failed
 pub fn ext_decryption_error(e_str: String) -> EthApiError {
     EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
-        -32000, // TODO: pick a better error code?
+        crate::eth::error_codes::seismic_error_codes::DECRYPTION_ERROR,
         "Error Decrypting in Seismic EthApiExt",
         Some(e_str),
     )))
@@ -737,7 +737,7 @@ pub fn ext_decryption_error(e_str: String) -> EthApiError {
 /// Creates an [`EthApiError`] that says that seismic encryption failed
 pub fn ext_encryption_error(e_str: String) -> EthApiError {
     EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
-        -32000, // TODO: pick a better error code?
+        crate::eth::error_codes::seismic_error_codes::ENCRYPTION_ERROR,
         "Error Encrypting in Seismic EthApiExt",
         Some(e_str),
     )))

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -1,5 +1,6 @@
 //! Seismic-Reth `eth_` endpoint implementation.
 
+pub mod error_codes;
 pub mod ext;
 pub mod receipt;
 pub mod transaction;

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -238,7 +238,7 @@ where
 fn seismic_expired_error(current_block: u64, expires_at_block: u64) -> EthApiError {
     let err = SeismicTxError::TransactionExpired { current_block, expires_at_block };
     EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
-        -32000,
+        crate::eth::error_codes::seismic_error_codes::TRANSACTION_EXPIRED,
         err.to_string(),
         None::<String>,
     )))
@@ -252,7 +252,7 @@ fn seismic_recent_block_hash_error(hash: B256) -> EthApiError {
         lookback: SEISMIC_TX_RECENT_BLOCK_LOOKBACK,
     };
     EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
-        -32000,
+        crate::eth::error_codes::seismic_error_codes::RECENT_BLOCK_HASH_NOT_FOUND,
         err.to_string(),
         None::<String>,
     )))


### PR DESCRIPTION
Fixes #462

Four Seismic-specific RPC error constructors (`ext_decryption_error`, `ext_encryption_error`, `seismic_expired_error`, `seismic_recent_block_hash_error`) all emitted the generic server error code `-32000`, two of them behind a `// TODO: get a real error code` comment. Clients could not distinguish one Seismic error from another without parsing the (unstable) message string.

**Fix:** added a new `seismic_error_codes` module (`crates/seismic/rpc/src/eth/error_codes.rs`) defining a distinct named constant for each, in the JSON-RPC implementation-defined-server-error range (`-32000` to `-32099`), matching the codes proposed in the issue:

```rust
pub mod seismic_error_codes {
    pub const DECRYPTION_ERROR: i32 = -39001;
    pub const ENCRYPTION_ERROR: i32 = -39002;
    pub const TRANSACTION_EXPIRED: i32 = -39003;
    pub const RECENT_BLOCK_HASH_NOT_FOUND: i32 = -39004;
}
```

**Scope:** deliberately limited to the four constructors named in the issue. Left the two other `-32000` usages in `transaction.rs` untouched (`send_raw_transaction_sync`'s ops-sentinel rejection and the `rpc_error` helper for ops-sentinel-not-canonical) - those cover a different error class not mentioned in the issue, and touching them felt like scope creep beyond what was asked.

**Verified:**
- `cargo check -p reth-seismic-rpc` - clean build
- `cargo fmt --check -p reth-seismic-rpc` - clean (exit 0)
- `cargo clippy -p reth-seismic-rpc --no-deps` - zero warnings attributable to the new code (checked specifically for `error_codes.rs` and the four constant names)