### PR TITLE
fix(seismic/txpool): retain EIP-4844 blob sidecars

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -48,7 +48,9 @@ use reth_rpc_eth_types::{
 use reth_rpc_server_types::RethRpcModule;
 use reth_seismic_evm::SeismicEvmConfig;
 use reth_seismic_payload_builder::SeismicBuilderConfig;
-use reth_seismic_primitives::{SeismicPrimitives, SeismicReceipt, SeismicTransactionSigned};
+use reth_seismic_primitives::{
+    SeismicPooledTransactionVariant, SeismicPrimitives, SeismicReceipt, SeismicTransactionSigned,
+};
 use reth_seismic_rpc::{
     ext::{EthApiExt, EthApiOverrideServer, SeismicApi, SeismicApiServer},
     SeismicEthApiBuilder, SeismicEthApiError, SeismicRethWithSignable,
@@ -58,7 +60,7 @@ use reth_transaction_pool::{
     CoinbaseTipOrdering, PoolTransaction, TransactionPool, TransactionValidationTaskExecutor,
 };
 use revm::context::TxEnv;
-use seismic_alloy_consensus::{SeismicTxEnvelope, SeismicTxType};
+use seismic_alloy_consensus::SeismicTxType;
 use std::{sync::Arc, time::SystemTime};
 use tracing::info;
 
@@ -748,7 +750,10 @@ impl<Node, Pool> NetworkBuilder<Node, Pool> for SeismicNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = SeismicPrimitives>>,
     Pool: TransactionPool<
-            Transaction: PoolTransaction<Consensus = TxTy<Node::Types>, Pooled = SeismicTxEnvelope>, /* equiv to op_alloy_consensus::OpPooledTransaction>, */
+            Transaction: PoolTransaction<
+                Consensus = TxTy<Node::Types>,
+                Pooled = SeismicPooledTransactionVariant,
+            >,
         > + Unpin
         + 'static,
 {
@@ -858,7 +863,7 @@ impl NetworkPrimitives for SeismicNetworkPrimitives {
     type BlockBody = alloy_consensus::BlockBody<SeismicTransactionSigned>;
     type Block = alloy_consensus::Block<SeismicTransactionSigned>;
     type BroadcastedTransaction = SeismicTransactionSigned;
-    type PooledTransaction = SeismicTxEnvelope;
+    type PooledTransaction = SeismicPooledTransactionVariant;
     type Receipt = SeismicReceipt;
     type NewBlockPayload = NewBlock<Self::Block>;
 }
@@ -869,6 +874,7 @@ mod tests {
     use alloy_eips::eip4895::{Withdrawal, Withdrawals};
     use alloy_primitives::Address;
     use alloy_rpc_types_eth::{BlockTransactions, Header};
+    use seismic_alloy_consensus::SeismicTxEnvelope;
 
     #[test]
     fn rpc_to_primitive_block_preserves_withdrawals() {

--- a/crates/seismic/node/tests/e2e/testsuite.rs
+++ b/crates/seismic/node/tests/e2e/testsuite.rs
@@ -6,6 +6,7 @@ use jsonrpsee::http_client::HttpClientBuilder;
 use reth_e2e_test_utils::transaction::TransactionTestContext;
 use reth_seismic_node::utils::e2e::ensure_mock_purpose_keys;
 use reth_seismic_rpc::ext::SeismicApiClient;
+use reth_transaction_pool::TransactionPool;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_seismic_node_info() -> Result<()> {
@@ -50,5 +51,21 @@ async fn test_seismic_produce_blocks() -> Result<()> {
     let payload = node.advance_block().await?;
     node.assert_new_block(tx_hash, payload.block().hash(), payload.block().number).await?;
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_seismic_blob_sidecar_survives_pool_ingress() -> Result<()> {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = reth_seismic_node::utils::e2e::setup(1).await?;
+    let node = nodes.pop().unwrap();
+    let raw_tx =
+        TransactionTestContext::tx_with_blobs_bytes(wallet.chain_id, wallet.inner.clone()).await?;
+
+    let tx_hash = node.rpc.inject_tx(raw_tx).await?;
+
+    assert!(node.inner.pool.get_blob(tx_hash)?.is_some());
     Ok(())
 }

--- a/crates/seismic/primitives/src/lib.rs
+++ b/crates/seismic/primitives/src/lib.rs
@@ -13,7 +13,8 @@ extern crate alloc;
 
 pub mod transaction;
 pub use transaction::{
-    signed::SeismicTransactionSigned, tx_type::SeismicTxType, SEISMIC_TX_RECENT_BLOCK_LOOKBACK,
+    signed::SeismicTransactionSigned, tx_type::SeismicTxType, SeismicPooledTransactionVariant,
+    SEISMIC_TX_RECENT_BLOCK_LOOKBACK,
 };
 
 mod receipt;

--- a/crates/seismic/primitives/src/transaction/mod.rs
+++ b/crates/seismic/primitives/src/transaction/mod.rs
@@ -1,8 +1,22 @@
 //! Seismic transaction types
 
+use alloy_consensus::{EthereumTxEnvelope, TxEip4844WithSidecar};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+use reth_primitives_traits::Extended;
+use seismic_alloy_consensus::SeismicTxEnvelope;
+
 pub mod error;
 pub mod signed;
 pub mod tx_type;
+
+/// Network representation for transactions accepted by the Seismic transaction pool.
+///
+/// Ethereum transaction types use the standard pooled envelope so EIP-4844 transactions retain
+/// their sidecars. The non-overlapping `Other` branch is reserved for Seismic transactions.
+pub type SeismicPooledTransactionVariant = Extended<
+    EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>,
+    SeismicTxEnvelope,
+>;
 
 /// Defines how recent [`recent_block_hash`] must be for a signed seismic transaction to count as
 /// fresh.

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -2,9 +2,10 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::{
+    error::ValueError,
     transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx},
-    SignableTransaction, Signed, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy,
-    Typed2718,
+    EthereumTxEnvelope, SignableTransaction, Signed, Transaction, TxEip1559, TxEip2930, TxEip4844,
+    TxEip7702, TxLegacy, Typed2718,
 };
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
@@ -26,7 +27,7 @@ use reth_primitives_traits::{
     crypto::secp256k1::{recover_signer, recover_signer_unchecked},
     sync::OnceLock,
     transaction::signed::RecoveryError,
-    InMemorySize, SignedTransaction, SignerRecoverable,
+    Extended, InMemorySize, SignedTransaction, SignerRecoverable,
 };
 use revm_context::TxEnv;
 use seismic_alloy_consensus::{
@@ -37,6 +38,8 @@ use seismic_revm::SeismicTransaction;
 
 // Seismic imports, not used by upstream
 use alloy_evm::FromTxWithEncoded;
+
+use super::SeismicPooledTransactionVariant;
 
 /// Signed transaction.
 ///
@@ -176,6 +179,46 @@ impl From<SeismicTransactionSigned> for SeismicTxEnvelope {
             SeismicTypedTransaction::Eip7702(tx) => {
                 Signed::new_unchecked(tx, signature, hash).into()
             }
+        }
+    }
+}
+
+impl From<SeismicPooledTransactionVariant> for SeismicTransactionSigned {
+    fn from(value: SeismicPooledTransactionVariant) -> Self {
+        match value {
+            Extended::BuiltIn(tx) => match tx {
+                EthereumTxEnvelope::Legacy(tx) => tx.into(),
+                EthereumTxEnvelope::Eip2930(tx) => tx.into(),
+                EthereumTxEnvelope::Eip1559(tx) => tx.into(),
+                EthereumTxEnvelope::Eip4844(tx) => {
+                    let (tx, signature, hash) = tx.into_parts();
+                    let (tx, _sidecar) = tx.into_parts();
+                    Self::new(SeismicTypedTransaction::Eip4844(tx), signature, hash)
+                }
+                EthereumTxEnvelope::Eip7702(tx) => tx.into(),
+            },
+            Extended::Other(tx) => tx.into(),
+        }
+    }
+}
+
+impl TryFrom<SeismicTransactionSigned> for SeismicPooledTransactionVariant {
+    type Error = ValueError<SeismicTransactionSigned>;
+
+    fn try_from(value: SeismicTransactionSigned) -> Result<Self, Self::Error> {
+        let envelope: SeismicTxEnvelope = value.into();
+        match envelope {
+            // Ethereum types are always represented by `BuiltIn`, matching `Extended`'s decoder
+            // dispatch and keeping its two branches non-overlapping.
+            SeismicTxEnvelope::Legacy(tx) => Ok(Self::BuiltIn(EthereumTxEnvelope::Legacy(tx))),
+            SeismicTxEnvelope::Eip2930(tx) => Ok(Self::BuiltIn(EthereumTxEnvelope::Eip2930(tx))),
+            SeismicTxEnvelope::Eip1559(tx) => Ok(Self::BuiltIn(EthereumTxEnvelope::Eip1559(tx))),
+            SeismicTxEnvelope::Eip7702(tx) => Ok(Self::BuiltIn(EthereumTxEnvelope::Eip7702(tx))),
+            SeismicTxEnvelope::Seismic(tx) => Ok(Self::Other(SeismicTxEnvelope::Seismic(tx))),
+            SeismicTxEnvelope::Eip4844(tx) => Err(ValueError::new_static(
+                SeismicTransactionSigned::from(SeismicTxEnvelope::Eip4844(tx)),
+                "pooled transaction requires 4844 sidecar",
+            )),
         }
     }
 }

--- a/crates/seismic/txpool/src/transaction.rs
+++ b/crates/seismic/txpool/src/transaction.rs
@@ -1,4 +1,7 @@
-use alloy_consensus::{transaction::Recovered, BlobTransactionValidationError, Typed2718};
+use alloy_consensus::{
+    error::ValueError, transaction::Recovered, BlobTransactionValidationError, EthereumTxEnvelope,
+    Signed, Typed2718,
+};
 use alloy_eips::{
     eip2930::AccessList, eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization,
     Encodable2718,
@@ -6,17 +9,20 @@ use alloy_eips::{
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
 use c_kzg::KzgSettings;
 use core::fmt::Debug;
-use reth_primitives_traits::{InMemorySize, SignedTransaction};
-use reth_seismic_primitives::SeismicTransactionSigned;
+use reth_primitives_traits::{Extended, InMemorySize, SignedTransaction};
+use reth_seismic_primitives::{SeismicPooledTransactionVariant, SeismicTransactionSigned};
 use reth_transaction_pool::{
     EthBlobTransactionSidecar, EthPoolTransaction, EthPooledTransaction, PoolTransaction,
 };
-use seismic_alloy_consensus::SeismicTxEnvelope;
+use seismic_alloy_consensus::SeismicTypedTransaction;
 use std::sync::Arc;
 
 /// Pool Transaction for Seismic.
 #[derive(Debug, Clone, derive_more::Deref)]
-pub struct SeismicPooledTransaction<Cons = SeismicTransactionSigned, Pooled = SeismicTxEnvelope> {
+pub struct SeismicPooledTransaction<
+    Cons = SeismicTransactionSigned,
+    Pooled = SeismicPooledTransactionVariant,
+> {
     #[deref]
     inner: EthPooledTransaction<Cons>,
     /// The pooled transaction type.
@@ -33,14 +39,10 @@ impl<Cons: SignedTransaction, Pooled> SeismicPooledTransaction<Cons, Pooled> {
     }
 }
 
-impl<Cons, Pooled> PoolTransaction for SeismicPooledTransaction<Cons, Pooled>
-where
-    Cons: SignedTransaction + From<Pooled>,
-    Pooled: SignedTransaction + TryFrom<Cons, Error: core::error::Error>,
-{
-    type TryFromConsensusError = <Pooled as TryFrom<Cons>>::Error;
-    type Consensus = Cons;
-    type Pooled = Pooled;
+impl PoolTransaction for SeismicPooledTransaction {
+    type TryFromConsensusError = ValueError<SeismicTransactionSigned>;
+    type Consensus = SeismicTransactionSigned;
+    type Pooled = SeismicPooledTransactionVariant;
 
     fn hash(&self) -> &TxHash {
         self.inner.transaction.tx_hash()
@@ -72,7 +74,22 @@ where
 
     fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
         let encoded_len = tx.encode_2718_len();
-        Self::new(tx.convert(), encoded_len)
+        let (tx, signer) = tx.into_parts();
+        match tx {
+            Extended::BuiltIn(EthereumTxEnvelope::Eip4844(tx)) => {
+                let (tx, signature, hash) = tx.into_parts();
+                let (tx, blob) = tx.into_parts();
+                let tx = SeismicTransactionSigned::from(Signed::new_unchecked(tx, signature, hash));
+                let tx = Recovered::new_unchecked(tx, signer);
+                let mut pooled = Self::new(tx, encoded_len);
+                pooled.inner.blob_sidecar = EthBlobTransactionSidecar::Present(blob);
+                pooled
+            }
+            tx => {
+                let tx = Recovered::new_unchecked(tx.into(), signer);
+                Self::new(tx, encoded_len)
+            }
+        }
     }
 }
 
@@ -147,37 +164,54 @@ where
     }
 }
 
-impl<Cons, Pooled> EthPoolTransaction for SeismicPooledTransaction<Cons, Pooled>
-where
-    Cons: SignedTransaction + From<Pooled>,
-    Pooled: SignedTransaction + TryFrom<Cons>,
-    <Pooled as TryFrom<Cons>>::Error: core::error::Error,
-{
+impl EthPoolTransaction for SeismicPooledTransaction {
     fn take_blob(&mut self) -> EthBlobTransactionSidecar {
-        EthBlobTransactionSidecar::None
+        if self.is_eip4844() {
+            std::mem::replace(&mut self.inner.blob_sidecar, EthBlobTransactionSidecar::Missing)
+        } else {
+            EthBlobTransactionSidecar::None
+        }
     }
 
     fn try_into_pooled_eip4844(
         self,
-        _sidecar: Arc<BlobTransactionSidecarVariant>,
+        sidecar: Arc<BlobTransactionSidecarVariant>,
     ) -> Option<Recovered<Self::Pooled>> {
-        None
+        let (tx, signer) = self.into_consensus().into_parts();
+        attach_blob_sidecar(tx, Arc::unwrap_or_clone(sidecar))
+            .map(|tx| Recovered::new_unchecked(tx, signer))
     }
 
     fn try_from_eip4844(
-        _tx: Recovered<Self::Consensus>,
-        _sidecar: BlobTransactionSidecarVariant,
+        tx: Recovered<Self::Consensus>,
+        sidecar: BlobTransactionSidecarVariant,
     ) -> Option<Self> {
-        None
+        let (tx, signer) = tx.into_parts();
+        attach_blob_sidecar(tx, sidecar)
+            .map(|tx| Recovered::new_unchecked(tx, signer))
+            .map(Self::from_pooled)
     }
 
     fn validate_blob(
         &self,
-        _sidecar: &BlobTransactionSidecarVariant,
-        _settings: &KzgSettings,
+        sidecar: &BlobTransactionSidecarVariant,
+        settings: &KzgSettings,
     ) -> Result<(), BlobTransactionValidationError> {
-        Err(BlobTransactionValidationError::NotBlobTransaction(self.ty()))
+        match self.inner.transaction.inner().transaction() {
+            SeismicTypedTransaction::Eip4844(tx) => tx.validate_blob(sidecar, settings),
+            _ => Err(BlobTransactionValidationError::NotBlobTransaction(self.ty())),
+        }
     }
+}
+
+fn attach_blob_sidecar(
+    tx: SeismicTransactionSigned,
+    sidecar: BlobTransactionSidecarVariant,
+) -> Option<SeismicPooledTransactionVariant> {
+    let (tx, signature, hash) = tx.into_parts();
+    let SeismicTypedTransaction::Eip4844(tx) = tx else { return None };
+    let tx = Signed::new_unchecked(tx.with_sidecar(sidecar), signature, hash);
+    Some(Extended::BuiltIn(EthereumTxEnvelope::Eip4844(tx)))
 }
 
 #[cfg(test)]
@@ -186,17 +220,91 @@ where
 #[allow(clippy::panic)] // Test code - panic on failure is acceptable
 mod tests {
     use crate::SeismicPooledTransaction;
-    use alloy_consensus::transaction::Recovered;
-    use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::B256;
-    use reth_primitives_traits::transaction::error::InvalidTransactionError;
+    use alloy_consensus::{
+        transaction::Recovered, EthereumTxEnvelope, Signed, TxEip1559, TxEip4844,
+    };
+    use alloy_eips::{
+        eip2718::Encodable2718, eip4844::BlobTransactionSidecar,
+        eip7594::BlobTransactionSidecarVariant,
+    };
+    use alloy_primitives::{Address, Signature, B256, U256};
+    use reth_primitives_traits::{transaction::error::InvalidTransactionError, Extended};
     use reth_provider::test_utils::MockEthProvider;
     use reth_seismic_chainspec::SEISMIC_MAINNET;
+    use reth_seismic_primitives::{SeismicPooledTransactionVariant, SeismicTransactionSigned};
     use reth_seismic_test_utils::get_signed_seismic_tx;
     use reth_transaction_pool::{
         blobstore::InMemoryBlobStore, error::InvalidPoolTransactionError,
-        validate::EthTransactionValidatorBuilder, TransactionOrigin, TransactionValidationOutcome,
+        validate::EthTransactionValidatorBuilder, EthBlobTransactionSidecar, EthPoolTransaction,
+        PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
     };
+    use seismic_alloy_consensus::SeismicTxEnvelope;
+    use std::sync::Arc;
+
+    fn pooled_blob_transaction() -> (SeismicPooledTransactionVariant, BlobTransactionSidecarVariant)
+    {
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::default());
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let tx = TxEip4844::default().with_sidecar(sidecar.clone());
+        let tx = Signed::new_unchecked(tx, signature, B256::repeat_byte(3));
+        (Extended::BuiltIn(EthereumTxEnvelope::Eip4844(tx)), sidecar)
+    }
+
+    #[test]
+    fn pooled_conversion_uses_non_overlapping_branches() {
+        let seismic = get_signed_seismic_tx(B256::ZERO);
+        let pooled = SeismicPooledTransactionVariant::try_from(seismic.clone())
+            .expect("seismic transaction should be poolable");
+        assert!(matches!(&pooled, Extended::Other(SeismicTxEnvelope::Seismic(_))));
+        assert_eq!(SeismicTransactionSigned::from(pooled), seismic);
+
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let ethereum = SeismicTransactionSigned::from(Signed::new_unchecked(
+            TxEip1559::default(),
+            signature,
+            B256::repeat_byte(1),
+        ));
+        let pooled = SeismicPooledTransactionVariant::try_from(ethereum.clone())
+            .expect("EIP-1559 transaction should be poolable");
+        assert!(matches!(&pooled, Extended::BuiltIn(EthereumTxEnvelope::Eip1559(_))));
+        assert_eq!(SeismicTransactionSigned::from(pooled), ethereum);
+    }
+
+    #[test]
+    fn consensus_eip4844_requires_sidecar_for_pooled_conversion() {
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let consensus = SeismicTransactionSigned::from(Signed::new_unchecked(
+            TxEip4844::default(),
+            signature,
+            B256::repeat_byte(3),
+        ));
+
+        let err = SeismicPooledTransactionVariant::try_from(consensus.clone())
+            .expect_err("consensus EIP-4844 transaction must not pool without a sidecar");
+        assert_eq!(err.into_value(), consensus);
+    }
+
+    #[test]
+    fn pooled_blob_sidecar_is_stripped_and_retained() {
+        let (tx, sidecar) = pooled_blob_transaction();
+        let encoded_length = tx.encode_2718_len();
+        let recovered = Recovered::new_unchecked(tx, Address::repeat_byte(1));
+        let mut pooled = SeismicPooledTransaction::from_pooled(recovered);
+
+        assert_eq!(pooled.encoded_length(), encoded_length);
+        assert!(encoded_length > pooled.clone_into_consensus().encode_2718_len());
+        let repropagated = pooled
+            .clone()
+            .try_into_pooled_eip4844(Arc::new(sidecar.clone()))
+            .expect("blob sidecar should reattach for propagation");
+        assert_eq!(repropagated.encode_2718_len(), encoded_length);
+        assert_eq!(pooled.take_blob(), EthBlobTransactionSidecar::Present(sidecar.clone()));
+
+        let consensus = pooled.clone_into_consensus();
+        let mut reattached = SeismicPooledTransaction::try_from_eip4844(consensus, sidecar.clone())
+            .expect("consensus blob transaction should accept a sidecar");
+        assert_eq!(reattached.take_blob(), EthBlobTransactionSidecar::Present(sidecar));
+    }
 
     #[tokio::test]
     async fn validate_seismic_transaction() {


### PR DESCRIPTION
## Problem

Seismic used the consensus-only `SeismicTxEnvelope<TxEip4844>` as its pooled/network transaction type. That envelope cannot decode the EIP-4844 network wrapper containing a blob sidecar. A valid blob transaction submitted through `eth_sendRawTransaction` was therefore rejected before pool validation, and the existing stubbed blob methods could not retain a sidecar for validation, propagation, or reorg recovery.

### Reproduction

1. Start a `SeismicNode` with the canonical E2E setup (Cancun is active from genesis).
2. Build a valid signed EIP-4844 pooled transaction with `TransactionTestContext::tx_with_blobs_bytes`.
3. Submit the encoded bytes through `node.rpc.inject_tx`, the raw transaction ingress used by `eth_sendRawTransaction`.
4. Query the pool blob store for the returned transaction hash.

On base `39d04d158da383324b12c2e3397b0b28f3c3ee36`, step 3 fails with `failed to decode signed transaction`. The expected behavior is successful admission with the sidecar available from the pool blob store.

The automated regression is:

```console
cargo test -p reth-seismic-node --test e2e testsuite::test_seismic_blob_sidecar_survives_pool_ingress -- --exact --nocapture
```

## Why it matters

On a Cancun-active Seismic node, otherwise valid EIP-4844 transactions cannot enter the pool through normal raw transaction submission. This prevents their inclusion and leaves the sidecar unavailable to the existing validation, propagation, and reorg paths.

## Fix

- add a pooled Seismic transaction representation that carries Ethereum EIP-4844 sidecars while keeping the consensus envelope sidecar-free
- preserve strict Seismic `0x4a` decoding in the extension branch
- extract and validate sidecars during pool admission, then reattach them for propagation and reorg recovery
- wire the node's network primitives to the pooled representation and retain the full pooled wire length

## Tests

- `cargo test -p reth-seismic-node --test e2e testsuite::test_seismic_blob_sidecar_survives_pool_ingress -- --exact --nocapture` — pass
- `cargo test -p reth-seismic-node --test e2e testsuite::test_seismic_produce_blocks -- --exact --nocapture` — pass
- `cargo test -p reth-seismic-node --test e2e integration::test_seismic_reth_rpc -- --exact --nocapture` — pass
- `cargo test -p reth-seismic-txpool` — pass
- `cargo check -p reth-seismic-node` — pass
- `cargo check --workspace` — pass
- `RUSTFLAGS='-D warnings' cargo check` — pass
- `cargo clippy -p 'reth-seismic*' -p 'seismic-reth*' --lib --tests --no-deps -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic -W clippy::unreachable -W clippy::todo` — pass
- `cargo +nightly fmt --all --check` — pass
- `git diff --check` — pass

Full nextest, MSRV 1.88, pinned workspace Clippy 1.91.1, dprint, and zepter were not available locally; GitHub CI will cover those jobs.

## Risk

The change is limited to network/pool representation and sidecar lifecycle handling. Consensus encoding, chain specifications, dependency pins, and vendored code are unchanged. Existing EIP-1559 and Seismic `0x4a` E2E flows pass unchanged.
