### PR TITLE
chore: log sanitization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10343,6 +10343,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]

--- a/bin/seismic-reth/src/main.rs
+++ b/bin/seismic-reth/src/main.rs
@@ -12,23 +12,28 @@ fn main() {
 
     reth_cli_util::sigsegv_handler::install();
 
-    if let Err(err) = Cli::<SeismicChainSpecParser>::parse().run(|builder, ext| async move {
-        // Fetch purpose keys BEFORE building node components
-        let purpose_keys = fetch_purpose_keys(&ext).await;
+    if Cli::<SeismicChainSpecParser>::parse()
+        .run(|builder, ext| async move {
+            // Fetch purpose keys BEFORE building node components
+            let purpose_keys = fetch_purpose_keys(&ext).await;
 
-        // Store purpose keys in global static storage as a fallback for code
-        // paths that cannot yet receive keys structurally (e.g. CLI stage command).
-        // Seismic RPC modules (seismic_ namespace + eth_ overrides) are registered
-        // in SeismicAddOns::launch_add_ons, which reads keys via get_purpose_keys().
-        reth_seismic_node::purpose_keys::init_purpose_keys(purpose_keys.clone());
+            // Store purpose keys in global static storage as a fallback for code
+            // paths that cannot yet receive keys structurally (e.g. CLI stage command).
+            // Seismic RPC modules (seismic_ namespace + eth_ overrides) are registered
+            // in SeismicAddOns::launch_add_ons, which reads keys via get_purpose_keys().
+            reth_seismic_node::purpose_keys::init_purpose_keys(purpose_keys.clone());
 
-        // Inject purpose keys structurally into SeismicNode so they flow
-        // through the node builder lifecycle without relying on the global.
-        let node =
-            builder.node(SeismicNode::new(purpose_keys)).launch_with_debug_capabilities().await?;
-        node.node_exit_future.await
-    }) {
-        eprintln!("Error: {err:?}");
+            // Inject purpose keys structurally into SeismicNode so they flow
+            // through the node builder lifecycle without relying on the global.
+            let node = builder
+                .node(SeismicNode::new(purpose_keys))
+                .launch_with_debug_capabilities()
+                .await?;
+            node.node_exit_future.await
+        })
+        .is_err()
+    {
+        eprintln!("seismic-reth terminated with an internal error");
         std::process::exit(1);
     }
 }

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -67,7 +67,9 @@ fn verify_only<N: NodeTypesWithDB>(provider_factory: ProviderFactory<N>) -> eyre
                 last_progress_time = Instant::now();
             }
         } else {
-            warn!("Inconsistency found: {output:?}");
+            // Only log the kind: the full output contains hashed account addresses,
+            // trie paths, and node values, which are private.
+            warn!(kind = output_kind(&output), "Inconsistency found");
             inconsistent_nodes += 1;
         }
     }
@@ -104,7 +106,9 @@ fn verify_and_repair<N: NodeTypesWithDB>(provider_factory: ProviderFactory<N>) -
         let output = output_result?;
 
         if !matches!(output, Output::Progress(_)) {
-            warn!("Inconsistency found, will repair: {output:?}");
+            // Only log the kind: the full output contains hashed account addresses,
+            // trie paths, and node values, which are private.
+            warn!(kind = output_kind(&output), "Inconsistency found, will repair");
             inconsistent_nodes += 1;
         }
 
@@ -158,6 +162,19 @@ fn verify_and_repair<N: NodeTypesWithDB>(provider_factory: ProviderFactory<N>) -
     }
 
     Ok(())
+}
+
+/// Returns a short, non-sensitive label for a verifier output.
+const fn output_kind(output: &Output) -> &'static str {
+    match output {
+        Output::AccountExtra(..) => "account_extra",
+        Output::StorageExtra(..) => "storage_extra",
+        Output::AccountWrong { .. } => "account_wrong",
+        Output::StorageWrong { .. } => "storage_wrong",
+        Output::AccountMissing(..) => "account_missing",
+        Output::StorageMissing(..) => "storage_missing",
+        Output::Progress(..) => "progress",
+    }
 }
 
 /// Output progress information based on the last seen account path.

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -149,14 +149,14 @@ where
             tokio::select! {
                 // Wait for the interval or the pool to receive a transaction
                 _ = &mut self.mode => {
-                    if let Err(e) = self.advance().await {
-                        error!(target: "engine::local", "Error advancing the chain: {:?}", e);
+                    if self.advance().await.is_err() {
+                        error!(target: "engine::local", "Failed to advance the chain");
                     }
                 }
                 // send FCU once in a while
                 _ = fcu_interval.tick() => {
-                    if let Err(e) = self.update_forkchoice_state().await {
-                        error!(target: "engine::local", "Error updating fork choice: {:?}", e);
+                    if self.update_forkchoice_state().await.is_err() {
+                        error!(target: "engine::local", "Failed to update fork choice");
                     }
                 }
             }

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -1,8 +1,10 @@
 //! Engine tree configuration.
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0; // todo(dalton): Maybe feature flag this? We need this so archive nodes can get an accurate
-                                                  // snapshot. benchmarks dont signal this is of great cost to us
+pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0; // todo(dalton): Maybe feature flag this? We need
+                                                  // this so archive nodes can get an accurate
+                                                  // snapshot. benchmarks dont signal this is of
+                                                  // great cost to us
 
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;

--- a/crates/engine/tree/src/backup.rs
+++ b/crates/engine/tree/src/backup.rs
@@ -201,8 +201,8 @@ impl BackupHandle {
         std::thread::Builder::new()
             .name("Backup Service".to_string())
             .spawn(move || {
-                if let Err(err) = service.run() {
-                    error!(target: "engine::backup", ?err, "Backup service failed");
+                if service.run().is_err() {
+                    error!(target: "engine::backup", "Backup service failed");
                 }
             })
             .unwrap();

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -1,6 +1,6 @@
 use crate::backfill::{BackfillAction, BackfillEvent, BackfillSync};
 use futures::Stream;
-use reth_stages_api::{ControlFlow, PipelineTarget};
+use reth_stages_api::{ControlFlow, PipelineError, PipelineTarget};
 use std::{
     fmt::{Display, Formatter, Result},
     pin::Pin,
@@ -97,7 +97,16 @@ where
                                 Poll::Ready(ChainEvent::BackfillSyncFinished)
                             }
                             Err(err) => {
-                                tracing::error!( %err, "backfill sync failed");
+                                let error_kind = match &err {
+                                    PipelineError::Stage(_) => "stage",
+                                    PipelineError::Database(_) => "database",
+                                    PipelineError::Provider(_) => "provider",
+                                    PipelineError::Channel(_) => "channel",
+                                    PipelineError::Internal(_) => "internal",
+                                    PipelineError::UnexpectedUnwind => "unexpected_unwind",
+                                    PipelineError::UnwindTargetPruned(_) => "unwind_target_pruned",
+                                };
+                                tracing::error!(error_kind, "backfill sync failed");
                                 Poll::Ready(ChainEvent::FatalError)
                             }
                         }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -232,7 +232,11 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
             .name("Persistence Service".to_string())
             .spawn(|| {
                 if let Err(err) = db_service.run() {
-                    error!(target: "engine::persistence", ?err, "Persistence service failed");
+                    let error_kind = match &err {
+                        PersistenceError::PrunerError(_) => "pruner",
+                        PersistenceError::ProviderError(_) => "provider",
+                    };
+                    error!(target: "engine::persistence", error_kind, "Persistence service failed");
                 }
             })
             .unwrap();

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -370,7 +370,10 @@ impl ProviderCaches {
             // error has occurred because this state should be unrepresentable. An account with
             // `None` current info, should be destroyed.
             let Some(ref account_info) = account.info else {
-                trace!(target: "engine::caching", ?account, "Account with None account info found in state updates");
+                trace!(
+                    target: "engine::caching",
+                    "Account with None account info found in state updates"
+                );
                 return Err(())
             };
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1381,7 +1381,12 @@ where
                                 }
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
-                                debug!("receiving beacon engine message: payload: {:?}", payload);
+                                debug!(
+                                    target: "engine::tree",
+                                    block_number = payload.block_number(),
+                                    block_hash = %payload.block_hash(),
+                                    "receiving beacon engine new payload message"
+                                );
                                 let mut output = self.on_new_payload(payload);
 
                                 let maybe_event =

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -25,7 +25,7 @@ use reth_engine_primitives::{
     ForkchoiceStateTracker, OnForkChoiceUpdated,
 };
 use reth_errors::{ConsensusError, ProviderResult};
-use reth_evm::{ConfigureEvm, OnStateHook};
+use reth_evm::{execute::InternalBlockExecutionError, ConfigureEvm, OnStateHook};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadBuilderAttributes, PayloadTypes,
@@ -439,7 +439,21 @@ where
                 Ok(Some(msg)) => {
                     debug!(target: "engine::tree", %msg, "received new engine message");
                     if let Err(fatal) = self.on_engine_message(msg) {
-                        error!(target: "engine::tree", %fatal, "insert block fatal error");
+                        match &fatal {
+                            InsertBlockFatalError::Provider(_) => {
+                                error!(target: "engine::tree", error_kind = "provider", "insert block fatal error");
+                            }
+                            InsertBlockFatalError::BlockExecutionError(
+                                InternalBlockExecutionError::EVM { hash, .. },
+                            ) => {
+                                error!(target: "engine::tree", error_kind = "evm", tx_hash = %hash, "insert block fatal error");
+                            }
+                            InsertBlockFatalError::BlockExecutionError(
+                                InternalBlockExecutionError::Other(_),
+                            ) => {
+                                error!(target: "engine::tree", error_kind = "other", "insert block fatal error");
+                            }
+                        }
                         return
                     }
                 }
@@ -456,8 +470,8 @@ where
                 error!(target: "engine::tree", %err, "Advancing persistence failed");
                 return
             }
-            if let Err(err) = self.advance_backup() {
-                error!(target: "engine::tree", %err, "Advancing backup failed");
+            if self.advance_backup().is_err() {
+                error!(target: "engine::tree", "Advancing backup failed");
                 return
             }
         }
@@ -1370,14 +1384,12 @@ where
                                     self.on_maybe_tree_event(res.event.take())?;
                                 }
 
-                                if let Err(err) =
-                                    tx.send(output.map(|o| o.outcome).map_err(Into::into))
-                                {
+                                if tx.send(output.map(|o| o.outcome).map_err(Into::into)).is_err() {
                                     self.metrics
                                         .engine
                                         .failed_forkchoice_updated_response_deliveries
                                         .increment(1);
-                                    error!(target: "engine::tree", "Failed to send event: {err:?}");
+                                    error!(target: "engine::tree", "Failed to send forkchoice updated response");
                                 }
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
@@ -1393,12 +1405,13 @@ where
                                     output.as_mut().ok().and_then(|out| out.event.take());
 
                                 // emit response
-                                if let Err(err) =
-                                    tx.send(output.map(|o| o.outcome).map_err(|e| {
+                                if tx
+                                    .send(output.map(|o| o.outcome).map_err(|e| {
                                         BeaconOnNewPayloadError::Internal(Box::new(e))
                                     }))
+                                    .is_err()
                                 {
-                                    error!(target: "engine::tree", "Failed to send event: {err:?}");
+                                    error!(target: "engine::tree", "Failed to send new payload response");
                                     self.metrics
                                         .engine
                                         .failed_new_payload_response_deliveries
@@ -1974,9 +1987,39 @@ where
                 }
                 Err(err) => {
                     if let InsertPayloadError::Block(err) = err {
-                        debug!(target: "engine::tree", ?err, "failed to connect buffered block to tree");
+                        let error_kind = match err.kind() {
+                            error::InsertBlockErrorKind::Consensus(_) => "consensus",
+                            error::InsertBlockErrorKind::Execution(
+                                reth_errors::BlockExecutionError::Validation(_),
+                            ) => "execution_validation",
+                            error::InsertBlockErrorKind::Execution(
+                                reth_errors::BlockExecutionError::Internal(_),
+                            ) => "execution_internal",
+                            error::InsertBlockErrorKind::Provider(_) => "provider",
+                            error::InsertBlockErrorKind::Other(_) => "other",
+                        };
+                        debug!(
+                            target: "engine::tree",
+                            block = ?child_num_hash,
+                            error_kind,
+                            "failed to connect buffered block to tree"
+                        );
                         if let Err(fatal) = self.on_insert_block_error(err) {
-                            warn!(target: "engine::tree", %fatal, "fatal error occurred while connecting buffered blocks");
+                            let error_kind = match &fatal {
+                                InsertBlockFatalError::Provider(_) => "provider",
+                                InsertBlockFatalError::BlockExecutionError(
+                                    InternalBlockExecutionError::EVM { .. },
+                                ) => "evm",
+                                InsertBlockFatalError::BlockExecutionError(
+                                    InternalBlockExecutionError::Other(_),
+                                ) => "other",
+                            };
+                            warn!(
+                                target: "engine::tree",
+                                block = ?child_num_hash,
+                                error_kind,
+                                "fatal error occurred while connecting buffered blocks"
+                            );
                             return Err(fatal)
                         }
                     }
@@ -2318,9 +2361,39 @@ where
             }
             Err(err) => {
                 if let InsertPayloadError::Block(err) = err {
-                    debug!(target: "engine::tree", err=%err.kind(), "failed to insert downloaded block");
+                    let error_kind = match err.kind() {
+                        error::InsertBlockErrorKind::Consensus(_) => "consensus",
+                        error::InsertBlockErrorKind::Execution(
+                            reth_errors::BlockExecutionError::Validation(_),
+                        ) => "execution_validation",
+                        error::InsertBlockErrorKind::Execution(
+                            reth_errors::BlockExecutionError::Internal(_),
+                        ) => "execution_internal",
+                        error::InsertBlockErrorKind::Provider(_) => "provider",
+                        error::InsertBlockErrorKind::Other(_) => "other",
+                    };
+                    debug!(
+                        target: "engine::tree",
+                        block = ?block_num_hash,
+                        error_kind,
+                        "failed to insert downloaded block"
+                    );
                     if let Err(fatal) = self.on_insert_block_error(err) {
-                        warn!(target: "engine::tree", %fatal, "fatal error occurred while inserting downloaded block");
+                        let error_kind = match &fatal {
+                            InsertBlockFatalError::Provider(_) => "provider",
+                            InsertBlockFatalError::BlockExecutionError(
+                                InternalBlockExecutionError::EVM { .. },
+                            ) => "evm",
+                            InsertBlockFatalError::BlockExecutionError(
+                                InternalBlockExecutionError::Other(_),
+                            ) => "other",
+                        };
+                        warn!(
+                            target: "engine::tree",
+                            block = ?block_num_hash,
+                            error_kind,
+                            "fatal error occurred while inserting downloaded block"
+                        );
                         return Err(fatal)
                     }
                 }
@@ -2577,11 +2650,15 @@ where
         // If the error was due to an invalid payload, the payload is added to the
         // invalid headers cache and `Ok` with [PayloadStatusEnum::Invalid] is
         // returned.
+        let validation_error_kind = match &validation_err {
+            error::InsertBlockValidationError::Consensus(_) => "consensus",
+            error::InsertBlockValidationError::Validation(_) => "execution_validation",
+        };
         warn!(
             target: "engine::tree",
             invalid_hash=%block.hash(),
             invalid_number=block.number(),
-            %validation_err,
+            validation_error_kind,
             "Invalid block error on new payload",
         );
         let latest_valid_hash = self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
@@ -2603,7 +2680,11 @@ where
         error: NewPayloadError,
         parent_hash: B256,
     ) -> ProviderResult<PayloadStatus> {
-        error!(target: "engine::tree", %error, "Invalid payload");
+        let error_kind = match &error {
+            NewPayloadError::Eth(_) => "payload",
+            NewPayloadError::Other(_) => "other",
+        };
+        error!(target: "engine::tree", error_kind, "Invalid payload");
         // we need to convert the error to a payload status (response to the CL)
 
         let latest_valid_hash =
@@ -2765,7 +2846,20 @@ where
         if let Err(err) =
             self.payload_validator.validate_payload_attributes_against_header(&attrs, head)
         {
-            warn!(target: "engine::tree", %err, ?head, "Invalid payload attributes");
+            let error_kind = match err {
+                reth_payload_primitives::InvalidPayloadAttributesError::InvalidTimestamp => {
+                    "invalid_timestamp"
+                }
+                reth_payload_primitives::InvalidPayloadAttributesError::InvalidParams(_) => {
+                    "invalid_params"
+                }
+            };
+            warn!(
+                target: "engine::tree",
+                head_number = head.number(),
+                error_kind,
+                "Invalid payload attributes"
+            );
             return OnForkChoiceUpdated::invalid_payload_attributes()
         }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -467,7 +467,14 @@ where
             }
 
             if let Err(err) = self.advance_persistence() {
-                error!(target: "engine::tree", %err, "Advancing persistence failed");
+                // `ProviderError`'s Display can embed hashed addresses/keys, so log only the
+                // error kind. `MissingAncestor` carries a public block hash, which is safe.
+                let error_kind = match &err {
+                    AdvancePersistenceError::RecvError(_) => "recv",
+                    AdvancePersistenceError::Provider(_) => "provider",
+                    AdvancePersistenceError::MissingAncestor(_) => "missing_ancestor",
+                };
+                error!(target: "engine::tree", error_kind, "Advancing persistence failed");
                 return
             }
             if self.advance_backup().is_err() {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -446,7 +446,6 @@ where
             trace!(
                 target: "engine::root",
                 proof_sequence_number,
-                ?proof_targets,
                 storage_targets,
                 "Starting dedicated storage proof calculation",
             );
@@ -518,7 +517,6 @@ where
             trace!(
                 target: "engine::root",
                 proof_sequence_number,
-                ?proof_targets,
                 account_targets,
                 storage_targets,
                 ?source,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -219,7 +219,7 @@ pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostStat
     for (address, account) in update {
         if account.is_touched() {
             let hashed_address = keccak256(address);
-            trace!(target: "engine::root", ?address, ?hashed_address, "Adding account to state update");
+            trace!(target: "engine::root", "Adding account to state update");
 
             let destroyed = account.is_selfdestructed();
             let info = if destroyed { None } else { Some(account.info.into()) };
@@ -1061,9 +1061,15 @@ where
                         }
                     }
                     MultiProofMessage::ProofCalculationError(err) => {
+                        let error_kind = match err {
+                            ProviderError::Database(_) => "database",
+                            ProviderError::Rlp(_) => "rlp",
+                            ProviderError::ConsistentView(_) => "consistent_view",
+                            _ => "other",
+                        };
                         error!(
                             target: "engine::root",
-                            ?err,
+                            error_kind,
                             "proof calculation error"
                         );
                         return

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -251,12 +251,8 @@ where
 
         let state_provider = match provider.build() {
             Ok(provider) => provider,
-            Err(err) => {
-                trace!(
-                    target: "engine::tree",
-                    %err,
-                    "Failed to build state provider in prewarm thread"
-                );
+            Err(_) => {
+                trace!(target: "engine::tree", "Failed to build state provider in prewarm thread");
                 return None
             }
         };
@@ -328,12 +324,10 @@ where
             let start = Instant::now();
             let res = match evm.transact(&tx) {
                 Ok(res) => res,
-                Err(err) => {
+                Err(_) => {
                     trace!(
                         target: "engine::tree",
-                        %err,
-                        tx_hash=%tx.tx().tx_hash(),
-                        sender=%tx.signer(),
+                        tx_hash = %tx.tx().tx_hash(),
                         "Error when executing prewarm transaction",
                     );
                     return

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -188,7 +188,7 @@ where
                     continue;
                 }
 
-                trace!(target: "engine::root::sparse", ?slot_nibbles, "Updating storage slot");
+                trace!(target: "engine::root::sparse", "Updating storage slot");
                 storage_trie.update_leaf(
                     slot_nibbles,
                     alloy_rlp::encode_fixed_size(&value).to_vec(),
@@ -198,7 +198,7 @@ where
             }
 
             for slot_nibbles in removed_slots {
-                trace!(target: "engine::root::sparse", ?slot_nibbles, "Removing storage slot");
+                trace!(target: "engine::root::sparse", "Removing storage slot");
                 storage_trie.remove_leaf(&slot_nibbles, &storage_provider)?;
             }
 
@@ -223,7 +223,7 @@ where
         if let Some(account) = state.accounts.remove(&address) {
             // If the account itself has an update, remove it from the state update and update in
             // one go instead of doing it down below.
-            trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
+            trace!(target: "engine::root::sparse", "Updating account and its storage root");
             if !trie.update_account(
                 address,
                 account.unwrap_or_default(),
@@ -233,7 +233,7 @@ where
             }
         } else if trie.is_account_revealed(address) {
             // Otherwise, if the account is revealed, only update its storage root.
-            trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
+            trace!(target: "engine::root::sparse", "Updating account storage root");
             if !trie.update_account_storage_root(address, blinded_provider_factory)? {
                 removed_accounts.push(address);
             }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -162,7 +162,7 @@ where
         .map(|(address, storage)| (address, storage, trie.take_storage_trie(&address)))
         .par_bridge()
         .map(|(address, storage, storage_trie)| {
-            let span = trace_span!(target: "engine::root::sparse", "Storage trie", ?address);
+            let span = trace_span!(target: "engine::root::sparse", "Storage trie");
             let _enter = span.enter();
             trace!(target: "engine::root::sparse", "Updating storage");
             let storage_provider = blinded_provider_factory.storage_node_provider(address);
@@ -242,7 +242,7 @@ where
 
     // Update accounts
     for (address, account) in state.accounts {
-        trace!(target: "engine::root::sparse", ?address, "Updating account");
+        trace!(target: "engine::root::sparse", "Updating account");
         if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
             removed_accounts.push(address);
         }
@@ -250,7 +250,7 @@ where
 
     // Remove accounts
     for address in removed_accounts {
-        trace!(target: "trie::sparse", ?address, "Removing account");
+        trace!(target: "trie::sparse", "Removing account");
         let nibbles = Nibbles::unpack(address);
         trie.remove_account_leaf(&nibbles, blinded_provider_factory)?;
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -499,7 +499,17 @@ where
                         }
                     }
                     Err(error) => {
-                        debug!(target: "engine::tree", %error, "Background parallel state root computation failed");
+                        let error_kind = match &error {
+                            ParallelStateRootError::StorageRoot(_) => "storage_root",
+                            ParallelStateRootError::Provider(_) => "provider",
+                            ParallelStateRootError::Other(_) => "other",
+                        };
+                        debug!(
+                            target: "engine::tree",
+                            block = ?block_num_hash,
+                            error_kind,
+                            "Background parallel state root computation failed, falling back"
+                        );
                     }
                 }
             } else {

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -483,7 +483,8 @@ mod tests {
         tree_state.insert_executed(fork_block_5.clone());
 
         assert_eq!(tree_state.blocks_by_hash.len(), 8);
-        assert_eq!(tree_state.blocks_by_number[&3].len(), 2); // two blocks at height 3 (original and fork)
+        assert_eq!(tree_state.blocks_by_number[&3].len(), 2); // two blocks at height 3 (original
+                                                              // and fork)
         assert_eq!(tree_state.parent_to_child[&blocks[1].recovered_block().hash()].len(), 2); // block 2 should have two children
 
         // verify that we can insert the same block again without issues

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -29,26 +29,25 @@ impl TrieUpdatesDiff {
             !self.storage_tries.is_empty()
     }
 
-    pub(super) fn log_differences(mut self) {
+    pub(super) fn log_differences(self) {
         if self.has_differences() {
-            for (path, EntryDiff { task, regular, database }) in &mut self.account_nodes {
-                warn!(target: "engine::tree", ?path, ?task, ?regular, ?database, "Difference in account trie updates");
+            // Trie paths are prefixes of hashed account addresses and node values contain
+            // state data, so only aggregate counts are logged.
+            if !self.account_nodes.is_empty() {
+                warn!(target: "engine::tree", count = self.account_nodes.len(), "Difference in account trie updates");
             }
 
-            for (
-                path,
-                EntryDiff {
-                    task: task_removed,
-                    regular: regular_removed,
-                    database: database_not_exists,
-                },
-            ) in &self.removed_nodes
+            for EntryDiff {
+                task: task_removed,
+                regular: regular_removed,
+                database: database_not_exists,
+            } in self.removed_nodes.values()
             {
-                warn!(target: "engine::tree", ?path, ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed account trie nodes");
+                warn!(target: "engine::tree", ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed account trie nodes");
             }
 
-            for (address, storage_diff) in self.storage_tries {
-                storage_diff.log_differences(address);
+            for (_address, storage_diff) in self.storage_tries {
+                storage_diff.log_differences();
             }
         }
     }
@@ -68,7 +67,7 @@ impl StorageTrieUpdatesDiff {
             !self.removed_nodes.is_empty()
     }
 
-    fn log_differences(&self, address: B256) {
+    fn log_differences(&self) {
         if let Some(EntryDiff {
             task: task_deleted,
             regular: regular_deleted,
@@ -78,8 +77,9 @@ impl StorageTrieUpdatesDiff {
             warn!(target: "engine::tree", ?task_deleted, ?regular_deleted, ?database_not_exists, "Difference in storage trie deletion");
         }
 
-        for (path, EntryDiff { task, regular, database }) in &self.storage_nodes {
-            warn!(target: "engine::tree", ?address, ?path, ?task, ?regular, ?database, "Difference in storage trie updates");
+        // Hashed addresses, trie paths, and node values are private; log only the count.
+        if !self.storage_nodes.is_empty() {
+            warn!(target: "engine::tree", count = self.storage_nodes.len(), "Difference in storage trie updates");
         }
 
         for EntryDiff {

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -75,23 +75,20 @@ impl StorageTrieUpdatesDiff {
             database: database_not_exists,
         }) = self.is_deleted
         {
-            warn!(target: "engine::tree", ?address, ?task_deleted, ?regular_deleted, ?database_not_exists, "Difference in storage trie deletion");
+            warn!(target: "engine::tree", ?task_deleted, ?regular_deleted, ?database_not_exists, "Difference in storage trie deletion");
         }
 
         for (path, EntryDiff { task, regular, database }) in &self.storage_nodes {
             warn!(target: "engine::tree", ?address, ?path, ?task, ?regular, ?database, "Difference in storage trie updates");
         }
 
-        for (
-            path,
-            EntryDiff {
-                task: task_removed,
-                regular: regular_removed,
-                database: database_not_exists,
-            },
-        ) in &self.removed_nodes
+        for EntryDiff {
+            task: task_removed,
+            regular: regular_removed,
+            database: database_not_exists,
+        } in self.removed_nodes.values()
         {
-            warn!(target: "engine::tree", ?address, ?path, ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed storage trie nodes");
+            warn!(target: "engine::tree", ?task_removed, ?regular_removed, ?database_not_exists, "Difference in removed storage trie nodes");
         }
     }
 }

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -142,7 +142,7 @@ where
         let next = ready!(this.stream.poll_next_unpin(cx));
         if let Some(msg) = &next {
             if let Err(error) = this.store.on_message(msg, SystemTime::now()) {
-                error!(target: "engine::stream::store", ?msg, %error, "Error handling Engine API message");
+                error!(target: "engine::stream::store", message = %msg, %error, "Error handling Engine API message");
             }
         }
         Poll::Ready(next)

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -133,11 +133,14 @@ where
                         );
                     }
                     Ok(Either::Right(Ok(fcu_status))) => {
+                        let status = match fcu_status.forkchoice_status() {
+                            reth_engine_primitives::ForkchoiceStatus::Valid => "valid",
+                            reth_engine_primitives::ForkchoiceStatus::Invalid => "invalid",
+                            reth_engine_primitives::ForkchoiceStatus::Syncing => "syncing",
+                        };
                         debug!(
                             target: "engine::stream::reorg",
-                            status = fcu_status.payload_status.status.as_str(),
-                            latest_valid_hash = ?fcu_status.payload_status.latest_valid_hash,
-                            payload_id = ?fcu_status.payload_id,
+                            status,
                             "Received response for reorg forkchoice update"
                         );
                     }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -114,16 +114,46 @@ where
             if let Poll::Ready(Some(response)) = this.reorg_responses.poll_next_unpin(cx) {
                 match response {
                     Ok(Either::Left(Ok(payload_status))) => {
-                        debug!(target: "engine::stream::reorg", ?payload_status, "Received response for reorg new payload");
+                        debug!(
+                            target: "engine::stream::reorg",
+                            status = payload_status.status.as_str(),
+                            latest_valid_hash = ?payload_status.latest_valid_hash,
+                            "Received response for reorg new payload"
+                        );
                     }
                     Ok(Either::Left(Err(payload_error))) => {
-                        error!(target: "engine::stream::reorg", %payload_error, "Error on reorg new payload");
+                        let error_kind = match payload_error {
+                            BeaconOnNewPayloadError::EngineUnavailable => "engine_unavailable",
+                            BeaconOnNewPayloadError::Internal(_) => "internal",
+                        };
+                        error!(
+                            target: "engine::stream::reorg",
+                            error_kind,
+                            "Error on reorg new payload"
+                        );
                     }
                     Ok(Either::Right(Ok(fcu_status))) => {
-                        debug!(target: "engine::stream::reorg", ?fcu_status, "Received response for reorg forkchoice update");
+                        debug!(
+                            target: "engine::stream::reorg",
+                            status = fcu_status.payload_status.status.as_str(),
+                            latest_valid_hash = ?fcu_status.payload_status.latest_valid_hash,
+                            payload_id = ?fcu_status.payload_id,
+                            "Received response for reorg forkchoice update"
+                        );
                     }
                     Ok(Either::Right(Err(fcu_error))) => {
-                        error!(target: "engine::stream::reorg", %fcu_error, "Error on reorg forkchoice update");
+                        let error_kind = match fcu_error {
+                            RethError::Execution(_) => "execution",
+                            RethError::Consensus(_) => "consensus",
+                            RethError::Database(_) => "database",
+                            RethError::Provider(_) => "provider",
+                            RethError::Other(_) => "other",
+                        };
+                        error!(
+                            target: "engine::stream::reorg",
+                            error_kind,
+                            "Error on reorg forkchoice update"
+                        );
                     }
                     Err(_) => {}
                 };
@@ -167,7 +197,18 @@ where
                     ) {
                         Ok(result) => result,
                         Err(error) => {
-                            error!(target: "engine::stream::reorg", %error, "Error attempting to create reorg head");
+                            let error_kind = match error {
+                                RethError::Execution(_) => "execution",
+                                RethError::Consensus(_) => "consensus",
+                                RethError::Database(_) => "database",
+                                RethError::Provider(_) => "provider",
+                                RethError::Other(_) => "other",
+                            };
+                            error!(
+                                target: "engine::stream::reorg",
+                                error_kind,
+                                "Error attempting to create reorg head"
+                            );
                             // Forward the payload and attempt to create reorg on top of
                             // the next one
                             return Poll::Ready(Some(BeaconEngineMessage::NewPayload {
@@ -303,10 +344,9 @@ where
         let gas_used = match builder.execute_transaction(tx_recovered) {
             Ok(gas_used) => gas_used,
             Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                hash,
-                error,
+                hash, ..
             })) => {
-                trace!(target: "engine::stream::reorg", hash = %hash, ?error, "Error executing transaction from next block");
+                trace!(target: "engine::stream::reorg", hash = %hash, "Error executing transaction from next block");
                 continue
             }
             // Treat error as fatal

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -48,9 +48,9 @@ where
                             target: "engine::stream::skip_new_payload",
                             block_number = payload.block_number(),
                             block_hash = %payload.block_hash(),
-                            ?payload,
-                            threshold=this.threshold,
-                            skipped=this.skipped, "Skipping new payload"
+                            threshold = this.threshold,
+                            skipped = this.skipped,
+                            "Skipping new payload"
                         );
                         let _ = tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing)));
                         continue

--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -142,7 +142,8 @@ impl From<EthVersion> for Capability {
 impl<'a> arbitrary::Arbitrary<'a> for Capability {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let version = u.int_in_range(66..=69)?; // Valid eth protocol versions are 66-69
-                                                // Only generate valid eth protocol name for now since it's the only supported protocol
+                                                // Only generate valid eth protocol name for now
+                                                // since it's the only supported protocol
         Ok(Self::new_static("eth", version))
     }
 }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -341,7 +341,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 if msg.is_valid_for_version(self.conn.version()) {
                     self.queued_outgoing.push_back(EthMessage::from(msg).into());
                 } else {
-                    debug!(target: "net", ?msg,  version=?self.conn.version(), "Message is invalid for connection version, skipping");
+                    debug!(target: "net", version=?self.conn.version(), "Message is invalid for connection version, skipping");
                 }
             }
             PeerMessage::EthRequest(req) => {
@@ -716,7 +716,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                         progress = true;
                                     }
                                     OnIncomingMessageOutcome::BadMessage { error, message } => {
-                                        debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
+                                        debug!(target: "net::session", %error, message_id=?message.message_id(), remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
                                         return this.close_on_error(error, cx)
                                     }
                                     OnIncomingMessageOutcome::NoCapacity(msg) => {

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -259,7 +259,8 @@ async fn test_get_header_range_falling() {
     // ensure we can fetch the correct headers in falling direction
     // start from the last header and work backwards
     for idx in (0..100).rev() {
-        let count = std::cmp::min(idx + 1, 100); // Can't fetch more than idx+1 headers when going backwards
+        let count = std::cmp::min(idx + 1, 100); // Can't fetch more than idx+1 headers when going
+                                                 // backwards
         let header = &all_headers[idx];
         let req = HeadersRequest {
             start: header.hash().into(),

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -40,8 +40,10 @@ pub use reth_engine_primitives::{
 };
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0; // todo(dalton): Maybe feature flag this? We need this so archive nodes can get an accurate
-                                                  // snapshot. benchmarks dont signal this is of great cost to us
+pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 0; // todo(dalton): Maybe feature flag this? We need
+                                                  // this so archive nodes can get an accurate
+                                                  // snapshot. benchmarks dont signal this is of
+                                                  // great cost to us
 
 /// Default size of cross-block cache in megabytes.
 pub const DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB: u64 = 4 * 1024;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -395,16 +395,16 @@ where
                 Poll::Ready(Ok(outcome)) => match outcome {
                     BuildOutcome::Better { payload, cached_reads } => {
                         this.cached_reads = Some(cached_reads);
-                        debug!(target: "payload_builder", value = %payload.fees(), "built better payload");
+                        debug!(target: "payload_builder", "built better payload");
                         this.best_payload = PayloadState::Best(payload);
                     }
                     BuildOutcome::Freeze(payload) => {
                         debug!(target: "payload_builder", "payload frozen, no further building will occur");
                         this.best_payload = PayloadState::Frozen(payload);
                     }
-                    BuildOutcome::Aborted { fees, cached_reads } => {
+                    BuildOutcome::Aborted { cached_reads, .. } => {
                         this.cached_reads = Some(cached_reads);
-                        trace!(target: "payload_builder", worse_fees = %fees, "skipped payload build of worse block");
+                        trace!(target: "payload_builder", "skipped payload build of worse block");
                     }
                     BuildOutcome::Cancelled => {
                         unreachable!("the cancel signal never fired")
@@ -412,7 +412,16 @@ where
                 },
                 Poll::Ready(Err(error)) => {
                     // job failed, but we simply try again next interval
-                    debug!(target: "payload_builder", %error, "payload build attempt failed");
+                    let error_kind = match &error {
+                        PayloadBuilderError::MissingParentHeader(_) => "missing_parent_header",
+                        PayloadBuilderError::MissingParentBlock(_) => "missing_parent_block",
+                        PayloadBuilderError::ChannelClosed => "channel_closed",
+                        PayloadBuilderError::MissingPayload => "missing_payload",
+                        PayloadBuilderError::Internal(_) => "internal",
+                        PayloadBuilderError::EvmExecutionError(_) => "evm",
+                        PayloadBuilderError::Other(_) => "other",
+                    };
+                    debug!(target: "payload_builder", error_kind, "payload build attempt failed");
                     this.metrics.inc_failed_payload_builds();
                 }
                 Poll::Pending => {
@@ -590,9 +599,18 @@ where
         if let Some(fut) = Pin::new(&mut this.maybe_better).as_pin_mut() {
             if let Poll::Ready(res) = fut.poll(cx) {
                 this.maybe_better = None;
-                if let Ok(Some(payload)) = res.map(|out| out.into_payload())
-                    .inspect_err(|err| warn!(target: "payload_builder", %err, "failed to resolve pending payload"))
-                {
+                if let Ok(Some(payload)) = res.map(|out| out.into_payload()).inspect_err(|err| {
+                    let error_kind = match err {
+                        PayloadBuilderError::MissingParentHeader(_) => "missing_parent_header",
+                        PayloadBuilderError::MissingParentBlock(_) => "missing_parent_block",
+                        PayloadBuilderError::ChannelClosed => "channel_closed",
+                        PayloadBuilderError::MissingPayload => "missing_payload",
+                        PayloadBuilderError::Internal(_) => "internal",
+                        PayloadBuilderError::EvmExecutionError(_) => "evm",
+                        PayloadBuilderError::Other(_) => "other",
+                    };
+                    warn!(target: "payload_builder", error_kind, "failed to resolve pending payload");
+                }) {
                     debug!(target: "payload_builder", "resolving better payload");
                     return Poll::Ready(Ok(payload))
                 }
@@ -610,7 +628,20 @@ where
                 return match res {
                     Ok(res) => {
                         if let Err(err) = &res {
-                            warn!(target: "payload_builder", %err, "failed to resolve empty payload");
+                            let error_kind = match err {
+                                PayloadBuilderError::MissingParentHeader(_) => {
+                                    "missing_parent_header"
+                                }
+                                PayloadBuilderError::MissingParentBlock(_) => {
+                                    "missing_parent_block"
+                                }
+                                PayloadBuilderError::ChannelClosed => "channel_closed",
+                                PayloadBuilderError::MissingPayload => "missing_payload",
+                                PayloadBuilderError::Internal(_) => "internal",
+                                PayloadBuilderError::EvmExecutionError(_) => "evm",
+                                PayloadBuilderError::Other(_) => "other",
+                            };
+                            warn!(target: "payload_builder", error_kind, "failed to resolve empty payload");
                         } else {
                             debug!(target: "payload_builder", "resolving empty payload");
                         }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -407,7 +407,16 @@ where
                         trace!(target: "payload_builder", %id, "payload job finished");
                     }
                     Poll::Ready(Err(err)) => {
-                        warn!(target: "payload_builder",%err, ?id, "Payload builder job failed; resolving payload");
+                        let error_kind = match &err {
+                            PayloadBuilderError::MissingParentHeader(_) => "missing_parent_header",
+                            PayloadBuilderError::MissingParentBlock(_) => "missing_parent_block",
+                            PayloadBuilderError::ChannelClosed => "channel_closed",
+                            PayloadBuilderError::MissingPayload => "missing_payload",
+                            PayloadBuilderError::Internal(_) => "internal",
+                            PayloadBuilderError::EvmExecutionError(_) => "evm",
+                            PayloadBuilderError::Other(_) => "other",
+                        };
+                        warn!(target: "payload_builder", error_kind, %id, "Payload builder job failed; resolving payload");
                         this.metrics.inc_failed_jobs();
                         this.metrics.set_active_jobs(this.payload_jobs.len());
                     }
@@ -443,7 +452,20 @@ where
                                 }
                                 Err(err) => {
                                     this.metrics.inc_failed_jobs();
-                                    warn!(target: "payload_builder", %err, %id, "Failed to create payload builder job");
+                                    let error_kind = match &err {
+                                        PayloadBuilderError::MissingParentHeader(_) => {
+                                            "missing_parent_header"
+                                        }
+                                        PayloadBuilderError::MissingParentBlock(_) => {
+                                            "missing_parent_block"
+                                        }
+                                        PayloadBuilderError::ChannelClosed => "channel_closed",
+                                        PayloadBuilderError::MissingPayload => "missing_payload",
+                                        PayloadBuilderError::Internal(_) => "internal",
+                                        PayloadBuilderError::EvmExecutionError(_) => "evm",
+                                        PayloadBuilderError::Other(_) => "other",
+                                    };
+                                    warn!(target: "payload_builder", error_kind, %id, "Failed to create payload builder job");
                                     res = Err(err);
                                 }
                             }

--- a/crates/primitives-traits/src/transaction/error.rs
+++ b/crates/primitives-traits/src/transaction/error.rs
@@ -7,9 +7,7 @@ use alloy_primitives::U256;
 #[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
 pub enum InvalidTransactionError {
     /// The sender does not have enough funds to cover the transaction fees
-    #[error(
-        "sender does not have enough funds ({}) to cover transaction fees: {}", _0.got, _0.expected
-    )]
+    #[error("sender does not have enough funds to cover transaction fees")]
     InsufficientFunds(GotExpectedBoxed<U256>),
     /// The nonce is lower than the account's nonce, or there is a nonce gap present.
     ///
@@ -88,4 +86,21 @@ pub enum TryFromRecoveredTransactionError {
     /// This error variant is used when a blob sidecar is missing.
     #[error("Blob sidecar missing for an EIP-4844 transaction")]
     BlobSidecarMissing,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insufficient_funds_display_redacts_values() {
+        let error = InvalidTransactionError::InsufficientFunds(
+            (U256::from(123_456), U256::from(789_012)).into(),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "sender does not have enough funds to cover transaction fees"
+        );
+    }
 }

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -389,7 +389,7 @@ where
     }
 
     fn call(&mut self, request: String) -> Self::Future {
-        trace!("{:?}", request);
+        trace!("Received IPC request");
 
         let cfg = RpcServiceCfg::CallsAndSubscriptions {
             bounded_subscriptions: BoundedSubscriptions::new(

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -603,7 +603,7 @@ where
         sender: Address,
         nonce: U64,
     ) -> RpcResult<Option<RpcTransaction<T::NetworkTypes>>> {
-        trace!(target: "rpc::eth", ?sender, ?nonce, "Serving eth_getTransactionBySenderAndNonce");
+        trace!(target: "rpc::eth", "Serving eth_getTransactionBySenderAndNonce");
         Ok(EthTransactions::get_transaction_by_sender_and_nonce(self, sender, nonce.to(), true)
             .await?)
     }
@@ -619,7 +619,7 @@ where
 
     /// Handler for: `eth_getBalance`
     async fn balance(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<U256> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getBalance");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getBalance");
         Ok(EthState::balance(self, address, block_number).await?)
     }
 
@@ -630,7 +630,7 @@ where
         index: JsonStorageKey,
         block_number: Option<BlockId>,
     ) -> RpcResult<B256> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getStorageAt");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getStorageAt");
         Ok(EthState::storage_at(self, address, index, block_number).await?)
     }
 
@@ -641,7 +641,7 @@ where
         index: JsonStorageKey,
         block_number: Option<BlockId>,
     ) -> RpcResult<FlaggedStorage> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getFlaggedStorageAt");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getFlaggedStorageAt");
         Ok(EthState::flagged_storage_at(self, address, index, block_number).await?)
     }
     /// Handler for: `eth_getTransactionCount`
@@ -650,13 +650,13 @@ where
         address: Address,
         block_number: Option<BlockId>,
     ) -> RpcResult<U256> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getTransactionCount");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getTransactionCount");
         Ok(EthState::transaction_count(self, address, block_number).await?)
     }
 
     /// Handler for: `eth_getCode`
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<Bytes> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getCode");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_getCode");
         Ok(EthState::get_code(self, address, block_number).await?)
     }
 

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -694,7 +694,13 @@ where
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<Bytes> {
-        trace!(target: "rpc::eth", ?request, ?block_number, ?state_overrides, ?block_overrides, "Serving eth_call");
+        trace!(
+            target: "rpc::eth",
+            ?block_number,
+            has_state_overrides = state_overrides.is_some(),
+            has_block_overrides = block_overrides.is_some(),
+            "Serving eth_call"
+        );
         Ok(EthCall::call(
             self,
             request,
@@ -711,7 +717,13 @@ where
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<Vec<Vec<EthCallResponse>>> {
-        trace!(target: "rpc::eth", ?bundles, ?state_context, ?state_override, "Serving eth_callMany");
+        trace!(
+            target: "rpc::eth",
+            bundle_count = bundles.len(),
+            has_state_context = state_context.is_some(),
+            has_state_override = state_override.is_some(),
+            "Serving eth_callMany"
+        );
         Ok(EthCall::call_many(self, bundles, state_context, state_override).await?)
     }
 
@@ -722,7 +734,12 @@ where
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<AccessListResult> {
-        trace!(target: "rpc::eth", ?request, ?block_number, ?state_override, "Serving eth_createAccessList");
+        trace!(
+            target: "rpc::eth",
+            ?block_number,
+            has_state_override = state_override.is_some(),
+            "Serving eth_createAccessList"
+        );
         Ok(EthCall::create_access_list_at(self, request, block_number, state_override).await?)
     }
 
@@ -733,7 +750,7 @@ where
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256> {
-        trace!(target: "rpc::eth", ?request, ?block_number, "Serving eth_estimateGas");
+        trace!(target: "rpc::eth", ?block_number, "Serving eth_estimateGas");
         Ok(EthCall::estimate_gas_at(
             self,
             request,
@@ -822,37 +839,37 @@ where
 
     /// Handler for: `eth_sendTransaction`
     async fn send_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<B256> {
-        trace!(target: "rpc::eth", ?request, "Serving eth_sendTransaction");
+        trace!(target: "rpc::eth", "Serving eth_sendTransaction");
         Ok(EthTransactions::send_transaction(self, request).await?)
     }
 
     /// Handler for: `eth_sendRawTransaction`
     async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256> {
-        trace!(target: "rpc::eth", ?tx, "Serving eth_sendRawTransaction");
+        trace!(target: "rpc::eth", "Serving eth_sendRawTransaction");
         Ok(EthTransactions::send_raw_transaction(self, tx).await?)
     }
 
     /// Handler for: `eth_sendRawTransactionSync`
     async fn send_raw_transaction_sync(&self, tx: Bytes) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
-        trace!(target: "rpc::eth", ?tx, "Serving eth_sendRawTransactionSync");
+        trace!(target: "rpc::eth", "Serving eth_sendRawTransactionSync");
         Ok(EthTransactions::send_raw_transaction_sync(self, tx).await?)
     }
 
     /// Handler for: `eth_sign`
     async fn sign(&self, address: Address, message: Bytes) -> RpcResult<Bytes> {
-        trace!(target: "rpc::eth", ?address, ?message, "Serving eth_sign");
+        trace!(target: "rpc::eth", "Serving eth_sign");
         Ok(EthTransactions::sign(self, address, message).await?)
     }
 
     /// Handler for: `eth_signTransaction`
     async fn sign_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<Bytes> {
-        trace!(target: "rpc::eth", ?request, "Serving eth_signTransaction");
+        trace!(target: "rpc::eth", "Serving eth_signTransaction");
         Ok(EthTransactions::sign_transaction(self, request).await?)
     }
 
     /// Handler for: `eth_signTypedData`
     async fn sign_typed_data(&self, address: Address, data: TypedData) -> RpcResult<Bytes> {
-        trace!(target: "rpc::eth", ?address, ?data, "Serving eth_signTypedData");
+        trace!(target: "rpc::eth", "Serving eth_signTypedData");
         Ok(EthTransactions::sign_typed_data(self, &data, address)?)
     }
 
@@ -863,7 +880,12 @@ where
         keys: Vec<JsonStorageKey>,
         block_number: Option<BlockId>,
     ) -> RpcResult<EIP1186AccountProofResponse> {
-        trace!(target: "rpc::eth", ?address, ?keys, ?block_number, "Serving eth_getProof");
+        trace!(
+            target: "rpc::eth",
+            key_count = keys.len(),
+            ?block_number,
+            "Serving eth_getProof"
+        );
         Ok(EthState::get_proof(self, address, keys, block_number)?.await?)
     }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -811,7 +811,12 @@ pub trait Call:
         if let Some(requested_gas) = request.as_ref().gas_limit() {
             let global_gas_cap = self.call_gas_limit();
             if global_gas_cap != 0 && global_gas_cap < requested_gas {
-                warn!(target: "rpc::eth::call", ?request, ?global_gas_cap, "Capping gas limit to global gas cap");
+                warn!(
+                    target: "rpc::eth::call",
+                    requested_gas,
+                    global_gas_cap,
+                    "Capping gas limit to global gas cap"
+                );
                 request.as_mut().set_gas_limit(global_gas_cap);
             }
         }
@@ -851,7 +856,12 @@ pub trait Call:
             // No gas limit was provided in the request, so we need to cap the transaction gas limit
             if tx_env.gas_price() > 0 {
                 // If gas price is specified, cap transaction gas limit with caller allowance
-                trace!(target: "rpc::eth::call", ?tx_env, "Applying gas limit cap with caller allowance");
+                trace!(
+                    target: "rpc::eth::call",
+                    gas_limit = tx_env.gas_limit(),
+                    gas_price = tx_env.gas_price(),
+                    "Applying gas limit cap with caller allowance"
+                );
                 let cap = self.caller_gas_allowance(db, &evm_env, &tx_env)?;
                 // ensure we cap gas_limit to the block's
                 tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit));

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -811,12 +811,7 @@ pub trait Call:
         if let Some(requested_gas) = request.as_ref().gas_limit() {
             let global_gas_cap = self.call_gas_limit();
             if global_gas_cap != 0 && global_gas_cap < requested_gas {
-                warn!(
-                    target: "rpc::eth::call",
-                    requested_gas,
-                    global_gas_cap,
-                    "Capping gas limit to global gas cap"
-                );
+                warn!(target: "rpc::eth::call", "Capping gas limit to global gas cap");
                 request.as_mut().set_gas_limit(global_gas_cap);
             }
         }
@@ -858,8 +853,6 @@ pub trait Call:
                 // If gas price is specified, cap transaction gas limit with caller allowance
                 trace!(
                     target: "rpc::eth::call",
-                    gas_limit = tx_env.gas_limit(),
-                    gas_price = tx_env.gas_price(),
                     "Applying gas limit cap with caller allowance"
                 );
                 let cap = self.caller_gas_allowance(db, &evm_env, &tx_env)?;

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -130,7 +130,13 @@ pub trait EstimateCall: Call {
             }
         }
 
-        trace!(target: "rpc::eth::estimate", ?tx_env, gas_limit = tx_env.gas_limit(), is_basic_transfer, "Starting gas estimation");
+        trace!(
+            target: "rpc::eth::estimate",
+            gas_limit = tx_env.gas_limit(),
+            gas_price = tx_env.gas_price(),
+            is_basic_transfer,
+            "Starting gas estimation"
+        );
 
         // Execute the transaction with the highest possible gas limit.
         let mut res = match evm.transact(tx_env.clone()).map_err(Self::Error::from_evm_err) {

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -132,8 +132,6 @@ pub trait EstimateCall: Call {
 
         trace!(
             target: "rpc::eth::estimate",
-            gas_limit = tx_env.gas_limit(),
-            gas_price = tx_env.gas_price(),
             is_basic_transfer,
             "Starting gas estimation"
         );

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -2,7 +2,7 @@
 //! RPC methods.
 
 use super::SpawnBlocking;
-use crate::{EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
+use crate::{AsEthApiError, EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{B256, U256};
@@ -180,7 +180,18 @@ pub trait LoadPendingBlock:
             {
                 Ok(block) => block,
                 Err(err) => {
-                    debug!(target: "rpc", "Failed to build pending block: {:?}", err);
+                    let error_kind = match err.as_err() {
+                        Some(EthApiError::Internal(RethError::Execution(_))) => "execution",
+                        Some(EthApiError::Internal(RethError::Consensus(_))) => "consensus",
+                        Some(EthApiError::Internal(RethError::Database(_))) => "database",
+                        Some(EthApiError::Internal(RethError::Provider(_))) => "provider",
+                        Some(EthApiError::InvalidTransaction(_)) => "invalid_transaction",
+                        Some(EthApiError::InvalidBlockData(_)) => "invalid_block",
+                        Some(EthApiError::Internal(_)) => "internal",
+                        Some(_) => "rpc",
+                        None => "other",
+                    };
+                    debug!(target: "rpc", error_kind, "Failed to build pending block");
                     return Ok(None)
                 }
             };

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -544,7 +544,7 @@ where
         to_block: u64,
         limits: QueryLimits,
     ) -> Result<Vec<Log>, EthFilterError> {
-        trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
+        trace!(target: "rpc::eth::filter", from=from_block, to=to_block, "finding logs in range");
 
         // perform boundary checks first
         if to_block < from_block {

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -419,7 +419,7 @@ where
         request: MevSendBundle,
         overrides: SimBundleOverrides,
     ) -> RpcResult<SimBundleResponse> {
-        trace!("mev_simBundle called, request: {:?}, overrides: {:?}", request, overrides);
+        trace!("mev_simBundle called");
 
         let override_timeout = overrides.timeout;
 

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -134,7 +134,7 @@ where
         &self,
         from: Address,
     ) -> RpcResult<TxpoolContentFrom<RpcTransaction<Eth::Network>>> {
-        trace!(target: "rpc::eth", ?from, "Serving txpool_contentFrom");
+        trace!(target: "rpc::eth", "Serving txpool_contentFrom");
         Ok(self.content().map_err(Into::into)?.remove_from(&from))
     }
 

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -60,8 +60,8 @@ const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 6] = [
 
 fn seismic_tracing_target_enabled(target: &str) -> bool {
     !DISABLED_SEISMIC_TRACING_TARGETS.iter().any(|disabled| {
-        target == *disabled
-            || target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
+        target == *disabled ||
+            target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
     })
 }
 

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -49,9 +49,10 @@ use tracing::info;
 ///
 /// These are blocked by a separate subscriber layer, so `RUST_LOG` and per-sink CLI filters cannot
 /// re-enable them.
-const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 5] = [
+const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 6] = [
     "trie::hash_builder",
     "trie::proof_retainer",
+    "trie::trie_cursor::depth_first",
     "jsonrpsee-http",
     "jsonrpsee-server",
     "jsonrpsee_core::proc_macros_support",
@@ -59,8 +60,8 @@ const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 5] = [
 
 fn seismic_tracing_target_enabled(target: &str) -> bool {
     !DISABLED_SEISMIC_TRACING_TARGETS.iter().any(|disabled| {
-        target == *disabled ||
-            target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
+        target == *disabled
+            || target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
     })
 }
 

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -39,14 +39,21 @@ use reth_node_metrics::recorder::install_prometheus_recorder;
 use std::{ffi::OsString, fmt, sync::Arc};
 use tracing::info;
 
-/// `seismic-trie` tracing targets that may emit private trie keys, values, proofs, or topology.
+/// Tracing targets that may emit private trie data, complete RPC requests, or authentication
+/// headers.
 ///
 /// These are blocked by a separate subscriber layer, so `RUST_LOG` and per-sink CLI filters cannot
 /// re-enable them.
-const DISABLED_SEISMIC_TRIE_TARGETS: [&str; 2] = ["trie::hash_builder", "trie::proof_retainer"];
+const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 5] = [
+    "trie::hash_builder",
+    "trie::proof_retainer",
+    "jsonrpsee-http",
+    "jsonrpsee-server",
+    "jsonrpsee_core::proc_macros_support",
+];
 
-fn seismic_trie_target_enabled(target: &str) -> bool {
-    !DISABLED_SEISMIC_TRIE_TARGETS.iter().any(|disabled| {
+fn seismic_tracing_target_enabled(target: &str) -> bool {
+    !DISABLED_SEISMIC_TRACING_TARGETS.iter().any(|disabled| {
         target == *disabled ||
             target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
     })
@@ -236,7 +243,7 @@ where
     /// that all logs are flushed to disk.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
         let mut layers = Layers::new();
-        layers.add_layer(filter_fn(|metadata| seismic_trie_target_enabled(metadata.target())));
+        layers.add_layer(filter_fn(|metadata| seismic_tracing_target_enabled(metadata.target())));
         self.logs.init_tracing_with_layers(layers)
     }
 }
@@ -265,7 +272,7 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
 
 #[cfg(test)]
 mod test {
-    use crate::{chainspec::SeismicChainSpecParser, seismic_trie_target_enabled, Cli, Commands};
+    use crate::{chainspec::SeismicChainSpecParser, seismic_tracing_target_enabled, Cli, Commands};
     use clap::Parser;
     use reth_cli_commands::{node::NoArgs, NodeCommand};
     use reth_seismic_chainspec::{
@@ -273,13 +280,17 @@ mod test {
     };
 
     #[test]
-    fn seismic_trie_tracing_targets_are_hard_disabled() {
-        assert!(!seismic_trie_target_enabled("trie::hash_builder"));
-        assert!(!seismic_trie_target_enabled("trie::hash_builder::child"));
-        assert!(!seismic_trie_target_enabled("trie::proof_retainer"));
-        assert!(!seismic_trie_target_enabled("trie::proof_retainer::child"));
-        assert!(seismic_trie_target_enabled("trie::sparse"));
-        assert!(seismic_trie_target_enabled("trie::hash_builder_safe"));
+    fn sensitive_tracing_targets_are_hard_disabled() {
+        assert!(!seismic_tracing_target_enabled("trie::hash_builder"));
+        assert!(!seismic_tracing_target_enabled("trie::hash_builder::child"));
+        assert!(!seismic_tracing_target_enabled("trie::proof_retainer"));
+        assert!(!seismic_tracing_target_enabled("trie::proof_retainer::child"));
+        assert!(!seismic_tracing_target_enabled("jsonrpsee-http"));
+        assert!(!seismic_tracing_target_enabled("jsonrpsee-server"));
+        assert!(!seismic_tracing_target_enabled("jsonrpsee_core::proc_macros_support"));
+        assert!(seismic_tracing_target_enabled("trie::sparse"));
+        assert!(seismic_tracing_target_enabled("trie::hash_builder_safe"));
+        assert!(seismic_tracing_target_enabled("jsonrpsee-client"));
     }
 
     #[test]

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -31,13 +31,26 @@ use reth_seismic_node::{
     purpose_keys::{get_purpose_keys, init_purpose_keys},
     SeismicEvmConfig,
 };
-use reth_tracing::FileWorkerGuard;
+use reth_tracing::{tracing_subscriber::filter::filter_fn, FileWorkerGuard, Layers};
 // This allows us to manually enable node metrics features, required for proper jemalloc metric
 // reporting
 use reth_node_metrics as _;
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use std::{ffi::OsString, fmt, sync::Arc};
 use tracing::info;
+
+/// `seismic-trie` tracing targets that may emit private trie keys, values, proofs, or topology.
+///
+/// These are blocked by a separate subscriber layer, so `RUST_LOG` and per-sink CLI filters cannot
+/// re-enable them.
+const DISABLED_SEISMIC_TRIE_TARGETS: [&str; 2] = ["trie::hash_builder", "trie::proof_retainer"];
+
+fn seismic_trie_target_enabled(target: &str) -> bool {
+    !DISABLED_SEISMIC_TRIE_TARGETS.iter().any(|disabled| {
+        target == *disabled ||
+            target.strip_prefix(disabled).is_some_and(|suffix| suffix.starts_with("::"))
+    })
+}
 
 /// Seismic-specific CLI args carried alongside the node command.
 ///
@@ -222,8 +235,9 @@ where
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
     pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
-        let guard = self.logs.init_tracing()?;
-        Ok(guard)
+        let mut layers = Layers::new();
+        layers.add_layer(filter_fn(|metadata| seismic_trie_target_enabled(metadata.target())));
+        self.logs.init_tracing_with_layers(layers)
     }
 }
 
@@ -251,12 +265,22 @@ pub enum Commands<C: ChainSpecParser, Ext: clap::Args + fmt::Debug> {
 
 #[cfg(test)]
 mod test {
-    use crate::{chainspec::SeismicChainSpecParser, Cli, Commands};
+    use crate::{chainspec::SeismicChainSpecParser, seismic_trie_target_enabled, Cli, Commands};
     use clap::Parser;
     use reth_cli_commands::{node::NoArgs, NodeCommand};
     use reth_seismic_chainspec::{
         SEISMIC_DEV, SEISMIC_DEV_GENESIS_HASH, SEISMIC_TESTNET_GENESIS_HASH,
     };
+
+    #[test]
+    fn seismic_trie_tracing_targets_are_hard_disabled() {
+        assert!(!seismic_trie_target_enabled("trie::hash_builder"));
+        assert!(!seismic_trie_target_enabled("trie::hash_builder::child"));
+        assert!(!seismic_trie_target_enabled("trie::proof_retainer"));
+        assert!(!seismic_trie_target_enabled("trie::proof_retainer::child"));
+        assert!(seismic_trie_target_enabled("trie::sparse"));
+        assert!(seismic_trie_target_enabled("trie::hash_builder_safe"));
+    }
 
     #[test]
     fn parse_dev() {

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -42,6 +42,11 @@ use tracing::info;
 /// Tracing targets that may emit private trie data, complete RPC requests, or authentication
 /// headers.
 ///
+/// `jsonrpsee-http` is emitted by `jsonrpsee-core`'s `http_helpers::read_body`, which logs the
+/// full HTTP request body at trace level. `jsonrpsee-server` covers the server transport and
+/// method-dispatch logs (params/responses), and `jsonrpsee_core::proc_macros_support` covers the
+/// generated RPC method tracing.
+///
 /// These are blocked by a separate subscriber layer, so `RUST_LOG` and per-sink CLI filters cannot
 /// re-enable them.
 const DISABLED_SEISMIC_TRACING_TARGETS: [&str; 5] = [

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -4,7 +4,10 @@
 //! the previous subprocess-based approach (`cargo run --bin seismic-reth`).
 //! Blocks are produced explicitly via `node.advance_block()` instead of relying
 //! on dev-mode auto-mining with `thread::sleep`.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, clippy::panic)] // Test file - panics are acceptable
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing, clippy::panic)] // Test
+                                                                                             // file
+                                                                                             // - panics
+                                                                                             // are acceptable
 
 use alloy_consensus::{proofs::calculate_transaction_root, Transaction as _, TxEnvelope};
 use alloy_dyn_abi::EventExt;

--- a/crates/seismic/node/tests/e2e/pending_block.rs
+++ b/crates/seismic/node/tests/e2e/pending_block.rs
@@ -1,5 +1,6 @@
 //! E2E test for the locally built pending block returned by `eth_getBlockByNumber("pending")`.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are acceptable
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are
+                                                                   // acceptable
 
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use reth_e2e_test_utils::{

--- a/crates/seismic/node/tests/e2e/signed_read_import.rs
+++ b/crates/seismic/node/tests/e2e/signed_read_import.rs
@@ -9,7 +9,8 @@
 //! The gate lives in the consensus-type decoder (`SeismicTransactionSigned::typed_decode`),
 //! which the payload→block conversion in `SeismicEngineValidator::ensure_well_formed_payload`
 //! runs on every payload transaction, so a signed-read tx fails to decode at import.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are acceptable
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are
+                                                                   // acceptable
 
 use alloy_consensus::proofs::calculate_transaction_root;
 use alloy_primitives::{aliases::U96, Address, Bytes, Signature, TxKind, B256, U256};

--- a/crates/seismic/node/tests/e2e/wrong_chain_import.rs
+++ b/crates/seismic/node/tests/e2e/wrong_chain_import.rs
@@ -6,7 +6,8 @@
 //! has to be enforced at the execution boundary. This test drives the real engine
 //! `newPayload` handler with a block a Byzantine proposer could craft — one that
 //! carries a wrong-chain transaction — and asserts the node rejects it.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are acceptable
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file - panics are
+                                                                   // acceptable
 
 use alloy_consensus::proofs::calculate_transaction_root;
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};

--- a/crates/seismic/payload/src/builder.rs
+++ b/crates/seismic/payload/src/builder.rs
@@ -198,7 +198,11 @@ where
 
         // convert tx to a signed transaction
         let tx = pool_tx.to_consensus();
-        debug!("default_seismic_payload: tx: {:?}", tx);
+        debug!(
+            target: "payload_builder",
+            tx_hash = %pool_tx.hash(),
+            "executing pooled transaction"
+        );
 
         let gas_used = match builder.execute_transaction(tx.clone()) {
             Ok(gas_used) => gas_used,
@@ -207,11 +211,21 @@ where
             })) => {
                 if error.is_nonce_too_low() {
                     // if the nonce is too low, we can skip this transaction
-                    trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
+                    trace!(
+                        target: "payload_builder",
+                        %error,
+                        tx_hash = %pool_tx.hash(),
+                        "skipping nonce too low transaction"
+                    );
                 } else {
                     // if the transaction is invalid, we can skip it and all of its
                     // descendants
-                    trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+                    trace!(
+                        target: "payload_builder",
+                        %error,
+                        tx_hash = %pool_tx.hash(),
+                        "skipping invalid transaction and its descendants"
+                    );
                     best_txs.mark_invalid(
                         &pool_tx,
                         InvalidPoolTransactionError::Consensus(

--- a/crates/seismic/payload/src/builder.rs
+++ b/crates/seismic/payload/src/builder.rs
@@ -174,7 +174,7 @@ where
     let mut total_fees = U256::ZERO;
 
     builder.apply_pre_execution_changes().map_err(|err| {
-        warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
+        warn!(target: "payload_builder", "failed to apply pre-execution changes");
         PayloadBuilderError::Internal(err.into())
     })?;
 
@@ -213,7 +213,6 @@ where
                     // if the nonce is too low, we can skip this transaction
                     trace!(
                         target: "payload_builder",
-                        %error,
                         tx_hash = %pool_tx.hash(),
                         "skipping nonce too low transaction"
                     );
@@ -222,7 +221,6 @@ where
                     // descendants
                     trace!(
                         target: "payload_builder",
-                        %error,
                         tx_hash = %pool_tx.hash(),
                         "skipping invalid transaction and its descendants"
                     );

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -44,7 +44,7 @@ use alloy_evm::FromTxWithEncoded;
 /// which can be Seismic(TxSeismic) with additional fields, or Ethereum compatible transactions.
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(rlp))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Eq, AsRef, Deref)]
+#[derive(Clone, Eq, AsRef, Deref)]
 pub struct SeismicTransactionSigned {
     /// Transaction hash
     #[cfg_attr(feature = "serde", serde(skip))]
@@ -55,6 +55,18 @@ pub struct SeismicTransactionSigned {
     #[deref]
     #[as_ref]
     transaction: SeismicTypedTransaction,
+}
+
+// Confidential transaction fields must never be exposed by incidental `Debug` logging.
+impl core::fmt::Debug for SeismicTransactionSigned {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SeismicTransactionSigned")
+            .field("hash", &self.hash.get())
+            .field("transaction_type", &Typed2718::ty(self))
+            .field("signature", &"<redacted>")
+            .field("transaction", &"<redacted>")
+            .finish()
+    }
 }
 
 impl SeismicTransactionSigned {
@@ -201,7 +213,7 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
             SeismicTypedTransaction::Seismic(tx) => TxEnv::from_recovered_tx(tx, sender),
         };
         let tx = Self { base, tx_hash, decryption_failed: false };
-        tracing::debug!("from_recovered_tx: tx: {:?}", tx);
+        tracing::debug!(%tx_hash, "converted recovered transaction");
         tx
     }
 }
@@ -745,10 +757,7 @@ mod tests {
         assert_eq!(recovered_signer, expected_signer);
     }
 
-    /// Build the EIP-2718 bytes of a signed seismic tx with the given `signed_read`/`to`.
-    /// The signature is arbitrary: the consensus decoder gates on `signed_read`/`to`
-    /// before any recovery, so a dummy signature exercises the path we care about.
-    fn encoded_seismic_tx(signed_read: bool, to: TxKind) -> Vec<u8> {
+    fn seismic_signed_tx(signed_read: bool, to: TxKind, input: Bytes) -> SeismicTransactionSigned {
         let tx = TxSeismic {
             chain_id: 5124,
             nonce: 0,
@@ -756,7 +765,7 @@ mod tests {
             gas_limit: 21_000,
             to,
             value: U256::ZERO,
-            input: Bytes::new(),
+            input,
             seismic_elements: TxSeismicElements {
                 encryption_pubkey: PublicKey::from_str(
                     "028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0",
@@ -771,8 +780,14 @@ mod tests {
             authorization_list: vec![],
         };
         let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
-        let signed =
-            SeismicTransactionSigned::new_unhashed(SeismicTypedTransaction::Seismic(tx), signature);
+        SeismicTransactionSigned::new_unhashed(SeismicTypedTransaction::Seismic(tx), signature)
+    }
+
+    /// Build the EIP-2718 bytes of a signed seismic tx with the given `signed_read`/`to`.
+    /// The signature is arbitrary: the consensus decoder gates on `signed_read`/`to`
+    /// before any recovery, so a dummy signature exercises the path we care about.
+    fn encoded_seismic_tx(signed_read: bool, to: TxKind) -> Vec<u8> {
+        let signed = seismic_signed_tx(signed_read, to, Bytes::new());
         let mut buf = Vec::new();
         signed.encode_2718(&mut buf);
         buf
@@ -846,6 +861,22 @@ mod tests {
 
             assert_eq!(actual_tx, expected_tx);
         }
+    }
+
+    #[test]
+    fn signed_transaction_debug_redacts_calldata() {
+        const PRIVATE_INPUT: &[u8] = b"private-signed-transaction-input";
+
+        let signed = seismic_signed_tx(
+            false,
+            TxKind::Call(Address::with_last_byte(1)),
+            Bytes::from_static(PRIVATE_INPUT),
+        );
+        let debug = format!("{signed:?}");
+        let marker = hex::encode(PRIVATE_INPUT);
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&marker), "private signed transaction input leaked: {debug}");
     }
 
     #[test]

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -213,7 +213,12 @@ where
             authorization_list,
         };
 
-        tracing::debug!("reth-seismic-rpc::eth create_txn_env {:?}", env);
+        tracing::debug!(
+            target: "reth-seismic-rpc::eth::call",
+            tx_type = env.tx_type(),
+            gas_limit = env.gas_limit(),
+            "created transaction environment"
+        );
 
         Ok(SeismicTransaction { base: env, tx_hash: Default::default(), decryption_failed: false }
             .into())

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -215,8 +215,6 @@ where
 
         tracing::debug!(
             target: "reth-seismic-rpc::eth::call",
-            tx_type = env.tx_type(),
-            gas_limit = env.gas_limit(),
             "created transaction environment"
         );
 

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -493,7 +493,13 @@ where
         state_context: Option<StateContext>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<Vec<Vec<EthCallResponse>>> {
-        debug!(target: "reth-seismic-rpc::eth", ?bundles, ?state_context, ?state_override, "Serving seismic eth_callMany extension");
+        debug!(
+            target: "reth-seismic-rpc::eth",
+            bundle_count = bundles.len(),
+            has_state_context = state_context.is_some(),
+            has_state_override = state_override.is_some(),
+            "Serving seismic eth_callMany extension"
+        );
 
         // Keep originals so we can encrypt return data per-call after the inner call_many.
         let seismic_bundles = bundles.clone();
@@ -584,7 +590,13 @@ where
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<Bytes> {
-        debug!(target: "reth-seismic-rpc::eth", ?request, ?block_number, ?state_overrides, ?block_overrides, "Serving seismic eth_call extension");
+        debug!(
+            target: "reth-seismic-rpc::eth",
+            ?block_number,
+            has_state_overrides = state_overrides.is_some(),
+            has_block_overrides = block_overrides.is_some(),
+            "Serving seismic eth_call extension"
+        );
 
         let call = resolve_seismic_call(request)?;
         let plaintext_tx_req = seismic_call_to_plaintext_tx(
@@ -627,7 +639,10 @@ where
     /// We do this so that it is encrypted in the tx pool, so it is encrypted in blocks
     /// decryption during execution is handled by the [`SeismicBlockExecutor`]
     async fn send_raw_transaction(&self, tx: SeismicRawTxRequest) -> RpcResult<B256> {
-        debug!(target: "reth-seismic-rpc::eth", ?tx, "Serving overridden eth_sendRawTransaction extension");
+        debug!(
+            target: "reth-seismic-rpc::eth",
+            "Serving overridden eth_sendRawTransaction extension"
+        );
         let bytes = match tx {
             SeismicRawTxRequest::Bytes(bytes) => bytes,
             SeismicRawTxRequest::TypedData(typed_data) => {
@@ -653,7 +668,12 @@ where
         block_number: Option<BlockId>,
         state_override: Option<StateOverride>,
     ) -> RpcResult<U256> {
-        debug!(target: "reth-seismic-rpc::eth", ?request, ?block_number, ?state_override, "serving seismic eth_estimateGas extension");
+        debug!(
+            target: "reth-seismic-rpc::eth",
+            ?block_number,
+            has_state_override = state_override.is_some(),
+            "serving seismic eth_estimateGas extension"
+        );
 
         // Same sanitization as eth_call: unsigned requests have `from`,
         // gas/value fields, and seismic_elements cleared to prevent caller

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -715,7 +715,7 @@ where
         block_number: Option<BlockId>,
         include_gas_token: Option<bool>,
     ) -> RpcResult<U256> {
-        debug!(target: "reth-seismic-rpc::eth", ?address, ?block_number, ?include_gas_token, "Serving seismic eth_getBalance extension");
+        debug!(target: "reth-seismic-rpc::eth", ?block_number, ?include_gas_token, "Serving seismic eth_getBalance extension");
 
         // Default: native balance, matching standard eth_getBalance.
         let native = EthState::balance(&self.eth_api, address, block_number).await?;
@@ -733,7 +733,7 @@ where
         block: BlockId,
         include_gas_token: Option<bool>,
     ) -> RpcResult<AccountInfo> {
-        debug!(target: "reth-seismic-rpc::eth", ?address, ?block, ?include_gas_token, "Serving seismic eth_getAccountInfo extension");
+        debug!(target: "reth-seismic-rpc::eth", ?block, ?include_gas_token, "Serving seismic eth_getAccountInfo extension");
 
         // Default: native balance, matching standard eth_getAccountInfo and eth_getBalance.
         let mut info = EthState::get_account_info(&self.eth_api, address, block).await?;

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -56,8 +56,19 @@ use reth_rpc_convert::SignTxRequestError;
 use seismic_alloy_network::TxSigner;
 
 /// Newtype wrapper around `SeismicTransactionRequest` to implement `SignableTxRequest`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct SignableSeismicTransactionRequest(pub SeismicTransactionRequest);
+
+// Requests can contain decrypted calldata, so `Debug` is intentionally redacted.
+impl fmt::Debug for SignableSeismicTransactionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignableSeismicTransactionRequest")
+            .field("transaction_type", &self.0.inner.transaction_type)
+            .field("has_seismic_elements", &self.0.seismic_elements.is_some())
+            .field("request", &"<redacted>")
+            .finish()
+    }
+}
 
 impl From<SeismicTransactionRequest> for SignableSeismicTransactionRequest {
     fn from(req: SeismicTransactionRequest) -> Self {
@@ -455,9 +466,27 @@ where
 #[cfg(test)]
 mod tests {
     use super::SignableSeismicTransactionRequest;
+    use alloy_primitives::Bytes;
+    use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
     use alloy_signer_local::PrivateKeySigner;
     use reth_rpc_convert::SignTxRequestError;
     use reth_rpc_eth_api::SignableTxRequest;
+
+    #[test]
+    fn debug_redacts_transaction_request_input() {
+        const PRIVATE_INPUT: &[u8] = b"private-signable-request-input";
+
+        let request = TransactionRequest {
+            input: TransactionInput { input: Some(Bytes::from_static(PRIVATE_INPUT)), data: None },
+            ..Default::default()
+        };
+        let request = SignableSeismicTransactionRequest::from(request);
+        let debug = format!("{request:?}");
+        let marker = alloy_primitives::hex::encode(PRIVATE_INPUT);
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&marker), "private request input leaked: {debug}");
+    }
 
     /// Seismic rejects node-side signing rather than returning a fabricated placeholder tx
     /// (Veridise 1204), so `eth_sendTransaction`/`eth_signTransaction` fail cleanly.

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -79,7 +79,8 @@ impl fmt::Debug for SeismicCall {
 pub fn resolve_seismic_call(request: SeismicCallRequest) -> Result<SeismicCall, EthApiError> {
     match request {
         SeismicCallRequest::TransactionRequest(mut tx_request) => {
-            seismic_override_call_request(&mut tx_request); // null fields that may reveal sensitive information
+            seismic_override_call_request(&mut tx_request); // null fields that may reveal sensitive
+                                                            // information
             Ok(SeismicCall::Transparent(tx_request))
         }
 

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -1,5 +1,7 @@
 //! Utils for testing the seismic rpc api
 
+use core::fmt;
+
 use alloy_primitives::{Address, B256};
 use reth_primitives::Recovered;
 use reth_primitives_traits::SignedTransaction;
@@ -50,12 +52,23 @@ pub fn recover_typed_data_request<T: SignedTransaction + Decodable712>(
 }
 
 /// A resolved Seismic call, classified by its authenticated execution semantics.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum SeismicCall {
     /// An unsigned object-form request. Sender-sensitive fields have been sanitized.
     Transparent(SeismicTransactionRequest),
     /// A signed, call-only request whose `signed_read` intent is covered by its signature.
     SignedRead(SeismicTransactionRequest),
+}
+
+// Resolved signed reads contain plaintext calldata, so `Debug` only identifies the call kind.
+impl fmt::Debug for SeismicCall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Transparent(_) => "transparent",
+            Self::SignedRead(_) => "signed_read",
+        };
+        f.debug_struct("SeismicCall").field("kind", &kind).field("request", &"<redacted>").finish()
+    }
 }
 
 /// Resolve a wire-format [`SeismicCallRequest`] into a [`SeismicCall`].
@@ -272,7 +285,7 @@ mod test {
         hex::{self, FromHex},
         Address, Bytes, FixedBytes, Signature, B256, U256,
     };
-    use alloy_rpc_types::TransactionRequest;
+    use alloy_rpc_types::{TransactionInput, TransactionRequest};
     use reth_primitives_traits::SignedTransaction;
     use reth_seismic_primitives::SeismicTransactionSigned;
     use reth_seismic_test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx};
@@ -322,6 +335,27 @@ mod test {
         assert_eq!(req.inner.max_fee_per_blob_gas, None);
         assert_eq!(req.inner.value, None);
         assert!(req.seismic_elements.is_none());
+    }
+
+    #[test]
+    fn seismic_call_debug_redacts_request() {
+        const PRIVATE_INPUT: &[u8] = b"private-resolved-call-input";
+
+        let request = SeismicTransactionRequest {
+            inner: TransactionRequest {
+                input: TransactionInput {
+                    input: Some(Bytes::from_static(PRIVATE_INPUT)),
+                    data: None,
+                },
+                ..Default::default()
+            },
+            seismic_elements: Some(dummy_seismic_elements()),
+        };
+        let debug = format!("{:?}", SeismicCall::SignedRead(request));
+        let marker = hex::encode(PRIVATE_INPUT);
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&marker), "resolved call input leaked: {debug}");
     }
 
     fn signed_seismic_request(signed_read: bool, typed_data: bool) -> SeismicCallRequest {

--- a/crates/seismic/txpool/src/maintain.rs
+++ b/crates/seismic/txpool/src/maintain.rs
@@ -61,9 +61,6 @@ impl ChangedAccountsHook for SeismicBalanceHook {
                 debug!(
                     target: "seismic::txpool",
                     address = %acc.address,
-                    native_balance = %acc.balance,
-                    usdc_scaled_balance = %usdc,
-                    pool_balance = %new_balance,
                     "augmenting changed account balance with USDC"
                 );
                 acc.balance = new_balance;

--- a/crates/seismic/txpool/src/maintain.rs
+++ b/crates/seismic/txpool/src/maintain.rs
@@ -58,11 +58,7 @@ impl ChangedAccountsHook for SeismicBalanceHook {
             let usdc = crate::usdc::read_usdc_balance(state, &acc.address);
             let new_balance = acc.balance.saturating_add(usdc);
             if new_balance != acc.balance {
-                debug!(
-                    target: "seismic::txpool",
-                    address = %acc.address,
-                    "augmenting changed account balance with USDC"
-                );
+                debug!(target: "seismic::txpool", "augmenting changed account balance with USDC");
                 acc.balance = new_balance;
             }
         }

--- a/crates/seismic/txpool/src/transaction.rs
+++ b/crates/seismic/txpool/src/transaction.rs
@@ -5,7 +5,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
 use c_kzg::KzgSettings;
-use core::fmt::Debug;
+use core::fmt::{self, Debug};
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use reth_seismic_primitives::SeismicTransactionSigned;
 use reth_transaction_pool::{
@@ -15,12 +15,23 @@ use seismic_alloy_consensus::SeismicTxEnvelope;
 use std::sync::Arc;
 
 /// Pool Transaction for Seismic.
-#[derive(Debug, Clone, derive_more::Deref)]
+#[derive(Clone, derive_more::Deref)]
 pub struct SeismicPooledTransaction<Cons = SeismicTransactionSigned, Pooled = SeismicTxEnvelope> {
     #[deref]
     inner: EthPooledTransaction<Cons>,
     /// The pooled transaction type.
     _pd: core::marker::PhantomData<Pooled>,
+}
+
+// Keep pooled transaction payloads out of incidental `Debug` logging.
+impl<Cons: SignedTransaction, Pooled> fmt::Debug for SeismicPooledTransaction<Cons, Pooled> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SeismicPooledTransaction")
+            .field("hash", self.inner.transaction.tx_hash())
+            .field("transaction_type", &self.inner.transaction.ty())
+            .field("transaction", &"<redacted>")
+            .finish()
+    }
 }
 
 impl<Cons: SignedTransaction, Pooled> SeismicPooledTransaction<Cons, Pooled> {
@@ -186,9 +197,9 @@ where
 #[allow(clippy::panic)] // Test code - panic on failure is acceptable
 mod tests {
     use crate::SeismicPooledTransaction;
-    use alloy_consensus::transaction::Recovered;
+    use alloy_consensus::{transaction::Recovered, Transaction as _};
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::B256;
+    use alloy_primitives::{hex, B256};
     use reth_primitives_traits::transaction::error::InvalidTransactionError;
     use reth_provider::test_utils::MockEthProvider;
     use reth_seismic_chainspec::SEISMIC_MAINNET;
@@ -197,6 +208,21 @@ mod tests {
         blobstore::InMemoryBlobStore, error::InvalidPoolTransactionError,
         validate::EthTransactionValidatorBuilder, TransactionOrigin, TransactionValidationOutcome,
     };
+
+    #[test]
+    fn pooled_transaction_debug_redacts_transaction_input() {
+        let signer = Default::default();
+        let signed = get_signed_seismic_tx(B256::ZERO);
+        let input = hex::encode(signed.input());
+        let recovered = Recovered::new_unchecked(signed, signer);
+        let encoded_length = recovered.encode_2718_len();
+        let pooled: SeismicPooledTransaction =
+            SeismicPooledTransaction::new(recovered, encoded_length);
+        let debug = format!("{pooled:?}");
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&input), "pooled transaction input leaked: {debug}");
+    }
 
     #[tokio::test]
     async fn validate_seismic_transaction() {

--- a/crates/seismic/txpool/src/validator.rs
+++ b/crates/seismic/txpool/src/validator.rs
@@ -135,11 +135,9 @@ where
                     Ok(state) => crate::usdc::read_usdc_balance(&*state, &sender),
                     // If we can't read state, fall back to native balance only:
                     // usdc = 0 degrades `can_afford` to `native >= cost`.
-                    Err(err) => {
+                    Err(_) => {
                         tracing::warn!(
                             target: "seismic::txpool",
-                            %err,
-                            %sender,
                             "failed to read state for USDC balance check, defaulting to zero"
                         );
                         U256::ZERO

--- a/crates/seismic/txpool/src/validator.rs
+++ b/crates/seismic/txpool/src/validator.rs
@@ -148,24 +148,14 @@ where
 
                 tracing::debug!(
                     target: "seismic::txpool",
-                    %sender,
                     tx_hash = %valid_tx.hash(),
-                    native_balance = %balance,
-                    usdc_scaled_balance = %usdc,
-                    gas_cost = %gas_cost,
-                    value = %value,
                     "seismic validator affordability check"
                 );
 
                 if !crate::usdc::can_afford(balance, usdc, gas_cost, value) {
                     tracing::debug!(
                         target: "seismic::txpool",
-                        %sender,
                         tx_hash = %valid_tx.hash(),
-                        native_balance = %balance,
-                        usdc_scaled_balance = %usdc,
-                        gas_cost = %gas_cost,
-                        value = %value,
                         "rejecting tx: balances insufficient for gas cost and value"
                     );
                     // The error carries a single got/expected pair, so report the

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -143,7 +143,6 @@ impl MerkleStage {
         if let Some(checkpoint) = checkpoint {
             debug!(
                 target: "sync::stages::merkle::exec",
-                last_account_key = ?checkpoint.last_account_key,
                 "Saving inner merkle checkpoint"
             );
             checkpoint.to_compact(&mut buf);
@@ -202,14 +201,14 @@ where
             let mut checkpoint = self.get_execution_checkpoint(provider)?;
 
             // if there are more blocks than threshold it is faster to rebuild the trie
-            let mut entities_checkpoint = if let Some(checkpoint) =
-                checkpoint.as_ref().filter(|c| c.target_block == to_block)
+            let mut entities_checkpoint = if checkpoint
+                .as_ref()
+                .is_some_and(|checkpoint| checkpoint.target_block == to_block)
             {
                 debug!(
                     target: "sync::stages::merkle::exec",
                     current = ?current_block_number,
                     target = ?to_block,
-                    last_account_key = ?checkpoint.last_account_key,
                     "Continuing inner merkle checkpoint"
                 );
 
@@ -219,7 +218,7 @@ where
                     target: "sync::stages::merkle::exec",
                     current = ?current_block_number,
                     target = ?to_block,
-                    previous_checkpoint = ?checkpoint,
+                    had_previous_checkpoint = checkpoint.is_some(),
                     "Rebuilding trie"
                 );
                 // Reset the checkpoint and clear trie tables

--- a/crates/storage/codecs/src/alloy/mod.rs
+++ b/crates/storage/codecs/src/alloy/mod.rs
@@ -51,7 +51,10 @@ mod tests {
         validate_bitflag_backwards_compat!(HeaderExt, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(TxEip2930, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StorageEntries, UnusedBits::Zero);
-        validate_bitflag_backwards_compat!(StorageEntry, UnusedBits::NotZero); // Seismic broke backwards compatibility here for the is_private flag
+        validate_bitflag_backwards_compat!(StorageEntry, UnusedBits::NotZero); // Seismic broke
+                                                                               // backwards compatibility
+                                                                               // here for the
+                                                                               // is_private flag
 
         validate_bitflag_backwards_compat!(GenesisAccountRef<'_>, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(GenesisAccount, UnusedBits::NotZero);

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -622,7 +622,6 @@ where
                 total_flushed_updates += updated_len;
 
                 trace!(target: "reth::cli",
-                    last_account_key = %state.account_root_state.last_hashed_key,
                     updated_len,
                     total_flushed_updates,
                     "Flushing trie updates"

--- a/crates/storage/errors/src/db.rs
+++ b/crates/storage/errors/src/db.rs
@@ -77,13 +77,36 @@ impl From<DatabaseWriteError> for DatabaseError {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn database_write_error_display_redacts_key() {
+        let error = DatabaseWriteError {
+            info: DatabaseErrorInfo { message: "write failed".into(), code: 1 },
+            operation: DatabaseWriteOperation::Put,
+            table_name: "PlainAccountState",
+            key: b"private-database-key".to_vec(),
+        };
+        let display = error.to_string();
+        let debug = format!("{error:?}");
+
+        for formatted in [display, debug] {
+            assert!(!formatted.contains("private-database-key"));
+            assert!(!formatted.contains("707269766174652d64617461626173652d6b6579"));
+        }
+    }
+}
+
 /// Database write error.
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("write operation {:?} failed for key \"{}\" in table {}: {}",
-            self.operation,
-            alloy_primitives::hex::encode(&self.key),
-            self.table_name,
-            self.info)]
+#[derive(Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "write operation {:?} failed in table {}: {}",
+    self.operation,
+    self.table_name,
+    self.info
+)]
 pub struct DatabaseWriteError {
     /// The error code and message.
     pub info: DatabaseErrorInfo,
@@ -93,6 +116,17 @@ pub struct DatabaseWriteError {
     pub table_name: &'static str,
     /// The write key.
     pub key: Vec<u8>,
+}
+
+impl Debug for DatabaseWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DatabaseWriteError")
+            .field("info", &self.info)
+            .field("operation", &self.operation)
+            .field("table_name", &self.table_name)
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Database write operation type.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1999,7 +1999,6 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             storage.par_sort_unstable_by_key(|a| a.key);
 
             for entry in storage {
-                tracing::trace!(?address, ?entry.key, "Updating plain state storage");
                 if let Some(db_entry) = storages_cursor.seek_by_key_subkey(address, entry.key)? {
                     if db_entry.key == entry.key {
                         storages_cursor.delete_current()?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1917,7 +1917,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 // See [StorageWipe::Primary] for more details.
                 let mut wiped_storage = Vec::new();
                 if wiped {
-                    tracing::trace!(?address, "Wiping storage");
+                    tracing::trace!("Wiping storage");
                     if let Some((_, entry)) = storages_cursor.seek_exact(address)? {
                         wiped_storage.push((entry.key, entry.into()));
                         while let Some(entry) = storages_cursor.next_dup_val()? {
@@ -1967,10 +1967,10 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         // write account to database.
         for (address, account) in changes.accounts {
             if let Some(account) = account {
-                tracing::trace!(?address, "Updating plain state account");
+                tracing::trace!("Updating plain state account");
                 accounts_cursor.upsert(address, &account.into())?;
             } else if accounts_cursor.seek_exact(address)?.is_some() {
-                tracing::trace!(?address, "Deleting plain state account");
+                tracing::trace!("Deleting plain state account");
                 accounts_cursor.delete_current()?;
             }
         }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1926,7 +1926,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                     }
                 }
 
-                tracing::trace!(?address, ?storage, "Writing storage reverts");
+                tracing::trace!(storage_entries = storage.len(), wiped, "Writing storage reverts");
                 for (key, value) in StorageRevertsIter::new(storage, wiped_storage) {
                     storage_changeset_cursor.append_dup(storage_id, StorageEntry { key, value })?;
                 }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -243,7 +243,8 @@ pub enum InvalidPoolTransactionError {
     #[error("transaction underpriced")]
     Underpriced,
     /// Thrown if the transaction's would require an account to be overdrawn
-    #[error("transaction overdraws from account, balance: {balance}, cost: {cost}")]
+    // The exact balance and cost are private; they must not appear in the message.
+    #[error("transaction overdraws from account")]
     Overdraft {
         /// Cost transaction is allowed to consume. See `reth_transaction_pool::PoolTransaction`.
         cost: U256,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -387,7 +387,7 @@ where
     where
         B: Block,
     {
-        trace!(target: "txpool", ?update, "updating pool on canonical state change");
+        trace!(target: "txpool", update = %update, "updating pool on canonical state change");
 
         let block_info = update.block_info();
         let CanonicalStateUpdate {
@@ -515,8 +515,6 @@ where
                     target: "txpool",
                     tx_hash = %hash,
                     ?subpool,
-                    reported_balance = %balance,
-                    state_nonce,
                     "transaction added to pool"
                 );
                 let state = match subpool {

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3060,7 +3060,8 @@ mod tests {
 
         // Now decrease basefee to trigger the zero-allocation optimization
         let mut block_info = pool.block_info();
-        block_info.pending_basefee = 450; // tx1 (500) and tx2 (600) can now afford it, tx3 (400) cannot
+        block_info.pending_basefee = 450; // tx1 (500) and tx2 (600) can now afford it, tx3 (400)
+                                          // cannot
         pool.set_block_info(block_info);
 
         // Verify the optimization worked correctly:

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -301,7 +301,8 @@ mod tests {
         prefix_set_mut.insert(Nibbles::from_nibbles([1, 2, 3])); // Duplicate
 
         assert_eq!(prefix_set_mut.keys.len(), 4); // Length should be 3 (including duplicate)
-        assert_eq!(prefix_set_mut.keys.capacity(), 101); // Capacity should be 101 (including duplicate)
+        assert_eq!(prefix_set_mut.keys.capacity(), 101); // Capacity should be 101 (including
+                                                         // duplicate)
 
         let mut prefix_set = prefix_set_mut.freeze();
         assert!(prefix_set.contains(&Nibbles::from_nibbles_unchecked([1, 2])));

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -54,6 +54,7 @@ criterion.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [features]
 default = ["metrics"]

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -424,6 +424,9 @@ mod tests {
             .with_max_level(tracing::Level::TRACE)
             .with_writer(logs.clone())
             .finish();
+        // A global (not thread-local) subscriber is required because the proof task logs from a
+        // `spawn_blocking` thread. This relies on per-process test isolation (cargo nextest, the
+        // project standard); no other test in this binary may set a global default.
         tracing::subscriber::set_global_default(subscriber).unwrap();
 
         let factory = create_test_provider_factory();

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -308,7 +308,8 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(decoded_storage_multiproof.root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
+                    let is_private = false; // account leaves are always public. Their storage
+                                            // leaves can be private.
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_address),
                         &account_rlp,

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -140,7 +140,6 @@ where
         debug!(
             target: "trie::parallel_proof",
             total_targets,
-            ?hashed_address,
             "Starting storage proof generation"
         );
 

--- a/crates/trie/parallel/src/proof.rs
+++ b/crates/trie/parallel/src/proof.rs
@@ -146,14 +146,13 @@ where
         let receiver = self.spawn_storage_proof(hashed_address, prefix_set, target_slots);
         let proof_result = receiver.recv().map_err(|_| {
             ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
-                format!("channel closed for {hashed_address}"),
+                "storage proof result channel closed".to_string(),
             )))
         })?;
 
         debug!(
             target: "trie::parallel_proof",
             total_targets,
-            ?hashed_address,
             "Storage proof generation completed"
         );
 
@@ -274,11 +273,11 @@ where
                     let decoded_storage_multiproof = match storage_proof_receivers
                         .remove(&hashed_address)
                     {
-                        Some(rx) => rx.recv().map_err(|e| {
+                        Some(rx) => rx.recv().map_err(|_| {
                             ParallelStateRootError::StorageRoot(StorageRootError::Database(
-                                DatabaseError::Other(format!(
-                                    "channel closed for {hashed_address}: {e}"
-                                )),
+                                DatabaseError::Other(
+                                    "storage proof result channel closed".to_string(),
+                                ),
                             ))
                         })??,
                         // Since we do not store all intermediate nodes in the database, there might
@@ -379,7 +378,123 @@ mod tests {
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
     use reth_trie::proof::Proof;
+    use std::{
+        io::{self, Write},
+        sync::Mutex,
+    };
     use tokio::runtime::Runtime;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl CapturedLogs {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    struct CapturedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturedLogs {
+        type Writer = CapturedLogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CapturedLogWriter(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn storage_proof_logs_redact_hashed_address() {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::TRACE)
+            .with_writer(logs.clone())
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+
+        let factory = create_test_provider_factory();
+        let consistent_view = ConsistentDbView::new(factory, None);
+        let rt = Runtime::new().unwrap();
+        let task_ctx =
+            ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
+        let proof_task =
+            ProofTaskManager::new(rt.handle().clone(), consistent_view.clone(), task_ctx, 1);
+        let proof_task_handle = proof_task.handle();
+        let join_handle = rt.spawn_blocking(move || proof_task.run());
+
+        let hashed_address = B256::repeat_byte(0x7a);
+        let proof = ParallelProof::new(
+            consistent_view,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            proof_task_handle.clone(),
+        );
+
+        let receiver =
+            proof.spawn_storage_proof(hashed_address, PrefixSet::default(), B256Set::default());
+        receiver.recv().unwrap().unwrap();
+
+        let dropped_receiver =
+            proof.spawn_storage_proof(hashed_address, PrefixSet::default(), B256Set::default());
+        drop(dropped_receiver);
+
+        proof.storage_proof(hashed_address, B256Set::default()).unwrap();
+
+        drop(proof_task_handle);
+        rt.block_on(join_handle).unwrap().unwrap();
+
+        let output = logs.contents();
+        assert!(output.contains("Completed storage proof task calculation"), "{output}");
+        assert!(
+            output.contains("Storage proof receiver is dropped, discarding the result"),
+            "{output}"
+        );
+        assert!(output.contains("Storage proof generation completed"), "{output}");
+        assert!(!output.contains(&hashed_address.to_string()));
+    }
+
+    #[test]
+    fn storage_proof_channel_error_redacts_hashed_address() {
+        let factory = create_test_provider_factory();
+        let consistent_view = ConsistentDbView::new(factory, None);
+        let rt = Runtime::new().unwrap();
+        let task_ctx =
+            ProofTaskCtx::new(Default::default(), Default::default(), Default::default());
+        let proof_task =
+            ProofTaskManager::new(rt.handle().clone(), consistent_view.clone(), task_ctx, 1);
+        let proof_task_handle = proof_task.handle();
+        drop(proof_task);
+
+        let hashed_address = B256::repeat_byte(0x7a);
+        let error = ParallelProof::new(
+            consistent_view,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            proof_task_handle,
+        )
+        .storage_proof(hashed_address, B256Set::default())
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("storage proof result channel closed"));
+        assert!(!error.contains(&hashed_address.to_string()));
+    }
 
     #[test]
     fn random_parallel_proof() {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -339,11 +339,7 @@ where
         result_sender: Sender<TrieNodeProviderResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
-            target: "trie::proof_task",
-            ?path,
-            "Starting blinded account node retrieval"
-        );
+        debug!(target: "trie::proof_task", "Starting blinded account node retrieval");
 
         let (trie_cursor_factory, hashed_cursor_factory) = self.create_factories();
 
@@ -357,16 +353,13 @@ where
         let result = blinded_provider_factory.account_node_provider().trie_node(&path);
         debug!(
             target: "trie::proof_task",
-            ?path,
             elapsed = ?start.elapsed(),
             "Completed blinded account node retrieval"
         );
 
-        if let Err(error) = result_sender.send(result) {
+        if result_sender.send(result).is_err() {
             tracing::error!(
                 target: "trie::proof_task",
-                ?path,
-                ?error,
                 "Failed to send blinded account node result"
             );
         }
@@ -401,12 +394,9 @@ where
             "Completed blinded storage node retrieval"
         );
 
-        if let Err(error) = result_sender.send(result) {
+        if result_sender.send(result).is_err() {
             tracing::error!(
                 target: "trie::proof_task",
-                ?account,
-                ?path,
-                ?error,
                 "Failed to send blinded storage node result"
             );
         }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -301,16 +301,12 @@ where
 
         let decoded_result = raw_proof_result.and_then(|raw_proof| {
             raw_proof.try_into().map_err(|e: alloy_rlp::Error| {
-                ParallelStateRootError::Other(format!(
-                    "Failed to decode storage proof for {}: {}",
-                    input.hashed_address, e
-                ))
+                ParallelStateRootError::Other(format!("Failed to decode storage proof: {e}"))
             })
         });
 
         debug!(
             target: "trie::proof_task",
-            hashed_address=?input.hashed_address,
             prefix_set = ?input.prefix_set.len(),
             target_slots = ?target_slots_len,
             proof_time = ?proof_start.elapsed(),
@@ -318,11 +314,9 @@ where
         );
 
         // send the result back
-        if let Err(error) = result_sender.send(decoded_result) {
+        if result_sender.send(decoded_result).is_err() {
             debug!(
                 target: "trie::proof_task",
-                hashed_address = ?input.hashed_address,
-                ?error,
                 task_time = ?proof_start.elapsed(),
                 "Storage proof receiver is dropped, discarding the result"
             );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -266,11 +266,7 @@ where
         result_sender: Sender<StorageProofResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
-            target: "trie::proof_task",
-            hashed_address=?input.hashed_address,
-            "Starting storage proof task calculation"
-        );
+        debug!(target: "trie::proof_task", "Starting storage proof task calculation");
 
         let (trie_cursor_factory, hashed_cursor_factory) = self.create_factories();
         let multi_added_removed_keys = input
@@ -281,9 +277,8 @@ where
         let span = tracing::trace_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
-            hashed_address=?input.hashed_address,
-            // Add a unique id because we often have parallel storage proof calculations for the
-            // same hashed address, and we want to differentiate them during trace analysis.
+            // Add a unique id because we often have parallel storage proof calculations, and we
+            // want to differentiate them during trace analysis.
             span_id=self.id,
         );
         let span_guard = span.enter();
@@ -388,12 +383,7 @@ where
         result_sender: Sender<TrieNodeProviderResult>,
         tx_sender: Sender<ProofTaskMessage<Tx>>,
     ) {
-        debug!(
-            target: "trie::proof_task",
-            ?account,
-            ?path,
-            "Starting blinded storage node retrieval"
-        );
+        debug!(target: "trie::proof_task", "Starting blinded storage node retrieval");
 
         let (trie_cursor_factory, hashed_cursor_factory) = self.create_factories();
 
@@ -407,8 +397,6 @@ where
         let result = blinded_provider_factory.storage_node_provider(account).trie_node(&path);
         debug!(
             target: "trie::proof_task",
-            ?account,
-            ?path,
             elapsed = ?start.elapsed(),
             "Completed blinded storage node retrieval"
         );

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -176,9 +176,9 @@ where
                     let storage_root_result = match storage_roots.remove(&hashed_address) {
                         Some(rx) => rx.recv().map_err(|_| {
                             ParallelStateRootError::StorageRoot(StorageRootError::Database(
-                                DatabaseError::Other(format!(
-                                    "channel closed for {hashed_address}"
-                                )),
+                                DatabaseError::Other(
+                                    "storage root result channel closed".to_string(),
+                                ),
                             ))
                         })??,
                         // Since we do not store all intermediate nodes in the database, there might

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -215,7 +215,8 @@ where
                     account_rlp.clear();
                     let account = account.into_trie_account(storage_root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
+                    let is_private = false; // account leaves are always public. Their storage
+                                            // leaves can be private.
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_address),
                         &account_rlp,

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -342,8 +342,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
                         if subtrie.nodes.get(&reveal_path).expect("node must exist").is_hash() {
                             debug!(
                                 target: "trie::parallel_sparse",
-                                child_path = ?reveal_path,
-                                leaf_full_path = ?full_path,
                                 "Extension node child not revealed in update_leaf, falling back to db",
                             );
                             if let Some(RevealedNode { node, tree_mask, hash_mask }) =
@@ -352,10 +350,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
                                 let decoded = TrieNode::decode(&mut &node[..])?;
                                 trace!(
                                     target: "trie::parallel_sparse",
-                                    ?reveal_path,
-                                    ?decoded,
-                                    ?tree_mask,
-                                    ?hash_mask,
                                     "Revealing child (from upper)",
                                 );
                                 subtrie.reveal_node(
@@ -608,9 +602,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
 
                 trace!(
                     target: "trie::parallel_sparse",
-                    ?leaf_path,
-                    ?branch_path,
-                    ?remaining_child_path,
                     "Branch node has only one child",
                 );
 
@@ -623,8 +614,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
                         SparseNode::Hash(_) => {
                             debug!(
                                 target: "trie::parallel_sparse",
-                                child_path = ?remaining_child_path,
-                                leaf_full_path = ?full_path,
                                 "Branch node child not revealed in remove_leaf, falling back to db",
                             );
                             if let Some(RevealedNode { node, tree_mask, hash_mask }) =
@@ -633,10 +622,6 @@ impl SparseTrieInterface for ParallelSparseTrie {
                                 let decoded = TrieNode::decode(&mut &node[..])?;
                                 trace!(
                                     target: "trie::parallel_sparse",
-                                    ?remaining_child_path,
-                                    ?decoded,
-                                    ?tree_mask,
-                                    ?hash_mask,
                                     "Revealing remaining blinded branch child"
                                 );
                                 remaining_child_subtrie.reveal_node(
@@ -1234,7 +1219,7 @@ impl ParallelSparseTrie {
     }
 
     /// Updates hashes for the upper subtrie, using nodes from both upper and lower subtries.
-    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, ret)]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all)]
     fn update_upper_subtrie_hashes(&mut self, prefix_set: &mut PrefixSet) -> RlpNode {
         trace!(target: "trie::parallel_sparse", "Updating upper subtrie hashes");
 
@@ -1551,8 +1536,6 @@ impl SparseSubtrie {
                         if self.nodes.get(&reveal_path).expect("node must exist").is_hash() {
                             debug!(
                                 target: "trie::parallel_sparse",
-                                child_path = ?reveal_path,
-                                leaf_full_path = ?full_path,
                                 "Extension node child not revealed in update_leaf, falling back to db",
                             );
                             if let Some(RevealedNode { node, tree_mask, hash_mask }) =
@@ -1561,10 +1544,6 @@ impl SparseSubtrie {
                                 let decoded = TrieNode::decode(&mut &node[..])?;
                                 trace!(
                                     target: "trie::parallel_sparse",
-                                    ?reveal_path,
-                                    ?decoded,
-                                    ?tree_mask,
-                                    ?hash_mask,
                                     "Revealing child (from lower)",
                                 );
                                 self.reveal_node(
@@ -1938,7 +1917,7 @@ impl SparseSubtrie {
     /// # Panics
     ///
     /// If the node at the root path does not exist.
-    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all, fields(root = ?self.path), ret)]
+    #[instrument(level = "trace", target = "trie::parallel_sparse", skip_all)]
     fn update_hashes(
         &mut self,
         prefix_set: &mut PrefixSet,
@@ -2102,13 +2081,7 @@ impl SparseSubtrieInner {
 
                     let store_in_db_trie_value = child_node_type.store_in_db_trie();
 
-                    trace!(
-                        target: "trie::parallel_sparse",
-                        ?path,
-                        ?child_path,
-                        ?child_node_type,
-                        "Extension node"
-                    );
+                    trace!(target: "trie::parallel_sparse", "Extension node");
 
                     *store_in_db_trie = store_in_db_trie_value;
 
@@ -2241,13 +2214,7 @@ impl SparseSubtrieInner {
                     }
                 }
 
-                trace!(
-                    target: "trie::parallel_sparse",
-                    ?path,
-                    ?tree_mask,
-                    ?hash_mask,
-                    "Branch node masks"
-                );
+                trace!(target: "trie::parallel_sparse", "Branch node masks");
 
                 // Top of the stack has all children node, we can encode the branch node and
                 // update its hash
@@ -2305,12 +2272,7 @@ impl SparseSubtrieInner {
         };
 
         self.buffers.rlp_node_stack.push(RlpNodeStackItem { path, rlp_node, node_type });
-        trace!(
-            target: "trie::parallel_sparse",
-            ?path,
-            ?node_type,
-            "Added node to RLP node stack"
-        );
+        trace!(target: "trie::parallel_sparse", "Added node to RLP node stack");
     }
 
     /// Clears the subtrie, keeping the data structures allocated.

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -6353,7 +6353,8 @@ mod tests {
         let mut sparse = ParallelSparseTrie::default();
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Creates branch at 0x12
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]); // Belongs to same branch
-        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at nibble 7
+        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at
+                                                                                 // nibble 7
 
         sparse.update_leaf(path1, encode_account_value(0), false, &provider).unwrap();
         sparse.update_leaf(path2, encode_account_value(1), false, &provider).unwrap();

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -2043,12 +2043,7 @@ impl SparseSubtrieInner {
         branch_node_hash_masks: &HashMap<Nibbles, TrieMask>,
     ) {
         let path = stack_item.path;
-        trace!(
-            target: "trie::parallel_sparse",
-            ?path,
-            ?node,
-            "Calculating node RLP"
-        );
+        trace!(target: "trie::parallel_sparse", "Calculating node RLP");
 
         // Check if the path is in the prefix set.
         // First, check the cached value. If it's `None`, then check the prefix set, and update

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -644,7 +644,8 @@ where
         if !self.revealed_account_paths.contains(&path) {
             self.revealed_account_paths.insert(path);
         }
-        let is_private = false; // account leaves are always public. Their storage leaves can be private.
+        let is_private = false; // account leaves are always public. Their storage leaves can be
+                                // private.
 
         let provider = provider_factory.account_node_provider();
         self.state.update_leaf(path, value, is_private, provider)?;
@@ -976,7 +977,8 @@ mod tests {
 
     #[test]
     fn reveal_account_path_twice() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
@@ -1051,7 +1053,8 @@ mod tests {
 
     #[test]
     fn reveal_storage_path_twice() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let provider_factory = DefaultTrieNodeProviderFactory;
         let mut sparse = SparseStateTrie::<SerialSparseTrie>::default();
 
@@ -1157,7 +1160,8 @@ mod tests {
         let slot_path_3 = Nibbles::unpack(slot_3);
         let value_3 = U256::from(rng.random::<u64>());
 
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
 
         let mut storage_hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([slot_path_1, slot_path_2]));
@@ -1188,7 +1192,8 @@ mod tests {
         let account_2 = Account::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
         let mut trie_account_2 = account_2.into_trie_account(EMPTY_ROOT_HASH);
 
-        let is_private = false; // account leaves are always public. Their storage leaves can be private.
+        let is_private = false; // account leaves are always public. Their storage leaves can be
+                                // private.
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([address_path_1, address_path_2]));
         hash_builder.add_leaf(address_path_1, &alloy_rlp::encode(trie_account_1), is_private);

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -682,10 +682,10 @@ where
         provider_factory: impl TrieNodeProviderFactory,
     ) -> SparseStateTrieResult<bool> {
         let storage_root = if let Some(storage_trie) = self.storage.tries.get_mut(&address) {
-            trace!(target: "trie::sparse", ?address, "Calculating storage root to update account");
+            trace!(target: "trie::sparse", "Calculating storage root to update account");
             storage_trie.root().ok_or(SparseTrieErrorKind::Blind)?
         } else if self.is_account_revealed(address) {
-            trace!(target: "trie::sparse", ?address, "Retrieving storage root from account leaf to update account");
+            trace!(target: "trie::sparse", "Retrieving storage root from account leaf to update account");
             // The account was revealed, either...
             if let Some(value) = self.get_account_value(&address) {
                 // ..it exists and we should take its current storage root or...
@@ -732,14 +732,14 @@ where
             .map(|v| TrieAccount::decode(&mut &v[..]))
             .transpose()?
         else {
-            trace!(target: "trie::sparse", ?address, "Account not found in trie, skipping storage root update");
+            trace!(target: "trie::sparse", "Account not found in trie, skipping storage root update");
             return Ok(true)
         };
 
         // Calculate the new storage root. If the storage trie doesn't exist, the storage root will
         // be empty.
         let storage_root = if let Some(storage_trie) = self.storage.tries.get_mut(&address) {
-            trace!(target: "trie::sparse", ?address, "Calculating storage root to update account");
+            trace!(target: "trie::sparse", "Calculating storage root to update account");
             storage_trie.root().ok_or(SparseTrieErrorKind::Blind)?
         } else {
             EMPTY_ROOT_HASH
@@ -754,7 +754,7 @@ where
         }
 
         // Otherwise, update the account leaf.
-        trace!(target: "trie::sparse", ?address, "Updating account with the new storage root");
+        trace!(target: "trie::sparse", "Updating account with the new storage root");
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         trie_account.encode(&mut self.account_rlp_buf);

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -702,7 +702,7 @@ where
             return Ok(false);
         }
 
-        trace!(target: "trie::sparse", ?address, "Updating account");
+        trace!(target: "trie::sparse", "Updating account");
         let nibbles = Nibbles::unpack(address);
         self.account_rlp_buf.clear();
         account.into_trie_account(storage_root).encode(&mut self.account_rlp_buf);

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -325,7 +325,7 @@ where
 
         if let Some(root_node) = root_node {
             // Reveal root node if it wasn't already.
-            trace!(target: "trie::sparse", ?root_node, "Revealing root account node");
+            trace!(target: "trie::sparse", "Revealing root account node");
             let trie =
                 self.state.reveal_root(root_node.node, root_node.masks, self.retain_updates)?;
 
@@ -378,7 +378,7 @@ where
     /// Reveals a decoded storage multiproof for the given address. This is internal static function
     /// is designed to handle a variety of associated public functions.
     fn reveal_decoded_storage_multiproof_inner(
-        account: B256,
+        _account: B256,
         storage_subtree: DecodedStorageMultiProof,
         revealed_nodes: &mut HashSet<Nibbles>,
         trie: &mut SparseTrie<S>,
@@ -394,14 +394,14 @@ where
 
         if let Some(root_node) = root_node {
             // Reveal root node if it wasn't already.
-            trace!(target: "trie::sparse", ?account, ?root_node, "Revealing root storage node");
+            trace!(target: "trie::sparse", "Revealing root storage node");
             let trie = trie.reveal_root(root_node.node, root_node.masks, retain_updates)?;
 
             // Reserve the capacity for new nodes ahead of time, if the trie implementation
             // supports doing so.
             trie.reserve_nodes(new_nodes);
 
-            trace!(target: "trie::sparse", ?account, total_nodes = ?nodes.len(), "Revealing storage nodes");
+            trace!(target: "trie::sparse", total_nodes = nodes.len(), "Revealing storage nodes");
             trie.reveal_nodes(nodes)?;
         }
 

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2025,7 +2025,8 @@ mod find_leaf_tests {
         let mut sparse = SerialSparseTrie::default();
         let path1 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Creates branch at 0x12
         let path2 = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x5, 0x6]); // Belongs to same branch
-        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at nibble 7
+        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x7, 0x8]); // Diverges at
+                                                                                 // nibble 7
 
         let is_private = false; // hardcode to false for legacy test
         sparse.update_leaf(path1, VALUE_A(), is_private, &provider).unwrap();
@@ -2168,8 +2169,10 @@ mod find_leaf_tests {
     #[test]
     fn find_leaf_error_trie_node_via_reveal() {
         let blinded_hash = B256::repeat_byte(0xAA);
-        let path_to_blind = Nibbles::from_nibbles_unchecked([0x1]); // Path of the blinded node itself
-        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Path we will search for
+        let path_to_blind = Nibbles::from_nibbles_unchecked([0x1]); // Path of the blinded node
+                                                                    // itself
+        let search_path = Nibbles::from_nibbles_unchecked([0x1, 0x2, 0x3, 0x4]); // Path we will
+                                                                                 // search for
 
         let revealed_leaf_prefix = Nibbles::from_nibbles_unchecked([0x5]);
         let revealed_leaf_suffix = Nibbles::from_nibbles_unchecked([0x6, 0x7, 0x8]);
@@ -2202,7 +2205,8 @@ mod find_leaf_tests {
         // Assertions before we reveal child5
         assert_matches!(sparse.nodes.get(&Nibbles::default()), Some(SparseNode::Branch { state_mask, .. }) if *state_mask == TrieMask::new(0b100010)); // Here we check that 1 and 5 are set in the state_mask
         assert_matches!(sparse.nodes.get(&path_to_blind), Some(SparseNode::Hash(h)) if *h == blinded_hash );
-        assert!(sparse.nodes.get(&revealed_leaf_prefix).unwrap().is_hash()); // Child 5 is initially a hash of its RLP
+        assert!(sparse.nodes.get(&revealed_leaf_prefix).unwrap().is_hash()); // Child 5 is initially
+                                                                             // a hash of its RLP
         assert!(sparse.values.is_empty());
 
         // 4. Explicitly reveal the leaf node for child 5
@@ -2282,7 +2286,8 @@ mod tests {
         proof_targets: impl IntoIterator<Item = Nibbles>,
     ) -> (B256, TrieUpdates, ProofNodes, HashMap<Nibbles, TrieMask>, HashMap<Nibbles, TrieMask>)
     {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let mut account_rlp = Vec::new();
 
         let mut hash_builder = HashBuilder::default()
@@ -2398,7 +2403,8 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_one() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let key = Nibbles::unpack(B256::with_last_byte(42));
         let value = || Account::default();
         let value_encoded = || {
@@ -2428,7 +2434,8 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple_lower_nibbles() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         reth_tracing::init_test_tracing();
 
         let paths = (0..=16).map(|b| Nibbles::unpack(B256::with_last_byte(b))).collect::<Vec<_>>();
@@ -2462,7 +2469,8 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple_upper_nibbles() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let paths = (239..=255).map(|b| Nibbles::unpack(B256::repeat_byte(b))).collect::<Vec<_>>();
         let value = || Account::default();
         let value_encoded = || {
@@ -2494,7 +2502,8 @@ mod tests {
 
     #[test]
     fn sparse_trie_empty_update_multiple() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let paths = (0..=255)
             .map(|b| {
                 Nibbles::unpack(if b % 2 == 0 {
@@ -2979,7 +2988,8 @@ mod tests {
                 let default_provider = DefaultTrieNodeProvider;
                 let provider_factory = create_test_provider_factory();
                 let mut sparse = SerialSparseTrie::default().with_updates(true);
-                let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+                let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                        // equivalent
 
                 for (update, keys_to_delete) in updates {
                     // Insert state updates into the sparse trie and calculate the root
@@ -3121,7 +3131,8 @@ mod tests {
     /// replacing it.
     #[test]
     fn sparse_trie_reveal_node_1() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
 
         let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00]));
         let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01]));
@@ -3336,7 +3347,8 @@ mod tests {
     ///    overwritten with the extension node from the proof.
     #[test]
     fn sparse_trie_reveal_node_3() {
-        let is_private = false; // hardcode to false for legacy test, TODO: make a private equivalent
+        let is_private = false; // hardcode to false for legacy test, TODO: make a private
+                                // equivalent
         let key1 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x01]));
         let key2 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x00, 0x02]));
         let key3 = || pad_nibbles_right(Nibbles::from_nibbles_unchecked([0x01, 0x00]));

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -575,7 +575,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         is_private: bool,
         provider: P,
     ) -> SparseTrieResult<()> {
-        trace!(target: "trie::sparse", ?full_path, ?value, "update_leaf called");
+        trace!(target: "trie::sparse", "update_leaf called");
 
         self.prefix_set.insert(full_path);
         let existing = self.values.insert(full_path, value);
@@ -647,8 +647,6 @@ impl SparseTrieInterface for SerialSparseTrie {
                             if self.nodes.get(&current).unwrap().is_hash() {
                                 debug!(
                                     target: "trie::sparse",
-                                    leaf_full_path = ?full_path,
-                                    child_path = ?current,
                                     "Extension node child not revealed in update_leaf, falling back to db",
                                 );
                                 if let Some(RevealedNode { node, tree_mask, hash_mask }) =
@@ -657,10 +655,6 @@ impl SparseTrieInterface for SerialSparseTrie {
                                     let decoded = TrieNode::decode(&mut &node[..])?;
                                     trace!(
                                         target: "trie::sparse",
-                                        ?current,
-                                        ?decoded,
-                                        ?tree_mask,
-                                        ?hash_mask,
                                         "Revealing extension node child",
                                     );
                                     self.reveal_node(
@@ -717,7 +711,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         full_path: &Nibbles,
         provider: P,
     ) -> SparseTrieResult<()> {
-        trace!(target: "trie::sparse", ?full_path, "remove_leaf called");
+        trace!(target: "trie::sparse", "remove_leaf called");
 
         if self.values.remove(full_path).is_none() {
             if let Some(&SparseNode::Hash(hash)) = self.nodes.get(full_path) {
@@ -725,7 +719,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                 return Err(SparseTrieErrorKind::BlindedNode { path: *full_path, hash }.into())
             }
 
-            trace!(target: "trie::sparse", ?full_path, "Leaf node is not present in the trie");
+            trace!(target: "trie::sparse", "Leaf node is not present in the trie");
             // Leaf is not present in the trie.
             return Ok(())
         }
@@ -819,13 +813,11 @@ impl SparseTrieInterface for SerialSparseTrie {
                         let mut child_path = removed_path;
                         child_path.push_unchecked(child_nibble);
 
-                        trace!(target: "trie::sparse", ?removed_path, ?child_path, "Branch node has only one child");
+                        trace!(target: "trie::sparse", "Branch node has only one child");
 
                         if self.nodes.get(&child_path).unwrap().is_hash() {
                             debug!(
                                 target: "trie::sparse",
-                                ?child_path,
-                                leaf_full_path = ?full_path,
                                 "Branch node child not revealed in remove_leaf, falling back to db",
                             );
                             if let Some(RevealedNode { node, tree_mask, hash_mask }) =
@@ -834,10 +826,6 @@ impl SparseTrieInterface for SerialSparseTrie {
                                 let decoded = TrieNode::decode(&mut &node[..])?;
                                 trace!(
                                     target: "trie::sparse",
-                                    ?child_path,
-                                    ?decoded,
-                                    ?tree_mask,
-                                    ?hash_mask,
                                     "Revealing remaining blinded branch child"
                                 );
                                 self.reveal_node(
@@ -911,7 +899,7 @@ impl SparseTrieInterface for SerialSparseTrie {
                 node: new_node.clone(),
                 unset_branch_nibble: None,
             };
-            trace!(target: "trie::sparse", ?removed_path, ?new_node, "Re-inserting the node");
+            trace!(target: "trie::sparse", "Re-inserting the node");
             self.nodes.insert(removed_path, new_node);
         }
 
@@ -1274,7 +1262,11 @@ impl SerialSparseTrie {
         // Update the prefix set to the prefix set of the nodes that still need to be updated.
         self.prefix_set = new_prefix_set;
 
-        trace!(target: "trie::sparse", ?depth, ?targets, "Updating nodes at depth");
+        trace!(
+            target: "trie::sparse",
+            target_count = targets.len(),
+            "Updating trie nodes"
+        );
 
         let mut temp_rlp_buf = core::mem::take(&mut self.rlp_buf);
         for (level, path) in targets {
@@ -1405,12 +1397,7 @@ impl SerialSparseTrie {
             buffers.path_stack.pop()
         {
             let node = self.nodes.get_mut(&path).unwrap();
-            trace!(
-                target: "trie::sparse",
-                ?level,
-                ?is_in_prefix_set,
-                "Popped node from path stack"
-            );
+            trace!(target: "trie::sparse", "Popped node from path stack");
 
             // Check if the path is in the prefix set.
             // First, check the cached value. If it's `None`, then check the prefix set, and update
@@ -1456,13 +1443,7 @@ impl SerialSparseTrie {
 
                         let store_in_db_trie_value = child_node_type.store_in_db_trie();
 
-                        trace!(
-                            target: "trie::sparse",
-                            ?path,
-                            ?child_path,
-                            ?child_node_type,
-                            "Extension node"
-                        );
+                        trace!(target: "trie::sparse", "Extension node");
 
                         *store_in_db_trie = store_in_db_trie_value;
 
@@ -1594,13 +1575,7 @@ impl SerialSparseTrie {
                         }
                     }
 
-                    trace!(
-                        target: "trie::sparse",
-                        ?path,
-                        ?tree_mask,
-                        ?hash_mask,
-                        "Branch node masks"
-                    );
+                    trace!(target: "trie::sparse", "Branch node masks");
 
                     rlp_buf.clear();
                     let branch_node_ref =
@@ -1665,13 +1640,7 @@ impl SerialSparseTrie {
                 }
             };
 
-            trace!(
-                target: "trie::sparse",
-                ?level,
-                ?node_type,
-                ?is_in_prefix_set,
-                "Added node to rlp node stack"
-            );
+            trace!(target: "trie::sparse", "Added node to rlp node stack");
 
             buffers.rlp_node_stack.push(RlpNodeStackItem { path, rlp_node, node_type });
         }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -420,7 +420,7 @@ impl SparseTrieInterface for SerialSparseTrie {
         node: TrieNode,
         masks: TrieMasks,
     ) -> SparseTrieResult<()> {
-        trace!(target: "trie::sparse", ?path, ?node, ?masks, "reveal_node called");
+        trace!(target: "trie::sparse", "Revealing trie node");
 
         // If the node is already revealed and it's not a hash node, do nothing.
         if self.nodes.get(&path).is_some_and(|node| !node.is_hash()) {
@@ -1401,19 +1401,14 @@ impl SerialSparseTrie {
         buffers: &mut RlpNodeBuffers,
         rlp_buf: &mut Vec<u8>,
     ) -> RlpNode {
-        let _starting_path = buffers.path_stack.last().map(|item| item.path);
-
         'main: while let Some(RlpNodePathStackItem { level, path, mut is_in_prefix_set }) =
             buffers.path_stack.pop()
         {
             let node = self.nodes.get_mut(&path).unwrap();
             trace!(
                 target: "trie::sparse",
-                ?_starting_path,
                 ?level,
-                ?path,
                 ?is_in_prefix_set,
-                ?node,
                 "Popped node from path stack"
             );
 
@@ -1672,10 +1667,7 @@ impl SerialSparseTrie {
 
             trace!(
                 target: "trie::sparse",
-                ?_starting_path,
                 ?level,
-                ?path,
-                ?node,
                 ?node_type,
                 ?is_in_prefix_set,
                 "Added node to rlp node stack"

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -124,7 +124,10 @@ where
     fn seek_hashed_entry(&mut self, key: B256) -> Result<Option<(B256, H::Value)>, DatabaseError> {
         if let Some((last_key, last_value)) = self.last_next_result {
             if last_key == key {
-                trace!(target: "trie::node_iter", seek_key = ?key, "reusing result from last next() call instead of seeking");
+                trace!(
+                    target: "trie::node_iter",
+                    "reusing result from last next() call instead of seeking"
+                );
                 self.last_next_result = None; // Consume the cached value
 
                 let result = Some((last_key, last_value));
@@ -145,7 +148,7 @@ where
             return Ok(entry);
         }
 
-        trace!(target: "trie::node_iter", ?key, "performing hashed cursor seek");
+        trace!(target: "trie::node_iter", "performing hashed cursor seek");
         let result = self.hashed_cursor.seek(key)?;
         self.last_seeked_hashed_entry = Some(SeekedHashedEntry { seeked_key: key, result });
 
@@ -194,8 +197,7 @@ where
         level = "trace",
         target = "trie::node_iter",
         skip_all,
-        fields(trie_type = ?self.trie_type),
-        ret
+        fields(trie_type = ?self.trie_type)
     )]
     pub fn try_next(
         &mut self,
@@ -231,7 +233,7 @@ where
                 }
 
                 // Set the next hashed entry as a leaf node and return
-                trace!(target: "trie::node_iter", ?hashed_key, "next hashed entry");
+                trace!(target: "trie::node_iter", "next hashed entry");
                 self.current_hashed_entry = self.next_hashed_entry()?;
 
                 #[cfg(feature = "metrics")]
@@ -242,7 +244,7 @@ where
             // Handle seeking and advancing based on the previous hashed key
             match self.previous_hashed_key.take() {
                 Some(hashed_key) => {
-                    trace!(target: "trie::node_iter", ?hashed_key, "seeking to the previous hashed entry");
+                    trace!(target: "trie::node_iter", "seeking to the previous hashed entry");
                     // Seek to the previous hashed key and get the next hashed entry
                     self.seek_hashed_entry(hashed_key)?;
                     self.current_hashed_entry = self.next_hashed_entry()?;
@@ -257,18 +259,12 @@ where
 
                     trace!(
                         target: "trie::node_iter",
-                        ?seek_key,
                         can_skip_current_node = self.walker.can_skip_current_node,
-                        last = ?self.walker.stack.last(),
                         "seeking to the next unprocessed hashed entry"
                     );
                     let can_skip_node = self.walker.can_skip_current_node;
                     self.walker.advance()?;
-                    trace!(
-                        target: "trie::node_iter",
-                        last = ?self.walker.stack.last(),
-                        "advanced walker"
-                    );
+                    trace!(target: "trie::node_iter", "advanced walker");
 
                     // We should get the iterator to return a branch node if we can skip the
                     // current node and the tree flag for the current node is set.
@@ -284,12 +280,7 @@ where
                         self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
                         self.walker.children_are_in_trie()
                     {
-                        trace!(
-                            target: "trie::node_iter",
-                            ?seek_key,
-                            walker_hash = ?self.walker.maybe_hash(),
-                            "skipping hashed seek"
-                        );
+                        trace!(target: "trie::node_iter", "skipping hashed seek");
 
                         self.should_check_walker_key = false;
                         continue

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -153,7 +153,8 @@ where
                     let account = account.into_trie_account(storage_multiproof.root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
 
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
+                    let is_private = false; // account leaves are always public. Their storage
+                                            // leaves can be private.
                     hash_builder.add_leaf(
                         Nibbles::unpack(hashed_address),
                         &account_rlp,

--- a/crates/trie/trie/src/proof/trie_node.rs
+++ b/crates/trie/trie/src/proof/trie_node.rs
@@ -101,11 +101,7 @@ where
         trace!(
             target: "trie::proof::blinded",
             elapsed = ?start.unwrap().elapsed(),
-            ?path,
-            ?node,
-            ?tree_mask,
-            ?hash_mask,
-            "Blinded node for account trie"
+            "Retrieved blinded node for account trie"
         );
         Ok(node.map(|node| RevealedNode { node, tree_mask, hash_mask }))
     }
@@ -162,13 +158,8 @@ where
 
         trace!(
             target: "trie::proof::blinded",
-            account = ?self.account,
             elapsed = ?start.unwrap().elapsed(),
-            ?path,
-            ?node,
-            ?tree_mask,
-            ?hash_mask,
-            "Blinded node for storage trie"
+            "Retrieved blinded node for storage trie"
         );
         Ok(node.map(|node| RevealedNode { node, tree_mask, hash_mask }))
     }

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -187,13 +187,7 @@ where
                 let hashed_address = account_root_state.last_hashed_key;
                 let account = storage_state.account;
 
-                debug!(
-                    target: "trie::state_root",
-                    account_nonce = account.nonce,
-                    account_balance = ?account.balance,
-                    last_hashed_key = ?account_root_state.last_hashed_key,
-                    "Resuming storage root calculation"
-                );
+                debug!(target: "trie::state_root", "Resuming storage root calculation");
 
                 // resume the storage root calculation
                 let remaining_threshold = self.threshold.saturating_sub(
@@ -445,10 +439,7 @@ impl StateRootContext {
                 // Storage root hit threshold or resumed calculation hit threshold
                 debug!(
                     target: "trie::state_root",
-                    ?hashed_address,
                     storage_slots_walked,
-                    last_storage_key = ?state.last_hashed_key,
-                    ?account,
                     "Pausing storage root calculation"
                 );
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -248,7 +248,8 @@ where
                 }
                 TrieElement::Leaf(hashed_address, account) => {
                     tracker.inc_leaf();
-                    let is_private = false; // account leaves are always public. Their storage leaves can be private.
+                    let is_private = false; // account leaves are always public. Their storage
+                                            // leaves can be private.
                     storage_ctx.hashed_entries_walked += 1;
 
                     // calculate storage root, calculating the remaining threshold so we have

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -611,7 +611,7 @@ where
     ///
     /// The storage root, number of walked entries and trie updates
     /// for a given address if requested.
-    #[instrument(skip_all, target = "trie::storage_root", name = "Storage trie", fields(hashed_address = ?self.hashed_address))]
+    #[instrument(skip_all, target = "trie::storage_root", name = "Storage trie")]
     pub fn calculate(self, retain_updates: bool) -> Result<StorageRootProgress, StorageRootError> {
         trace!(target: "trie::storage_root", "calculating storage root");
 
@@ -707,8 +707,6 @@ where
 
         trace!(
             target: "trie::storage_root",
-            %root,
-            hashed_address = %self.hashed_address,
             duration = ?stats.duration(),
             branches_added = stats.branches_added(),
             leaves_added = stats.leaves_added(),

--- a/crates/trie/trie/src/trie_cursor/depth_first.rs
+++ b/crates/trie/trie/src/trie_cursor/depth_first.rs
@@ -262,7 +262,8 @@ mod tests {
         // Expected depth-first order:
         // All descendants come before ancestors
         // Within same level, lexicographical order
-        assert_eq!(paths[0], Nibbles::from_nibbles([0x1, 0x1, 0x1])); // 0x111 (deepest in 0x1 branch)
+        assert_eq!(paths[0], Nibbles::from_nibbles([0x1, 0x1, 0x1])); // 0x111 (deepest in 0x1
+                                                                      // branch)
         assert_eq!(paths[1], Nibbles::from_nibbles([0x1, 0x1, 0x2])); // 0x112 (sibling of 0x111)
         assert_eq!(paths[2], Nibbles::from_nibbles([0x1, 0x1])); // 0x11 (parent of 0x111, 0x112)
         assert_eq!(paths[3], Nibbles::from_nibbles([0x1, 0x2])); // 0x12 (sibling of 0x11)

--- a/crates/trie/trie/src/trie_cursor/subnode.rs
+++ b/crates/trie/trie/src/trie_cursor/subnode.rs
@@ -98,10 +98,6 @@ impl CursorSubNode {
             let nonremoved_mask = !removed_mask & node.state_mask;
             tracing::trace!(
                 target: "trie::walker",
-                key = ?self.key,
-                ?removed_mask,
-                ?nonremoved_mask,
-                ?nibble,
                 "Checking full_key_is_only_nonremoved_node",
             );
             nonremoved_mask.count_ones() == 1 && nonremoved_mask.is_bit_set(nibble)

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -250,7 +250,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
             }
 
             let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
-            trace!(target: "trie::verify", account=?self.account, ?curr_path, ?path, "Current cursor node");
+            trace!(target: "trie::verify", "Current cursor node");
 
             // Use depth-first ordering for comparison
             match depth_first::cmp(&path, curr_path) {
@@ -370,7 +370,7 @@ impl<T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<T, H> {
             };
 
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
-                trace!(target: "trie::verify", account = ?curr_account, "Verying account has empty storage");
+                trace!(target: "trie::verify", "Verying account has empty storage");
 
                 let mut storage_cursor =
                     self.trie_cursor_factory.storage_trie_cursor(curr_account)?;
@@ -409,7 +409,7 @@ impl<T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<T, H> {
                 self.complete = true;
             }
             Some(BranchNode::Account(path, node)) => {
-                trace!(target: "trie::verify", ?path, "Account node from state root");
+                trace!(target: "trie::verify", "Account node from state root");
                 self.account.next(&mut self.outputs, path, node)?;
                 // Push progress indicator
                 if !path.is_empty() {
@@ -417,7 +417,7 @@ impl<T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<T, H> {
                 }
             }
             Some(BranchNode::Storage(account, path, node)) => {
-                trace!(target: "trie::verify", ?account, ?path, "Storage node from state root");
+                trace!(target: "trie::verify", "Storage node from state root");
                 match self.storage.as_mut() {
                     None => {
                         // First storage account - check for any empty storages before it

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -958,9 +958,11 @@ mod tests {
     fn test_single_verifier_complex_depth_first() {
         // Test a complex tree structure with depth-first ordering
         // Build a tree structure with proper parent-child relationships
-        let node_root = test_branch_node(0b0110, 0, 0b0110, vec![]); // root: children at nibbles 1 and 2
+        let node_root = test_branch_node(0b0110, 0, 0b0110, vec![]); // root: children at nibbles 1
+                                                                     // and 2
         let node1 = test_branch_node(0b0110, 0, 0b0110, vec![]); // 0x1: children at nibbles 1 and 2
-        let node11 = test_branch_node(0b0110, 0, 0b0110, vec![]); // 0x11: children at nibbles 1 and 2
+        let node11 = test_branch_node(0b0110, 0, 0b0110, vec![]); // 0x11: children at nibbles 1 and
+                                                                  // 2
         let node111 = test_branch_node(0b0001, 0, 0b0001, vec![]); // 0x111: leaf
         let node112 = test_branch_node(0b0010, 0, 0b0010, vec![]); // 0x112: leaf
         let node12 = test_branch_node(0b0100, 0, 0b0100, vec![]); // 0x12: leaf

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -157,7 +157,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Returns the next unprocessed key in the trie along with its raw [`Nibbles`] representation.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(level = "trace", skip(self))]
     pub fn next_unprocessed_key(&self) -> Option<(B256, Nibbles)> {
         self.key()
             .and_then(|key| if self.can_skip_current_node { key.increment() } else { Some(*key) })
@@ -181,12 +181,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
                     node.full_key_is_only_nonremoved_child(added_removed_keys.as_ref())
                 });
 
-            trace!(
-                target: "trie::walker",
-                ?key_is_only_nonremoved_child,
-                full_key=?node.full_key(),
-                "Checked for only nonremoved child",
-            );
+            trace!(target: "trie::walker", "Checked for only nonremoved child");
 
             !self.changes.contains(node.full_key()) &&
                 node.hash_flag() &&
@@ -196,7 +191,6 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             target: "trie::walker",
             old,
             new = self.can_skip_current_node,
-            last = ?self.stack.last(),
             "updated skip node flag"
         );
     }
@@ -260,7 +254,6 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             if !self.can_skip_current_node && self.children_are_in_trie() {
                 trace!(
                     target: "trie::walker",
-                    position = ?last.position(),
                     "cannot skip current node and children are in the trie"
                 );
                 // If we can't skip the current node and the children are in the trie,
@@ -297,7 +290,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Consumes the next node in the trie, updating the stack.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(level = "trace", skip(self))]
     fn consume_node(&mut self) -> Result<(), DatabaseError> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
@@ -343,7 +336,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
     }
 
     /// Moves to the next sibling node in the trie, updating the stack.
-    #[instrument(level = "trace", skip(self), ret)]
+    #[instrument(level = "trace", skip(self))]
     fn move_to_next_sibling(
         &mut self,
         allow_root_to_child_nibble: bool,
@@ -370,11 +363,11 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         loop {
             let position = subnode.position();
             if subnode.state_flag() {
-                trace!(target: "trie::walker", ?position, "found next sibling with state");
+                trace!(target: "trie::walker", "found next sibling with state");
                 return Ok(())
             }
             if position.is_last_child() {
-                trace!(target: "trie::walker", ?position, "checked all siblings");
+                trace!(target: "trie::walker", "checked all siblings");
                 break
             }
             subnode.inc_nibble();


### PR DESCRIPTION
This sanitizes logs that could potentially leak private data.

My strategy was to have Codex/Claude surface logs that could potentially leak data, group them, and then decided how to handle each group.
Many of the logs contained dynamic errors, which could contain arbitrary strings. In some cases it is not easy to verify that no private data could be contained in these strings. I always erred on the side of caution.
The PR also disables tracing targets originating from `alloy-trie`, `jsonrpsee-core`, and `jsonrpsee-server`.
These crates contain logs that could leak sensitive data.