### PR TITLE
chore: move the Seismic tx test helpers into their own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9671,6 +9671,7 @@ dependencies = [
  "reth-seismic-payload-builder",
  "reth-seismic-primitives",
  "reth-seismic-rpc",
+ "reth-seismic-test-utils",
  "reth-seismic-txpool",
  "reth-tasks",
  "reth-tracing",
@@ -9729,21 +9730,14 @@ name = "reth-seismic-primitives"
 version = "1.7.0"
 dependencies = [
  "alloy-consensus",
- "alloy-dyn-abi",
  "alloy-eips",
  "alloy-evm",
- "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types",
- "alloy-signer-local",
- "anyhow",
  "arbitrary",
  "bincode 1.3.3",
  "bytes",
  "derive_more 2.1.1",
- "enr",
- "k256",
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
@@ -9751,14 +9745,12 @@ dependencies = [
  "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
+ "reth-seismic-test-utils",
  "reth-zstd-compressors",
  "revm-context",
  "rstest",
  "secp256k1 0.30.0",
  "seismic-alloy-consensus",
- "seismic-alloy-network",
- "seismic-alloy-rpc-types",
- "seismic-crypto",
  "seismic-revm",
  "serde",
  "serde_json",
@@ -9815,6 +9807,7 @@ dependencies = [
  "reth-seismic-chainspec",
  "reth-seismic-evm",
  "reth-seismic-primitives",
+ "reth-seismic-test-utils",
  "reth-seismic-txpool",
  "reth-storage-api",
  "reth-storage-errors",
@@ -9836,6 +9829,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-seismic-test-utils"
+version = "1.7.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-signer-local",
+ "anyhow",
+ "enr",
+ "k256",
+ "reth-seismic-primitives",
+ "secp256k1 0.30.0",
+ "seismic-alloy-consensus",
+ "seismic-alloy-network",
+ "seismic-alloy-rpc-types",
+ "seismic-crypto",
+]
+
+[[package]]
 name = "reth-seismic-txpool"
 version = "1.7.0"
 dependencies = [
@@ -9852,6 +9867,7 @@ dependencies = [
  "reth-provider",
  "reth-seismic-chainspec",
  "reth-seismic-primitives",
+ "reth-seismic-test-utils",
  "reth-transaction-pool",
  "seismic-alloy-consensus",
  "tokio",
@@ -11217,7 +11233,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "arbitrary",
  "derive_more 1.0.0",
  "seismic-alloy-consensus",
  "seismic-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/seismic/primitives/",
     "crates/seismic/reth/",
     "crates/seismic/rpc/",
+    "crates/seismic/test-utils/",
     "crates/seismic/txpool/",
     "crates/seismic/hardforks",
     "crates/seismic/fuzz",
@@ -358,6 +359,7 @@ reth-seismic-payload-builder = { path = "crates/seismic/payload" }
 reth-seismic-primitives = { path = "crates/seismic/primitives" }
 reth-seismic-reth = { path = "crates/seismic/reth" }
 reth-seismic-rpc = { path = "crates/seismic/rpc" }
+reth-seismic-test-utils = { path = "crates/seismic/test-utils" }
 reth-seismic-txpool = { path = "crates/seismic/txpool" }
 reth-seismic-forks = { path = "crates/seismic/hardforks", default-features = false }
 reth-seismic-fuzz = { path = "crates/seismic/fuzz" }

--- a/crates/seismic/node/Cargo.toml
+++ b/crates/seismic/node/Cargo.toml
@@ -95,6 +95,7 @@ reth-e2e-test-utils = { workspace = true }
 reth-rpc-e2e-tests.workspace = true
 reth-seismic-evm.workspace = true
 reth-seismic-chainspec.workspace = true
+reth-seismic-test-utils.workspace = true
 alloy-network = { workspace = true }
 alloy-chains.workspace = true
 alloy-signer-local = { workspace = true }

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -94,23 +94,14 @@ pub mod e2e {
     }
 }
 
-/// RPC test utilities: nonce helpers, re-exported test helpers.
+/// RPC test utilities: nonce helpers.
+#[cfg(feature = "test-utils")]
 pub mod test_utils {
     use alloy_primitives::Address;
     use alloy_rpc_types::{Block, Header, Transaction, TransactionReceipt};
     use jsonrpsee::http_client::HttpClient;
     use reth_rpc_eth_api::EthApiClient;
     use seismic_alloy_rpc_types::SeismicTransactionRequest;
-
-    pub use reth_seismic_primitives::test_utils::{
-        client_decrypt, client_encrypt, get_ciphertext, get_client_io_sk, get_encryption_nonce,
-        get_network_public_key, get_plaintext, get_seismic_elements, get_seismic_metadata,
-        get_seismic_tx, get_signed_read_seismic_metadata, get_signed_seismic_call_bytes,
-        get_signed_seismic_call_typed_data, get_signed_seismic_tx, get_signed_seismic_tx_bytes,
-        get_signed_seismic_tx_encoding, get_signed_seismic_tx_typed_data, get_signing_private_key,
-        get_unsigned_seismic_call_request, get_unsigned_seismic_tx_request,
-        get_unsigned_seismic_tx_typed_data, get_wrong_private_key, sign_seismic_tx, sign_tx,
-    };
 
     /// Get the nonce from the client
     pub async fn get_nonce(client: &HttpClient, address: Address) -> u64 {

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -95,7 +95,6 @@ pub mod e2e {
 }
 
 /// RPC test utilities: nonce helpers.
-#[cfg(feature = "test-utils")]
 pub mod test_utils {
     use alloy_primitives::Address;
     use alloy_rpc_types::{Block, Header, Transaction, TransactionReceipt};

--- a/crates/seismic/node/tests/e2e/fuzz.rs
+++ b/crates/seismic/node/tests/e2e/fuzz.rs
@@ -16,9 +16,10 @@ use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_param
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use reth_seismic_node::utils::{
     e2e::{ensure_mock_purpose_keys, setup},
-    test_utils::{get_nonce, get_signed_seismic_tx_bytes},
+    test_utils::get_nonce,
 };
 use reth_seismic_rpc::ext::EthApiOverrideClient;
+use reth_seismic_test_utils::get_signed_seismic_tx_bytes;
 use tracing::{info, trace};
 
 /// Number of random payloads per fuzz batch

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -31,18 +31,16 @@ use reth_e2e_test_utils::wallet::Wallet;
 use reth_rpc_eth_api::EthApiClient;
 use reth_seismic_node::utils::{
     e2e::{ensure_mock_purpose_keys, setup, SeismicTestNode},
-    test_utils::{
-        client_decrypt, get_nonce, get_plaintext, get_signed_read_seismic_metadata,
-        get_signed_seismic_call_bytes, get_signed_seismic_call_typed_data,
-        get_signed_seismic_tx_bytes, get_unsigned_seismic_call_request,
-        get_unsigned_seismic_tx_request,
-    },
+    test_utils::get_nonce,
 };
-use reth_seismic_primitives::{
-    test_utils::{get_unsigned_legacy_tx_request, sign_tx},
-    SeismicBlock, SeismicTransactionSigned,
-};
+use reth_seismic_primitives::{SeismicBlock, SeismicTransactionSigned};
 use reth_seismic_rpc::ext::EthApiOverrideClient;
+use reth_seismic_test_utils::{
+    client_decrypt, get_plaintext, get_signed_read_seismic_metadata, get_signed_seismic_call_bytes,
+    get_signed_seismic_call_typed_data, get_signed_seismic_tx_bytes,
+    get_unsigned_legacy_tx_request, get_unsigned_seismic_call_request,
+    get_unsigned_seismic_tx_request, sign_tx,
+};
 use seismic_alloy_consensus::SeismicTxEnvelope;
 use seismic_alloy_network::{
     reth::builder::seismic_reth_tx_builder, wallet::SeismicWallet, SeismicReth,

--- a/crates/seismic/node/tests/e2e/wrong_chain_import.rs
+++ b/crates/seismic/node/tests/e2e/wrong_chain_import.rs
@@ -19,10 +19,8 @@ use reth_seismic_node::{
     engine::SeismicPayloadTypes,
     utils::e2e::{ensure_mock_purpose_keys, setup},
 };
-use reth_seismic_primitives::{
-    test_utils::{get_unsigned_legacy_tx_request, sign_tx},
-    SeismicBlock, SeismicTransactionSigned,
-};
+use reth_seismic_primitives::{SeismicBlock, SeismicTransactionSigned};
+use reth_seismic_test_utils::{get_unsigned_legacy_tx_request, sign_tx};
 use std::time::Duration;
 
 /// A block containing a transaction signed for a different chain must be rejected by

--- a/crates/seismic/primitives/Cargo.toml
+++ b/crates/seismic/primitives/Cargo.toml
@@ -12,8 +12,6 @@ description = "Seismic primitive types"
 workspace = true
 
 [dependencies]
-seismic-crypto.workspace = true
-
 # reth
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 reth-codecs = { workspace = true, optional = true }
@@ -26,11 +24,9 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
 alloy-eips = { workspace = true, features = ["k256"] }
-alloy-network = { workspace = true }
 
 # seismic
 seismic-alloy-consensus.workspace = true
-seismic-alloy-network = { workspace = true }
 seismic-revm.workspace = true
 
 # codec
@@ -41,22 +37,13 @@ serde_with = { workspace = true, optional = true }
 
 # misc
 derive_more = { workspace = true, features = ["deref", "from", "into", "constructor"] }
-secp256k1 = { workspace = true, features = ["rand", "std", "global-context", "recovery"] }
-anyhow.workspace = true
+secp256k1 = { workspace = true, features = ["rand", "std", "global-context", "recovery"], optional = true }
 tracing.workspace = true
 
 # test
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 rand_08 = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
-
-# test utils
-alloy-signer-local.workspace = true
-alloy-rpc-types.workspace = true
-k256.workspace = true
-enr = { workspace = true, features = ["rust-secp256k1"] }
-alloy-dyn-abi.workspace = true
-seismic-alloy-rpc-types.workspace = true
 
 [dev-dependencies]
 arbitrary.workspace = true
@@ -65,7 +52,9 @@ proptest.workspace = true
 rand.workspace = true
 rand_08.workspace = true
 reth-codecs = { workspace = true, features = ["test-utils"] }
+reth-seismic-test-utils.workspace = true
 rstest.workspace = true
+secp256k1 = { workspace = true, features = ["rand", "std", "global-context", "recovery"] }
 serde_json.workspace = true
 bincode.workspace = true
 
@@ -81,7 +70,7 @@ std = [
     "serde?/std",
     "bytes?/std",
     "derive_more/std",
-    "secp256k1/std",
+    "secp256k1?/std",
     "alloy-rlp/std",
     "reth-zstd-compressors?/std",
     "seismic-alloy-consensus/std",
@@ -89,9 +78,6 @@ std = [
     "serde_json/std",
     "alloy-evm/std",
     "serde_with?/std",
-    "k256/std",
-    "seismic-alloy-network/std",
-    "seismic-alloy-rpc-types/std",
     "tracing/std",
 ]
 reth-codec = [
@@ -114,13 +100,9 @@ serde = [
     "reth-codecs?/serde",
     "seismic-alloy-consensus/serde",
     "rand/serde",
-    "secp256k1/serde",
+    "secp256k1?/serde",
     "revm-context/serde",
-    "enr/serde",
-    "k256/serde",
     "rand_08?/serde",
-    "seismic-alloy-network/serde",
-    "seismic-alloy-rpc-types/serde",
     "seismic-revm/serde",
 ]
 serde-bincode-compat = [
@@ -134,7 +116,7 @@ serde-bincode-compat = [
 arbitrary = [
     "std",
     "dep:arbitrary",
-    # "dep:secp256k1",
+    "dep:secp256k1",
     "secp256k1/rand",
     "reth-primitives-traits/arbitrary",
     "reth-codecs?/arbitrary",
@@ -143,7 +125,4 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
     "rand_08",
-    "alloy-dyn-abi/arbitrary",
-    "alloy-rpc-types/arbitrary",
-    "seismic-alloy-rpc-types/arbitrary",
 ]

--- a/crates/seismic/primitives/src/lib.rs
+++ b/crates/seismic/primitives/src/lib.rs
@@ -18,7 +18,6 @@ pub use transaction::{
 
 mod receipt;
 pub use receipt::SeismicReceipt;
-pub mod test_utils;
 
 /// Seismic-specific block type.
 pub type SeismicBlock = alloy_consensus::Block<SeismicTransactionSigned>;

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -724,7 +724,7 @@ pub mod serde_bincode_compat {
 mod tests {
     use core::str::FromStr;
 
-    use crate::test_utils::{get_signed_seismic_tx, get_signing_private_key};
+    use reth_seismic_test_utils::{get_signed_seismic_tx, get_signing_private_key};
 
     use super::*;
     use alloy_primitives::{aliases::U96, hex, U256};

--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -89,6 +89,7 @@ reth-e2e-test-utils.workspace = true
 reth-engine-primitives.workspace = true
 reth-node-ethereum.workspace = true
 reth-seismic-evm.workspace = true
+reth-seismic-test-utils.workspace = true
 seismic-crypto.workspace = true
 reth-rpc-engine-api.workspace = true
 alloy-rpc-types-engine.workspace = true

--- a/crates/seismic/rpc/src/eth/receipt.rs
+++ b/crates/seismic/rpc/src/eth/receipt.rs
@@ -103,7 +103,7 @@ mod tests {
         Eip658Value, Receipt,
     };
     use alloy_primitives::{Address, B256};
-    use reth_seismic_primitives::test_utils::get_signed_seismic_tx;
+    use reth_seismic_test_utils::get_signed_seismic_tx;
     use std::borrow::Cow;
 
     #[test]

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -274,10 +274,8 @@ mod test {
     };
     use alloy_rpc_types::TransactionRequest;
     use reth_primitives_traits::SignedTransaction;
-    use reth_seismic_primitives::{
-        test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx},
-        SeismicTransactionSigned,
-    };
+    use reth_seismic_primitives::SeismicTransactionSigned;
+    use reth_seismic_test_utils::{get_seismic_tx, get_signing_private_key, sign_seismic_tx};
     use secp256k1::PublicKey;
     use seismic_alloy_consensus::{
         SeismicTxEnvelope, TxSeismic, TxSeismicElements, TypedDataRequest,

--- a/crates/seismic/test-utils/Cargo.toml
+++ b/crates/seismic/test-utils/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "reth-seismic-test-utils"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Test helpers for building and signing Seismic transactions"
+
+[lints]
+workspace = true
+
+[dependencies]
+seismic-crypto.workspace = true
+
+# reth
+reth-seismic-primitives.workspace = true
+
+# ethereum
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-dyn-abi.workspace = true
+alloy-eips = { workspace = true, features = ["std"] }
+alloy-network.workspace = true
+alloy-primitives = { workspace = true, features = ["std"] }
+alloy-rpc-types.workspace = true
+alloy-signer-local.workspace = true
+
+# seismic
+seismic-alloy-consensus = { workspace = true, features = ["std"] }
+seismic-alloy-network = { workspace = true, features = ["std"] }
+seismic-alloy-rpc-types = { workspace = true, features = ["std"] }
+
+# misc
+anyhow.workspace = true
+enr = { workspace = true, features = ["rust-secp256k1"] }
+k256.workspace = true
+secp256k1 = { workspace = true, features = ["global-context", "recovery"] }

--- a/crates/seismic/test-utils/src/lib.rs
+++ b/crates/seismic/test-utils/src/lib.rs
@@ -1,8 +1,14 @@
-//! Test utils for seismic primitives, e.g. `SeismicTransactionSigned`
+//! Test helpers for building, encrypting, and signing Seismic transactions.
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/SeismicSystems/seismic-reth/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![warn(unused_crate_dependencies)]
 #![allow(clippy::unwrap_used, clippy::expect_used)] // Test utilities - panics are acceptable
 
-use crate::SeismicTransactionSigned;
 use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Encodable2718;
@@ -13,6 +19,7 @@ use alloy_signer_local::PrivateKeySigner;
 use core::str::FromStr;
 use enr::EnrKey;
 use k256::ecdsa::SigningKey;
+use reth_seismic_primitives::SeismicTransactionSigned;
 use seismic_crypto::well_known_tx_io_keypair;
 
 use secp256k1::{PublicKey, SecretKey};

--- a/crates/seismic/txpool/Cargo.toml
+++ b/crates/seismic/txpool/Cargo.toml
@@ -36,6 +36,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 reth-seismic-chainspec.workspace = true
+reth-seismic-test-utils.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 tokio.workspace = true
 criterion.workspace = true

--- a/crates/seismic/txpool/benches/eviction_scan.rs
+++ b/crates/seismic/txpool/benches/eviction_scan.rs
@@ -8,7 +8,7 @@ use alloy_consensus::transaction::Recovered;
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, B256};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use reth_seismic_primitives::test_utils::get_signed_seismic_tx;
+use reth_seismic_test_utils::get_signed_seismic_tx;
 use reth_seismic_txpool::{stale_seismic_hashes, RecentBlockCache, SeismicPooledTransaction};
 use reth_transaction_pool::{
     identifier::{SenderId, TransactionId},

--- a/crates/seismic/txpool/src/transaction.rs
+++ b/crates/seismic/txpool/src/transaction.rs
@@ -192,7 +192,7 @@ mod tests {
     use reth_primitives_traits::transaction::error::InvalidTransactionError;
     use reth_provider::test_utils::MockEthProvider;
     use reth_seismic_chainspec::SEISMIC_MAINNET;
-    use reth_seismic_primitives::test_utils::get_signed_seismic_tx;
+    use reth_seismic_test_utils::get_signed_seismic_tx;
     use reth_transaction_pool::{
         blobstore::InMemoryBlobStore, error::InvalidPoolTransactionError,
         validate::EthTransactionValidatorBuilder, TransactionOrigin, TransactionValidationOutcome,


### PR DESCRIPTION
Fixes SEI-343

reth-seismic-primitives exported 458 lines of test helpers as `pub mod test_utils` — transaction builders, client-side encryption, signing fixtures with hardcoded private keys — from the default public API of a crate every consumer depends on, the production node included. They now live in crates/seismic/test-utils
(`reth-seismic-test-utils`), reached only through a `[dev-dependencies]` line. `[dev-dependencies]` are in scope for the listing crate's test, bench, and example targets, so `use reth_seismic_test_utils::…` from a crate's `src/` does not resolve.

Nothing marks a crate dev-only workspace-wide — someone can always move the line into `[dependencies]` — but that is one visible line in the manifest of the crate doing it, caught in review. What a dev-dependency rules out is the leak a feature cannot avoid: features unify across a build and dev-dependency features fold in whenever test targets are built, so under a `test-utils` feature on the primitives crate, one crate's dev-dependency would turn the module on for every crate in the same `cargo test --workspace`. Production code in reth-seismic-node could import the helpers, compile clean in CI's test job, and break only in a later `cargo build` of the binary — an error in a crate nobody touched.

The file moves verbatim. reth-seismic-primitives drops the module and the ten dependencies only those helpers used: seismic-crypto, seismic-alloy-network, seismic-alloy-rpc-types, alloy-signer-local, alloy-rpc-types, alloy-dyn-abi, alloy-network, enr, k256, and anyhow. Its manifest now lists what the primitives actually need. secp256k1 is the one that stays: the rest of the crate reaches it only from the `arbitrary` impl, so it becomes optional under the `arbitrary` feature and a dev-dependency for the crate's own tests, the shape rand_08 already has there.

Call sites take the new import path with a dev-dependency: primitives/src/transaction/signed.rs, rpc/src/eth/receipt.rs, rpc/src/eth/utils.rs, txpool/src/transaction.rs, and txpool/benches/eviction_scan.rs. reth-seismic-node's `utils::test_utils` re-export goes away — its only consumers are that crate's own e2e tests, which depend on the new crate directly — and the module keeps `get_nonce` behind the node's `test-utils` feature.

primitives dev-depends on a crate that depends on primitives. Cargo allows dev-dependency cycles: dev edges do not participate in the lib build graph, and this repo already leans on the self-cycle reth-seismic-node dev-depending on itself with `features = ["test-utils"]`.