### PR TITLE
fix(txpool): reload queued senders on USDC storage changes

### DIFF
--- a/crates/seismic/txpool/src/maintain.rs
+++ b/crates/seismic/txpool/src/maintain.rs
@@ -6,16 +6,16 @@ use crate::{
     validator::seismic_freshness_error,
 };
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{Sealable, TxHash};
+use alloy_primitives::{Address, Sealable, TxHash, B256};
 use futures_util::StreamExt;
-use reth_execution_types::ChangedAccount;
+use reth_execution_types::{ChangedAccount, ExecutionOutcome};
 use reth_provider::{BlockReaderIdExt, CanonStateNotificationStream, StateProvider};
 use reth_seismic_primitives::SeismicPrimitives;
 use reth_transaction_pool::{
     maintain::ChangedAccountsHook, PoolTransaction, TransactionPool, ValidPoolTransaction,
 };
 use seismic_alloy_consensus::SeismicTypedTransaction;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use tracing::debug;
 
 /// Makes the transaction pool's balance accounting aware of USDC gas payment.
@@ -70,6 +70,43 @@ impl ChangedAccountsHook for SeismicBalanceHook {
             }
         }
     }
+
+    fn extend_reload_queued_senders<R>(
+        &self,
+        queued_senders: &HashSet<Address>,
+        old: Option<&ExecutionOutcome<R>>,
+        new: &ExecutionOutcome<R>,
+        dirty_addresses: &mut HashSet<Address>,
+    ) {
+        dirty_addresses.extend(queued_senders_with_changed_usdc_slots(queued_senders, old, new));
+    }
+}
+
+fn queued_senders_with_changed_usdc_slots<'a, R>(
+    queued_senders: &'a HashSet<Address>,
+    old: Option<&ExecutionOutcome<R>>,
+    new: &ExecutionOutcome<R>,
+) -> impl Iterator<Item = Address> + 'a {
+    let changed_slots = changed_usdc_storage_slots(new)
+        .chain(old.into_iter().flat_map(changed_usdc_storage_slots))
+        .collect::<HashSet<_>>();
+
+    queued_senders.iter().copied().filter(move |address| {
+        changed_slots.contains(&crate::usdc::usdc_balance_storage_key(address))
+    })
+}
+
+fn changed_usdc_storage_slots<R>(state: &ExecutionOutcome<R>) -> impl Iterator<Item = B256> + '_ {
+    state
+        .bundle_accounts_iter()
+        .filter_map(|(address, account)| (address == crate::usdc::USDC_CONTRACT).then_some(account))
+        .flat_map(|account| {
+            account
+                .storage
+                .iter()
+                .filter(|(_, value)| value.is_changed())
+                .map(|(slot, _)| B256::from(slot.to_be_bytes::<32>()))
+        })
 }
 
 /// Run the full-pool scan every Nth head (the cache still updates every head). Eviction is just
@@ -139,4 +176,62 @@ pub fn stale_seismic_hashes<'a>(
                 .map(|_| *tx.hash())
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{map::HashMap, FlaggedStorage, U256};
+    use reth_execution_types::{BundleStateInit, RevertsInit};
+
+    #[test]
+    fn reloads_only_queued_senders_with_changed_usdc_slots() {
+        let affected = alloy_primitives::address!("000000000000000000000000000000000000000a");
+        let unaffected = alloy_primitives::address!("000000000000000000000000000000000000000b");
+        let queued_senders = HashSet::from([affected, unaffected]);
+        let state = execution_outcome_with_changed_usdc_slots([affected]);
+
+        let dirty = queued_senders_with_changed_usdc_slots(&queued_senders, None, &state)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(dirty, HashSet::from([affected]));
+    }
+
+    #[test]
+    fn includes_changed_slots_from_old_and_new_state() {
+        let old_sender = alloy_primitives::address!("000000000000000000000000000000000000000a");
+        let new_sender = alloy_primitives::address!("000000000000000000000000000000000000000b");
+        let queued_senders = HashSet::from([old_sender, new_sender]);
+        let old = execution_outcome_with_changed_usdc_slots([old_sender]);
+        let new = execution_outcome_with_changed_usdc_slots([new_sender]);
+
+        let dirty = queued_senders_with_changed_usdc_slots(&queued_senders, Some(&old), &new)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(dirty, HashSet::from([old_sender, new_sender]));
+    }
+
+    fn execution_outcome_with_changed_usdc_slots(
+        senders: impl IntoIterator<Item = Address>,
+    ) -> ExecutionOutcome<()> {
+        let mut init = BundleStateInit::default();
+        init.insert(
+            crate::usdc::USDC_CONTRACT,
+            (
+                None,
+                None,
+                senders
+                    .into_iter()
+                    .map(|sender| {
+                        (
+                            crate::usdc::usdc_balance_storage_key(&sender),
+                            (FlaggedStorage::ZERO, FlaggedStorage::from(U256::from(1))),
+                        )
+                    })
+                    .collect::<HashMap<_, _>>(),
+            ),
+        );
+
+        ExecutionOutcome::new_init(init, RevertsInit::default(), [], vec![], 0, vec![])
+    }
 }

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -17,7 +17,7 @@ use futures_util::{
 };
 use reth_chain_state::CanonStateNotification;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
-use reth_execution_types::ChangedAccount;
+use reth_execution_types::{ChangedAccount, ExecutionOutcome};
 use reth_fs_util::FsPathError;
 use reth_primitives_traits::{
     transaction::signed::SignedTransaction, NodePrimitives, SealedHeader,
@@ -108,6 +108,17 @@ pub trait ChangedAccountsHook: Send + Sync + 'static {
     /// load native balance/nonce, so implementations always see a consistent
     /// view of the chain.
     fn transform(&self, state: &dyn StateProvider, accounts: &mut Vec<ChangedAccount>);
+
+    /// Extends the dirty set with queued senders whose executability may have
+    /// changed due to off-account state updates in the canonical update.
+    fn extend_reload_queued_senders<R>(
+        &self,
+        _queued_senders: &HashSet<Address>,
+        _old: Option<&ExecutionOutcome<R>>,
+        _new: &ExecutionOutcome<R>,
+        _dirty_addresses: &mut HashSet<Address>,
+    ) {
+    }
 }
 
 /// No-op implementation for chains that don't need balance augmentation.
@@ -504,6 +515,14 @@ pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
                 metrics.inc_reinserted_transactions(pruned_old_transactions.len());
                 let _ = pool.add_external_transactions(pruned_old_transactions).await;
 
+                let queued_senders = queued_senders(&pool);
+                hook.extend_reload_queued_senders(
+                    &queued_senders,
+                    Some(old_state),
+                    new_state,
+                    &mut dirty_addresses,
+                );
+
                 // keep track of new mined blob transactions
                 blob_store_tracker.add_new_chain_blocks(&new_blocks);
             }
@@ -580,6 +599,14 @@ pub async fn maintain_transaction_pool_with_hook<N, Client, P, St, Tasks, H>(
                     update_kind: PoolUpdateKind::Commit,
                 };
                 pool.on_canonical_state_change(update);
+
+                let queued_senders = queued_senders(&pool);
+                hook.extend_reload_queued_senders(
+                    &queued_senders,
+                    None,
+                    state,
+                    &mut dirty_addresses,
+                );
 
                 // keep track of mined blob transactions
                 blob_store_tracker.add_new_chain_blocks(&blocks);
@@ -687,6 +714,10 @@ where
         }
     }
     Ok(res)
+}
+
+fn queued_senders<P: TransactionPool>(pool: &P) -> HashSet<Address> {
+    pool.queued_transactions().into_iter().map(|tx| tx.sender()).collect()
 }
 
 /// Loads transactions from a file, decodes them from the JSON or RLP format, and


### PR DESCRIPTION
## Summary

Closes #381

Fixes queued transaction reloads when a block mutates a sender's USDC predeploy balance. Previously, txpool maintenance only marked senders dirty when their native account state changed, so USDC-only balance slot updates did not cause queued transactions to be re-evaluated.

---

## Changes

- `crates/transaction-pool/src/maintain.rs` — add a hook extension point for queued senders affected by off-account state updates and invoke it after commit/reorg updates.
- `crates/seismic/txpool/src/maintain.rs` — detect changed USDC balance storage slots and mark matching queued senders dirty.
- `crates/seismic/txpool/src/maintain.rs` — add regression tests for filtering affected queued senders and unioning old/new state changes across reorgs.

---

## How to Test

```bash
cargo +nightly fmt --all --check
cargo +1.88.0 test -p reth-seismic-txpool
cargo +1.88.0 check -p reth-transaction-pool -p reth-seismic-txpool
cargo +1.88.0 clippy -p reth-seismic-txpool --lib --no-deps -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic -W clippy::unreachable -W clippy::todo
```

**Results:**
- Formatting passed
- `reth-seismic-txpool` tests passed: 33 passed
- Targeted check passed
- Targeted Seismic txpool clippy passed

---

## Compatibility

No consensus, state format, wire protocol, or API compatibility impact.

---

## Checklist

- [x] Tests pass — 33/33
- [x] Formatting and clippy clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low-to-medium.** The change affects txpool maintenance only and limits reloads to queued senders whose USDC balance storage slot changed. No consensus, state format, wire protocol, or API compatibility impact.

**Type:** 🐛 Bug fix
**Closes:** #381