### PR TITLE
test: verify eth_sendRawTransaction rejects signed_read typed-data submissions

### DIFF
--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -1707,6 +1707,45 @@ async fn test_usdc_only_eth_estimate_gas_typed_data() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Regression test for the replay-protection gap flagged in
+/// `SeismicTxEnvelope::decode_712`'s and `SeismicRawTxRequest::TypedData`'s own doc comments:
+/// `decode_712` itself has no `signed_read` gate (unlike the strict `Decodable2718::decode_2718`
+/// path, which rejects `signed_read = true` at decode time). `eth_sendRawTransaction`'s
+/// `TypedData` payload form is currently safe only because the handler re-encodes the decoded
+/// envelope to RLP and re-decodes it through that strict pipeline (see the handler's own
+/// comment in `ext.rs::send_raw_transaction`) -- an indirect guarantee that a future refactor
+/// could silently break. This test is the trip wire: it submits a `signed_read = true`
+/// transaction (the same kind `get_signed_seismic_call_typed_data` produces for legitimate
+/// `eth_call`/`eth_estimateGas` use, see `test_usdc_only_eth_estimate_gas_typed_data` above)
+/// via `eth_sendRawTransaction` instead, where it must be rejected rather than accepted into
+/// the pool.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signed_read_typed_data_rejected_by_send_raw_transaction() -> eyre::Result<()> {
+    let (mut node, client, chain_id, wallet, _tasks) = setup_test_node().await?;
+    let (contract_addr, recent_block_hash) =
+        rpc_test_deploy_contract(&mut node, &client, chain_id, &wallet).await?;
+
+    let signer = PrivateKeySigner::random();
+    let typed = get_signed_seismic_call_typed_data(
+        &signer,
+        get_nonce(&client, signer.address()).await,
+        TxKind::Call(contract_addr),
+        chain_id,
+        ContractTestContext::get_is_odd_input_plaintext(),
+        recent_block_hash,
+    )
+    .await;
+
+    let result = EthApiOverrideClient::<Block>::send_raw_transaction(&client, typed.into()).await;
+    assert!(
+        result.is_err(),
+        "a signed-read (eth_call-only) transaction submitted via eth_sendRawTransaction's \
+         typed-data form must be rejected, not inserted into the pool"
+    );
+
+    Ok(())
+}
+
 /// 1000 USDC × 10^12 = 10^21 wei cap; `gas_price` = 10^18 → allowance 1000 gas, below 21000 floor.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_usdc_only_insufficient_balance_high_gas_price() -> eyre::Result<()> {


### PR DESCRIPTION
Closes #480.

Adds a regression test verifying that `eth_sendRawTransaction`'s `TypedData` payload form correctly rejects `signed_read = true` transactions.

## Background
`SeismicTxEnvelope::decode_712` has no `signed_read` gate of its own — unlike the strict `Decodable2718::decode_2718` path, which rejects `signed_read = true` at decode time. This is exactly the fragility an existing author TODO in `seismic-alloy` warns about:

> TODO(samlaf): transform this replaying-signed-read-as-write invariant into a cryptographic property of the signature scheme rather than a runtime check. Right now if anyone adds a new ingress path (like we had for eip-712 signatures) that doesn't go through this 2718 decode has a potential to have a replayability bug.

## Why this is currently safe (and what was untested)
`send_raw_transaction`'s `TypedData` branch is already protected: it re-encodes the decoded envelope back to RLP and re-decodes it through the strict pipeline before pool insertion, so the `signed_read` rejection does apply — the handler's own comment documents this intentionally. So this PR is **not** reporting an active vulnerability.

What was missing: no test anywhere verified this indirect protection actually holds end-to-end. The closest existing coverage (`get_signed_seismic_call_typed_data`, used in `test_usdc_only_eth_estimate_gas_typed_data`) only exercises the legitimate `eth_call`/`eth_estimateGas` use of `signed_read = true`, never submission via `eth_sendRawTransaction`.

## Change
Adds `test_signed_read_typed_data_rejected_by_send_raw_transaction`, right next to `test_usdc_only_eth_estimate_gas_typed_data`, reusing the same helpers. It submits a `signed_read = true` typed-data transaction via `eth_sendRawTransaction` and asserts it's rejected — so a future refactor that breaks the re-encode/re-decode protection fails CI immediately instead of silently regressing.

Test-only addition, no production code changes.

The underlying architectural suggestion in the TODO (making this a cryptographic property via distinct signing-hash domains for reads vs. writes) is a bigger design change not attempted here — this PR only closes the test-coverage gap around the current, working mitigation.
