### PR TITLE
fix(seismic/txpool): RecentBlockCache off-by-one silently rejects valid transactions at the lookback boundary

### DIFF
--- a/crates/seismic/txpool/src/recent_block_cache.rs
+++ b/crates/seismic/txpool/src/recent_block_cache.rs
@@ -28,7 +28,15 @@ pub struct RecentBlockCache {
 
 impl Default for RecentBlockCache {
     fn default() -> Self {
-        Self::new(SEISMIC_TX_RECENT_BLOCK_LOOKBACK)
+        // `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` is a maximum *distance* (the RPC validator in
+        // `validate_seismic_freshness` accepts `recent_block_hash` at distance <= LOOKBACK,
+        // inclusive), so the inclusive window `[tip - LOOKBACK, tip]` spans `LOOKBACK + 1`
+        // distinct blocks. `max_size` here is a retained *count* (see `insert`'s eviction), so
+        // it must be seeded with `LOOKBACK + 1`, not `LOOKBACK` - otherwise `rebuild_window`
+        // evicts the oldest still-valid block (at distance exactly LOOKBACK) as soon as it
+        // finishes inserting the window, and a transaction referencing that block's hash is
+        // rejected by the txpool despite being accepted by `eth_call`.
+        Self::new(SEISMIC_TX_RECENT_BLOCK_LOOKBACK + 1)
     }
 }
 
@@ -407,6 +415,35 @@ mod tests {
         assert!(!cache.contains(&h5_old));
         assert!(cache.contains(&h5_new));
         assert_eq!(cache.current_block_number(), 5);
+    }
+
+    #[test]
+    fn test_rebuild_window_holds_full_inclusive_lookback() {
+        // Regression test for #460: a production-seeded cache (via `Default`, i.e.
+        // `SEISMIC_TX_RECENT_BLOCK_LOOKBACK`) must retain the block at distance exactly
+        // `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` after a rebuild, since `validate_seismic_freshness`
+        // (crates/seismic/rpc/src/eth/utils.rs) accepts `recent_block_hash` at that distance
+        // (inclusive `<=`). Before the fix, the oldest block in the window was evicted one
+        // insert too early, silently rejecting valid transactions referencing it.
+        fn hash_for(n: u64) -> B256 {
+            let mut bytes = [0u8; 32];
+            bytes[24..].copy_from_slice(&n.to_be_bytes());
+            B256::from(bytes)
+        }
+
+        let mut cache = RecentBlockCache::default();
+        let tip = 10_000u64;
+        let oldest_distance = SEISMIC_TX_RECENT_BLOCK_LOOKBACK;
+        let oldest_block = tip - oldest_distance;
+
+        let blocks: Vec<(B256, u64)> = (oldest_block..=tip).map(|n| (hash_for(n), n)).collect();
+        cache.rebuild_to_tip(tip, mock_canonical(&blocks));
+
+        assert!(
+            cache.contains(&hash_for(oldest_block)),
+            "block at distance {oldest_distance} (the oldest still-valid distance) must be in \
+             the cache after rebuild_to_tip"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #460

`RecentBlockCache::default()` seeded `max_size` directly with `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` (100). But `SEISMIC_TX_RECENT_BLOCK_LOOKBACK` is a maximum *distance*: `validate_seismic_freshness` (`rpc/src/eth/utils.rs`) accepts `recent_block_hash` at distance `<= LOOKBACK`, inclusive - an inclusive window of `LOOKBACK + 1` distinct blocks. `max_size`, however, is a retained *count* (`insert()`'s eviction cap). Seeding it with `LOOKBACK` instead of `LOOKBACK + 1` meant `rebuild_window`'s insert loop (`earliest..=tip`, which correctly spans `LOOKBACK + 1` blocks) immediately evicted the oldest one as soon as the loop finished, leaving the cache holding only distances `0..=LOOKBACK-1`.

**Effect:** a transaction referencing `recent_block_hash` from exactly `LOOKBACK` blocks ago passed the RPC's `eth_call` check but was rejected by the txpool with `SeismicTxError::RecentBlockHashNotFound` - a silent mismatch between what `eth_call` accepts and what `eth_sendRawTransaction` accepts.

**Fix:** seed `max_size` with `LOOKBACK + 1` instead of `LOOKBACK`. `insert()`'s generic eviction contract (retain at most `self.max_size`, exercised directly by `test_eviction` et al.) is untouched, so no other call site or test changes behavior - only the `Default`-constructed production cache (used by both `validator.rs` and `maintain.rs`) gets the corrected capacity. This also makes the existing `incomplete_until` hole-tracking arithmetic exactly correct rather than one block early, as a side effect.

**Tests:** added `test_rebuild_window_holds_full_inclusive_lookback`, constructed via `Default` (matching production) rather than a literal small `max_size`, asserting the block at exactly `LOOKBACK` distance survives `rebuild_to_tip`. Verified it fails against the pre-fix code and passes against the fix (manually toggled and reran both ways).

**Verified:**
- `cargo test -p reth-seismic-txpool` - 32/32 passing (full package)
- `cargo fmt --check -p reth-seismic-txpool` - clean
- `cargo clippy -p reth-seismic-txpool --no-deps` - zero warnings attributable to `recent_block_cache.rs`