### PR TITLE
chore(deps)!: bump seismic-crypto and drop this repo's well-known key copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.24"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b163ff4acf0eac29af05a911397cc418a76e153467b859398adc26cb9335a611"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=7c2072141ed851f0d38c1489b205782f87b5f9a8#7c2072141ed851f0d38c1489b205782f87b5f9a8"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=d347fbbc8ceaa36677ed36713a08c1038cb47138#d347fbbc8ceaa36677ed36713a08c1038cb47138"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=7c2072141ed851f0d38c1489b205782f87b5f9a8#7c2072141ed851f0d38c1489b205782f87b5f9a8"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=d347fbbc8ceaa36677ed36713a08c1038cb47138#d347fbbc8ceaa36677ed36713a08c1038cb47138"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -689,6 +689,7 @@ dependencies = [
  "revm",
  "secp256k1 0.30.0",
  "seismic-alloy-consensus",
+ "seismic-crypto",
  "seismic-revm",
 ]
 
@@ -962,7 +963,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -973,7 +974,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2972,7 +2973,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3251,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3635,16 +3636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom_or_panic"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
-dependencies = [
- "rand 0.8.5",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,6 +3857,12 @@ checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hickory-proto"
@@ -4529,7 +4526,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5278,18 +5275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5569,7 +5554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5808,7 +5793,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "revm",
@@ -9566,11 +9551,9 @@ dependencies = [
  "reth-testing-utils",
  "revm",
  "revm-state",
- "schnorrkel",
  "secp256k1 0.30.0",
  "seismic-alloy-consensus",
  "seismic-alloy-genesis",
- "seismic-crypto",
  "seismic-revm",
  "thiserror 2.0.17",
  "tracing",
@@ -9611,7 +9594,6 @@ dependencies = [
  "reth-seismic-primitives",
  "revm",
  "seismic-alloy-consensus",
- "seismic-crypto",
  "seismic-revm",
 ]
 
@@ -10419,7 +10401,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10437,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10448,7 +10430,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10464,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10479,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10492,7 +10474,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -10504,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10522,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -10564,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10576,7 +10558,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10600,7 +10582,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10611,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10866,7 +10848,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11028,27 +11010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnorrkel"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
-dependencies = [
- "aead",
- "arrayref",
- "arrayvec",
- "cfg-if",
- "curve25519-dalek",
- "getrandom_or_panic",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "serde_bytes",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11155,15 +11116,18 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-consensus"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eip2930",
+ "alloy-eip7702",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "alloy-tx-macros",
  "anyhow",
  "arbitrary",
  "derive_more 1.0.0",
@@ -11181,7 +11145,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-genesis"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -11194,10 +11158,11 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-network"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7702",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
@@ -11222,8 +11187,9 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-provider"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
+ "alloy-chains",
  "alloy-contract",
  "alloy-network",
  "alloy-primitives",
@@ -11243,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "seismic-alloy-rpc-types"
 version = "0.0.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=b9d4260621a586a2292abf6d60e79cc9cc49e581#b9d4260621a586a2292abf6d60e79cc9cc49e581"
+source = "git+https://github.com/SeismicSystems/seismic-alloy.git?rev=70d1fb739c411b86199578b1f190fbc03c27ccda#70d1fb739c411b86199578b1f190fbc03c27ccda"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11262,13 +11228,13 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=7dc159d50f7142466e0ac5c73e15d524d996b5b2#7dc159d50f7142466e0ac5c73e15d524d996b5b2"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "hex-literal",
  "hkdf",
  "rand 0.9.2",
- "schnorrkel",
  "secp256k1 0.30.0",
  "serde",
  "sha2",
@@ -11277,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "seismic-custodian-ipc"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=7dc159d50f7142466e0ac5c73e15d524d996b5b2#7dc159d50f7142466e0ac5c73e15d524d996b5b2"
 dependencies = [
  "ciborium",
  "serde",
@@ -11328,7 +11294,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -11938,7 +11904,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13159,7 +13125,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -670,7 +670,6 @@ proptest-arbitrary-interop = "0.1.0"
 enr = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
-schnorrkel = { version = "0.11.2" }
 # rand 8 for secp256k1
 rand_08 = { package = "rand", version = "0.8" }
 
@@ -754,8 +753,8 @@ vergen-git2 = "1.0.5"
 
 [patch.crates-io]
 # enclave crates
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
-seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "7dc159d50f7142466e0ac5c73e15d524d996b5b2" }
+seismic-custodian-ipc = { git = "https://github.com/SeismicSystems/enclave.git", rev = "7dc159d50f7142466e0ac5c73e15d524d996b5b2" }
 
 # seismic-alloy-core
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -769,28 +768,28 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 
 # Seismic alloy
-seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
-seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
+seismic-alloy-consensus = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-rpc-types = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-network = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
+seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "70d1fb739c411b86199578b1f190fbc03c27ccda" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "7c2072141ed851f0d38c1489b205782f87b5f9a8" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "7c2072141ed851f0d38c1489b205782f87b5f9a8" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "d347fbbc8ceaa36677ed36713a08c1038cb47138" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "d347fbbc8ceaa36677ed36713a08c1038cb47138" }

--- a/crates/seismic/evm/Cargo.toml
+++ b/crates/seismic/evm/Cargo.toml
@@ -47,7 +47,6 @@ seismic-revm.workspace = true
 derive_more.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-schnorrkel.workspace = true
 
 [dev-dependencies]
 reth-evm = { workspace = true, features = ["test-utils"] }
@@ -58,7 +57,6 @@ alloy-consensus.workspace = true
 reth-seismic-primitives = { workspace = true, features = ["arbitrary"] }
 reth-testing-utils.workspace = true
 secp256k1.workspace = true
-seismic-crypto.workspace = true
 revm-state.workspace = true
 k256.workspace = true
 

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -336,26 +336,14 @@ mod tests {
         primitives::Log,
         state::AccountInfo,
     };
-    use seismic_crypto::{
-        get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-        get_unsecure_sample_secp256k1_sk,
-    };
     use seismic_revm::transaction::abstraction::SeismicTransaction;
     use std::sync::Arc;
 
     fn test_evm_config() -> SeismicEvmConfig {
         // Get mock purpose keys for testing
-        let mock_keys = Box::leak(Box::new(get_mock_keys()));
+        let mock_keys = Box::leak(Box::new(PurposeKeys::well_known()));
 
         SeismicEvmConfig::new(SEISMIC_MAINNET.clone(), mock_keys)
-    }
-
-    fn get_mock_keys() -> PurposeKeys {
-        PurposeKeys {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            rng_ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes(),
-        }
     }
 
     #[test]
@@ -375,7 +363,7 @@ mod tests {
 
         // Use the `SeismicEvmConfig` to create the `cfg_env` and `block_env` based on the
         // ChainSpec, Header, and total difficulty
-        let mock_keys = Box::leak(Box::new(get_mock_keys()));
+        let mock_keys = Box::leak(Box::new(PurposeKeys::well_known()));
         let EvmEnv { cfg_env, .. } =
             SeismicEvmConfig::new(Arc::new(chain_spec.clone()), mock_keys).evm_env(&header);
 

--- a/crates/seismic/fuzz/Cargo.toml
+++ b/crates/seismic/fuzz/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # seismic
-seismic-crypto.workspace = true
 seismic-revm.workspace = true
 alloy-seismic-evm.workspace = true
 seismic-alloy-consensus.workspace = true

--- a/crates/seismic/fuzz/src/mock_keys.rs
+++ b/crates/seismic/fuzz/src/mock_keys.rs
@@ -1,9 +1,5 @@
 //! Mock purpose keys for fuzz targets.
 use alloy_seismic_evm::PurposeKeys;
-use seismic_crypto::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk,
-};
 use std::sync::OnceLock;
 
 /// Returns a `&'static` reference to mock purpose keys.
@@ -12,11 +8,5 @@ use std::sync::OnceLock;
 /// reused across all iterations within a single process.
 pub fn get_static_mock_keys() -> &'static PurposeKeys {
     static KEYS: OnceLock<&'static PurposeKeys> = OnceLock::new();
-    KEYS.get_or_init(|| {
-        Box::leak(Box::new(PurposeKeys {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            rng_ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes(),
-        }))
-    })
+    KEYS.get_or_init(|| Box::leak(Box::new(PurposeKeys::well_known())))
 }

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -73,10 +73,10 @@ tokio = { workspace = true }
 jsonrpsee = { workspace = true }
 reth-e2e-test-utils = { workspace = true, optional = true }
 reth-tasks = { workspace = true, optional = true }
-seismic-crypto = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-seismic-node = { workspace = true, features = ["test-utils"] }
+seismic-crypto.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 reth-db.workspace = true
@@ -155,7 +155,6 @@ test-utils = [
     "reth-tasks",
     "reth-e2e-test-utils",
     "reth-seismic-chainspec",
-    "seismic-crypto",
     "reth-node-builder/test-utils",
     "reth-chainspec/test-utils",
     "reth-consensus/test-utils",

--- a/crates/seismic/node/src/keys_source.rs
+++ b/crates/seismic/node/src/keys_source.rs
@@ -1,6 +1,6 @@
 //! Tools to obtain purpose keys: from the local key custodian's Unix socket, or built
 //! locally from the well-known keys when running without a TEE.
-use std::{path::Path, str::FromStr, time::Duration};
+use std::{path::Path, time::Duration};
 
 use alloy_seismic_evm::{secp256k1, PurposeKeys};
 use reth_node_core::args::{PurposeKeysArgs, PurposeKeysSource};
@@ -11,43 +11,6 @@ use tracing::{info, warn};
 /// explicit operator-triggered rotation (a consensus event); until that mechanism
 /// exists every node derives at epoch 0.
 const PURPOSE_KEY_EPOCH: u64 = 0;
-
-/// The well-known rng HKDF input key material, as `schnorrkel::SecretKey::to_bytes()`
-/// (32-byte key || 32-byte nonce) of the well-known keypair. No schnorrkel
-/// cryptography is performed anywhere with it — the RNG precompile consumes it as
-/// HKDF ikm only.
-const WELL_KNOWN_RNG_IKM: [u8; 64] = [
-    108, 143, 208, 128, 94, 149, 36, 232, 240, 31, 238, 111, 54, 39, 246, 163, 231, 190, 237, 137,
-    76, 19, 107, 188, 78, 133, 126, 183, 245, 50, 56, 8, 121, 108, 125, 215, 62, 231, 212, 112, 83,
-    141, 75, 154, 109, 225, 74, 71, 155, 254, 199, 42, 79, 100, 86, 93, 155, 190, 165, 181, 199,
-    249, 195, 114,
-];
-
-/// The well-known purpose keys, used when `--seismic.purpose-keys-source built-in` is
-/// selected (dev nodes and pre-TEE deployments, which run no TEE at all).
-///
-/// These are real keys with zero secrecy, not mocks: on pre-TEE networks — the live
-/// testnet included — every node boots with `--seismic.purpose-keys-source built-in`,
-/// so they are the consensus-visible network keys — wallets encrypt to this `tx_io_pk`,
-/// sync decrypts history with `tx_io_sk`, and `rng_ikm` seeds the RNG precompile.
-// TODO: these are the only keys reth can run without a custodian; there is no way to
-// input other key material. By mainnet launch, a pre-TEE mainnet must not run keys
-// published on GitHub — needs a per-network keypair provisioned outside source control
-// (e.g. a `file` key source), while sanvil/dev networks stay on the well-known keys.
-#[allow(clippy::expect_used)] // hardcoded constants; validity is exercised by tests
-pub fn well_known_purpose_keys() -> PurposeKeys {
-    PurposeKeys {
-        tx_io_sk: secp256k1::SecretKey::from_str(
-            "311d54d3bf8359c70827122a44a7b4458733adce3c51c6b59d9acfce85e07505",
-        )
-        .expect("valid well-known tx_io secret key"),
-        tx_io_pk: secp256k1::PublicKey::from_str(
-            "028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0",
-        )
-        .expect("valid well-known tx_io public key"),
-        rng_ikm: WELL_KNOWN_RNG_IKM,
-    }
-}
 
 /// Fetch purpose keys: built locally with `--seismic.purpose-keys-source built-in`, otherwise
 /// fetched from the key custodian's Unix socket (`--seismic.custodian.socket`).
@@ -64,7 +27,16 @@ where
     let config = config.as_ref();
     if config.source == PurposeKeysSource::BuiltIn {
         info!(target: "reth::cli", "Using built-in well-known purpose keys (no TEE)");
-        return well_known_purpose_keys();
+        // Real keys with zero secrecy, not mocks: on pre-TEE networks — the live testnet
+        // included — every node boots with this source, so the well-known keys are the
+        // consensus-visible network keys. Wallets encrypt to the tx-io public key, sync
+        // decrypts history with the secret one, and the ikm seeds the RNG precompile.
+        // TODO: these are the only keys reth can run without a custodian; there is no way
+        // to input other key material. By mainnet launch, a pre-TEE mainnet must not run
+        // keys published on GitHub — needs a per-network keypair provisioned outside
+        // source control (e.g. a `file` key source), while sanvil/dev networks stay on the
+        // well-known keys.
+        return PurposeKeys::well_known();
     }
 
     let custodian = &config.custodian;
@@ -115,14 +87,18 @@ fn purpose_keys_from_custodian_bytes(
     tx_io: &TxIoKeypairBytes,
     rng: &RngIkmBytes,
 ) -> eyre::Result<PurposeKeys> {
+    let secp = secp256k1::Secp256k1::new();
     let tx_io_sk = secp256k1::SecretKey::from_byte_array(&tx_io.sk)?;
     let tx_io_pk = secp256k1::PublicKey::from_byte_array_compressed(&tx_io.pk)?;
-    let derived_pk = tx_io_sk.public_key(&secp256k1::Secp256k1::new());
+    let derived_pk = tx_io_sk.public_key(&secp);
     eyre::ensure!(
         tx_io_pk == derived_pk,
         "custodian served a mismatched tx-io keypair: public key {tx_io_pk} is not the secret key's ({derived_pk})"
     );
-    Ok(PurposeKeys { tx_io_sk, tx_io_pk, rng_ikm: rng.ikm })
+    Ok(PurposeKeys {
+        tx_io: secp256k1::Keypair::from_secret_key(&secp, &tx_io_sk),
+        rng_ikm: rng.ikm,
+    })
 }
 
 #[cfg(test)]
@@ -131,31 +107,6 @@ mod tests {
 
     use super::*;
     use std::time::Instant;
-
-    /// sanvil (whose mock arm serves keys built from the sample-key fns) must produce
-    /// these exact keys: `rng_ikm` is a consensus input via the RNG precompile, so
-    /// drift splits the chain, and divergence from sanvil breaks dev-tooling interop.
-    /// This holds for as long as dev networks share keys with anvil.
-    #[test]
-    fn well_known_purpose_keys_match_enclave_crate() {
-        use seismic_crypto::{
-            get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-            get_unsecure_sample_secp256k1_sk,
-        };
-
-        let ours = well_known_purpose_keys();
-        assert_eq!(ours.tx_io_sk, get_unsecure_sample_secp256k1_sk());
-        assert_eq!(ours.tx_io_pk, get_unsecure_sample_secp256k1_pk());
-        assert_eq!(ours.rng_ikm, get_unsecure_sample_schnorrkel_keypair().secret.to_bytes());
-    }
-
-    /// The hardcoded `tx_io_pk` must actually be `tx_io_sk`'s public key — wallets
-    /// ECDH against the published key, the node decrypts with the secret one.
-    #[test]
-    fn well_known_tx_io_keypair_is_consistent() {
-        let keys = well_known_purpose_keys();
-        assert_eq!(keys.tx_io_pk, keys.tx_io_sk.public_key(&secp256k1::Secp256k1::new()));
-    }
 
     /// The clap default must stay in lockstep with the custodian's canonical socket
     /// path (the images-side unit files bind it there); node-core hardcodes the
@@ -168,25 +119,22 @@ mod tests {
         );
     }
 
-    /// The custodian's raw key bytes decode to exactly the well-known keys when
-    /// fed the sample derivations.
+    /// The custodian's raw key bytes decode to exactly the well-known bundle when the
+    /// custodian serves the well-known key material.
     #[test]
     fn custodian_bytes_decode_to_purpose_keys() {
-        use seismic_crypto::{
-            get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-            get_unsecure_sample_secp256k1_sk,
-        };
+        use seismic_crypto::{well_known_rng_ikm, well_known_tx_io_keypair};
 
+        let keypair = well_known_tx_io_keypair();
         let tx_io = TxIoKeypairBytes {
-            sk: get_unsecure_sample_secp256k1_sk().secret_bytes(),
-            pk: get_unsecure_sample_secp256k1_pk().serialize(),
+            sk: keypair.secret_key().secret_bytes(),
+            pk: keypair.public_key().serialize(),
         };
-        let rng = RngIkmBytes { ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes() };
+        let rng = RngIkmBytes { ikm: well_known_rng_ikm() };
 
         let keys = purpose_keys_from_custodian_bytes(&tx_io, &rng).expect("decode purpose keys");
-        let expected = well_known_purpose_keys();
-        assert_eq!(keys.tx_io_sk, expected.tx_io_sk);
-        assert_eq!(keys.tx_io_pk, expected.tx_io_pk);
+        let expected = PurposeKeys::well_known();
+        assert_eq!(keys.tx_io, expected.tx_io);
         assert_eq!(keys.rng_ikm, expected.rng_ikm);
     }
 
@@ -195,16 +143,14 @@ mod tests {
     /// decrypt for.
     #[test]
     fn mismatched_custodian_keypair_is_rejected() {
-        use seismic_crypto::{
-            get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-        };
+        use seismic_crypto::{well_known_rng_ikm, well_known_tx_io_keypair};
 
         let other_sk = secp256k1::SecretKey::from_byte_array(&[1; 32]).expect("valid secret key");
         let tx_io = TxIoKeypairBytes {
             sk: other_sk.secret_bytes(),
-            pk: get_unsecure_sample_secp256k1_pk().serialize(),
+            pk: well_known_tx_io_keypair().public_key().serialize(),
         };
-        let rng = RngIkmBytes { ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes() };
+        let rng = RngIkmBytes { ikm: well_known_rng_ikm() };
 
         let err = purpose_keys_from_custodian_bytes(&tx_io, &rng)
             .expect_err("mismatched keypair must be rejected");

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -18,10 +18,6 @@ pub mod e2e {
     use reth_seismic_chainspec::SEISMIC_DEV;
     use reth_seismic_primitives::SeismicPrimitives;
     use reth_tasks::TaskManager;
-    use seismic_crypto::{
-        get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-        get_unsecure_sample_secp256k1_sk,
-    };
     use std::sync::{Arc, Once};
     use tokio::sync::Mutex;
 
@@ -33,11 +29,7 @@ pub mod e2e {
     /// Initializes mock purpose keys for tests. Safe to call multiple times.
     pub fn ensure_mock_purpose_keys() {
         INIT_KEYS.call_once(|| {
-            init_purpose_keys(PurposeKeys {
-                tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-                tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-                rng_ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes(),
-            });
+            init_purpose_keys(PurposeKeys::well_known());
         });
     }
 

--- a/crates/seismic/node/tests/e2e/hardfork_config.rs
+++ b/crates/seismic/node/tests/e2e/hardfork_config.rs
@@ -18,21 +18,13 @@ use reth_e2e_test_utils::setup;
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_seismic_chainspec::SEISMIC_DEV;
 use reth_seismic_node::{node::SeismicNode, purpose_keys::init_purpose_keys};
-use seismic_crypto::{
-    get_unsecure_sample_schnorrkel_keypair, get_unsecure_sample_secp256k1_pk,
-    get_unsecure_sample_secp256k1_sk,
-};
 use std::sync::Once;
 
 /// Ensure mock purpose keys are initialized exactly once per test binary.
 static INIT_KEYS: Once = Once::new();
 fn ensure_mock_purpose_keys() {
     INIT_KEYS.call_once(|| {
-        init_purpose_keys(PurposeKeys {
-            tx_io_sk: get_unsecure_sample_secp256k1_sk(),
-            tx_io_pk: get_unsecure_sample_secp256k1_pk(),
-            rng_ikm: get_unsecure_sample_schnorrkel_keypair().secret.to_bytes(),
-        });
+        init_purpose_keys(PurposeKeys::well_known());
     });
 }
 

--- a/crates/seismic/primitives/src/test_utils.rs
+++ b/crates/seismic/primitives/src/test_utils.rs
@@ -13,7 +13,7 @@ use alloy_signer_local::PrivateKeySigner;
 use core::str::FromStr;
 use enr::EnrKey;
 use k256::ecdsa::SigningKey;
-use seismic_crypto::get_unsecure_sample_secp256k1_pk;
+use seismic_crypto::well_known_tx_io_keypair;
 
 use secp256k1::{PublicKey, SecretKey};
 use seismic_alloy_consensus::{
@@ -24,7 +24,7 @@ use seismic_alloy_rpc_types::SeismicTransactionRequest;
 
 /// Get the network public key
 pub fn get_network_public_key() -> PublicKey {
-    get_unsecure_sample_secp256k1_pk()
+    well_known_tx_io_keypair().public_key()
 }
 
 /// Get the client's sk for tx io

--- a/crates/seismic/rpc/src/eth/ext.rs
+++ b/crates/seismic/rpc/src/eth/ext.rs
@@ -99,7 +99,7 @@ impl<P: PeersInfo> SeismicApi<P> {
 impl<P: PeersInfo + 'static> SeismicApiServer for SeismicApi<P> {
     async fn get_tee_public_key(&self) -> RpcResult<PublicKey> {
         trace!(target: "rpc::seismic", "Serving seismic_getTeePublicKey");
-        Ok(self.purpose_keys.tx_io_pk)
+        Ok(self.purpose_keys.tx_io.public_key())
     }
 
     async fn node_info(&self) -> RpcResult<SeismicNodeInfo> {
@@ -268,7 +268,7 @@ impl<Eth> EthApiExt<Eth> {
         let sender = parse_request_sender(seismic_tx_request)?;
         let metadata = Self::build_metadata(seismic_tx_request, sender)?;
         let encrypted = metadata
-            .encrypt_response(&self.purpose_keys.tx_io_sk, output)
+            .encrypt_response(&self.purpose_keys.tx_io.secret_key(), output)
             .map_err(|e| ext_encryption_error(e.to_string()))?;
 
         Ok(E::from_eth_err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::Revert(
@@ -404,7 +404,7 @@ where
                 let call = resolve_seismic_call(call)?;
                 let plaintext_tx_req = seismic_call_to_plaintext_tx(
                     &call,
-                    &self.purpose_keys.tx_io_sk,
+                    &self.purpose_keys.tx_io.secret_key(),
                     self.eth_api.provider(),
                 )?;
                 let tx_request: TransactionRequest = plaintext_tx_req.inner;
@@ -466,7 +466,10 @@ where
                 let sender = parse_request_sender(&request)?;
                 let metadata = Self::build_metadata(&request, sender)?;
                 let encrypted_output = metadata
-                    .encrypt_response(&self.purpose_keys.tx_io_sk, &call_result.return_data)
+                    .encrypt_response(
+                        &self.purpose_keys.tx_io.secret_key(),
+                        &call_result.return_data,
+                    )
                     .map_err(|e| ext_encryption_error(e.to_string()))?;
                 call_result.return_data = encrypted_output;
 
@@ -507,7 +510,7 @@ where
                 let call = resolve_seismic_call(call)?;
                 let plaintext_tx_req = seismic_call_to_plaintext_tx(
                     &call,
-                    &self.purpose_keys.tx_io_sk,
+                    &self.purpose_keys.tx_io.secret_key(),
                     self.eth_api.provider(),
                 )?;
                 let tx_request: TransactionRequest = plaintext_tx_req.inner;
@@ -544,7 +547,7 @@ where
                         let sender = parse_request_sender(&request)?;
                         let metadata = Self::build_metadata(&request, sender)?;
                         value = metadata
-                            .encrypt_response(&self.purpose_keys.tx_io_sk, &value)
+                            .encrypt_response(&self.purpose_keys.tx_io.secret_key(), &value)
                             .map_err(|e| ext_encryption_error(e.to_string()))?;
                         EthCallResponse { value: Some(value), error: None }
                     }
@@ -586,7 +589,7 @@ where
         let call = resolve_seismic_call(request)?;
         let plaintext_tx_req = seismic_call_to_plaintext_tx(
             &call,
-            &self.purpose_keys.tx_io_sk,
+            &self.purpose_keys.tx_io.secret_key(),
             self.eth_api.provider(),
         )?;
 
@@ -612,7 +615,7 @@ where
                 let sender = parse_request_sender(&request)?;
                 let metadata = Self::build_metadata(&request, sender)?;
                 Ok(metadata
-                    .encrypt_response(&self.purpose_keys.tx_io_sk, &result)
+                    .encrypt_response(&self.purpose_keys.tx_io.secret_key(), &result)
                     .map_err(|e| ext_encryption_error(e.to_string()))?)
             }
         }
@@ -659,7 +662,7 @@ where
         let call = resolve_seismic_call(request)?;
         let decrypted_req = seismic_call_to_plaintext_tx(
             &call,
-            &self.purpose_keys.tx_io_sk,
+            &self.purpose_keys.tx_io.secret_key(),
             self.eth_api.provider(),
         )?;
 

--- a/crates/seismic/rpc/src/eth/transaction.rs
+++ b/crates/seismic/rpc/src/eth/transaction.rs
@@ -483,7 +483,7 @@ mod test {
         use k256::ecdsa::SigningKey;
         use secp256k1::PublicKey;
         use seismic_alloy_consensus::{TxSeismic, TxSeismicElements};
-        use seismic_crypto::get_unsecure_sample_secp256k1_pk;
+        use seismic_crypto::well_known_tx_io_keypair;
 
         // First anvil key
         let private_key_bytes: [u8; 32] =
@@ -494,7 +494,7 @@ mod test {
         let signing_key = SigningKey::from_bytes(&private_key_bytes.into()).unwrap();
 
         // Network public key
-        let network_pubkey: PublicKey = get_unsecure_sample_secp256k1_pk();
+        let network_pubkey: PublicKey = well_known_tx_io_keypair().public_key();
 
         // Create a seismic transaction
         let tx = TxSeismic {


### PR DESCRIPTION
Fixes SEI-172

seismic-crypto renamed its well-known network key getters for what they are (SeismicSystems/enclave#262): these are the keys every network without a root key actually runs — the live testnet included, via `--seismic.purpose-keys-source built-in` — not test fixtures. seismic-evm now owns the bundle built from them: PurposeKeys holds the tx-io pair as one secp256k1::Keypair, and PurposeKeys::well_known() is the single definition of what a network with no root key boots on (SeismicSystems/seismic-evm#65). The revm and alloy pins move to the revs carrying the same rename (SeismicSystems/seismic-revm#239, SeismicSystems/seismic-alloy#113).

So this repo's second copy goes away: the two hex literals, WELL_KNOWN_RNG_IKM, and the well_known_purpose_keys() wrapper are gone, and the built-in key source returns PurposeKeys::well_known() directly, keeping the note on what those keys mean for a pre-TEE network. Two tests go with them: one asserted our copy equalled seismic-crypto's, which is now a tautology, and one asserted the hardcoded public key was the secret key's, which the Keypair makes structural. The four mock bundles (node test utils, fuzz targets, the evm unit tests, the hardfork e2e test) call the same constructor, so every key value they use is unchanged.

Elsewhere the tx-io pair is read through the keypair: the rpc extension serves tx_io.public_key() and encrypts and decrypts with tx_io.secret_key(). The custodian decode keeps its wire-level cross-check of the served pair and then builds the Keypair from the secret half; the IPC contract is untouched.

schnorrkel leaves the repo along with the derivation that needed it. The rng ikm is HKDF input material that no schnorrkel cryptography ever touched, and seismic-crypto now returns those same bytes as a frozen constant.