### PR TITLE
fix(seismic-rpc): populate blobGasPrice in EIP-4844 receipts

### DIFF
--- a/crates/seismic/rpc/Cargo.toml
+++ b/crates/seismic/rpc/Cargo.toml
@@ -24,6 +24,7 @@ alloy-sol-types.workspace = true
 
 # reth
 reth-evm.workspace = true
+reth-chainspec.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-network-api.workspace = true
@@ -73,7 +74,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 reth-seismic-chainspec.workspace = true
-reth-chainspec.workspace = true
 reth-consensus.workspace = true
 reth-storage-errors.workspace = true
 reth-evm-ethereum.workspace = true

--- a/crates/seismic/rpc/src/eth/mod.rs
+++ b/crates/seismic/rpc/src/eth/mod.rs
@@ -20,6 +20,7 @@ use alloy_eips::BlockId;
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::AccountInfo;
 use futures::Future;
+use reth_chainspec::ChainSpecProvider;
 use reth_evm::{ConfigureEvm, SpecFor, TxEnvFor};
 use reth_node_api::{FullNodeComponents, HeaderTy};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
@@ -440,7 +441,8 @@ where
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
         let ops_whitelist = ctx.ops_whitelist.clone();
-        let receipt_converter = SeismicReceiptConverter::new();
+        let receipt_converter =
+            SeismicReceiptConverter::new(ctx.components.provider().chain_spec());
 
         let rpc_converter: SeismicRpcConvert<N, NetworkT> = RpcConverter::new(receipt_converter)
             .with_sim_tx_converter(SeismicSimTxConverter::new())

--- a/crates/seismic/rpc/src/eth/receipt.rs
+++ b/crates/seismic/rpc/src/eth/receipt.rs
@@ -1,6 +1,8 @@
 //! Loads and formats Seismic receipt RPC response.
 
 use alloy_consensus::Typed2718;
+use alloy_eips::eip7840::BlobParams;
+use reth_chainspec::EthChainSpec;
 use reth_rpc_convert::transaction::{ConvertReceiptInput, ReceiptConverter};
 use reth_rpc_eth_api::{helpers::LoadReceipt, RpcConvert, RpcNodeCore};
 use reth_rpc_eth_types::{receipt::build_receipt, EthApiError};
@@ -8,7 +10,7 @@ use reth_rpc_server_types::result::internal_rpc_err;
 use reth_seismic_primitives::{SeismicPrimitives, SeismicReceipt};
 use seismic_alloy_consensus::SeismicReceiptEnvelope;
 use seismic_alloy_rpc_types::SeismicTransactionReceipt;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use crate::{SeismicEthApi, SeismicEthApiError};
 
@@ -30,7 +32,10 @@ pub struct SeismicReceiptBuilder {
 
 impl SeismicReceiptBuilder {
     /// Returns a new builder.
-    pub fn new(input: ConvertReceiptInput<'_, SeismicPrimitives>) -> Result<Self, EthApiError> {
+    pub fn new(
+        input: ConvertReceiptInput<'_, SeismicPrimitives>,
+        blob_params: Option<BlobParams>,
+    ) -> Result<Self, EthApiError> {
         // The receipt and its transaction must agree on the transaction type.
         let receipt_ty = input.receipt.tx_type() as u8;
         let tx_ty = input.tx.ty();
@@ -40,14 +45,15 @@ impl SeismicReceiptBuilder {
             ))));
         }
 
-        let base = build_receipt(&input, None, |receipt_with_bloom| match input.receipt.as_ref() {
-            SeismicReceipt::Legacy(_) => SeismicReceiptEnvelope::Legacy(receipt_with_bloom),
-            SeismicReceipt::Eip2930(_) => SeismicReceiptEnvelope::Eip2930(receipt_with_bloom),
-            SeismicReceipt::Eip1559(_) => SeismicReceiptEnvelope::Eip1559(receipt_with_bloom),
-            SeismicReceipt::Eip7702(_) => SeismicReceiptEnvelope::Eip7702(receipt_with_bloom),
-            SeismicReceipt::Seismic(_) => SeismicReceiptEnvelope::Seismic(receipt_with_bloom),
-            SeismicReceipt::Eip4844(_) => SeismicReceiptEnvelope::Eip4844(receipt_with_bloom),
-        });
+        let base =
+            build_receipt(&input, blob_params, |receipt_with_bloom| match input.receipt.as_ref() {
+                SeismicReceipt::Legacy(_) => SeismicReceiptEnvelope::Legacy(receipt_with_bloom),
+                SeismicReceipt::Eip2930(_) => SeismicReceiptEnvelope::Eip2930(receipt_with_bloom),
+                SeismicReceipt::Eip1559(_) => SeismicReceiptEnvelope::Eip1559(receipt_with_bloom),
+                SeismicReceipt::Eip7702(_) => SeismicReceiptEnvelope::Eip7702(receipt_with_bloom),
+                SeismicReceipt::Seismic(_) => SeismicReceiptEnvelope::Seismic(receipt_with_bloom),
+                SeismicReceipt::Eip4844(_) => SeismicReceiptEnvelope::Eip4844(receipt_with_bloom),
+            });
 
         Ok(Self { base })
     }
@@ -59,20 +65,33 @@ impl SeismicReceiptBuilder {
     }
 }
 
-/// Seismic receipt converter.
-#[derive(Debug, Clone)]
-pub struct SeismicReceiptConverter;
+trait BlobParamsProvider: Debug + Send + Sync {
+    fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams>;
+}
 
-impl Default for SeismicReceiptConverter {
-    fn default() -> Self {
-        Self::new()
+impl<ChainSpec> BlobParamsProvider for ChainSpec
+where
+    ChainSpec: EthChainSpec,
+{
+    fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {
+        EthChainSpec::blob_params_at_timestamp(self, timestamp)
     }
 }
 
+/// Seismic receipt converter.
+#[derive(Debug, Clone)]
+pub struct SeismicReceiptConverter {
+    // Erase the chain spec type to keep the public RPC converter alias non-generic.
+    chain_spec: Arc<dyn BlobParamsProvider>,
+}
+
 impl SeismicReceiptConverter {
-    /// Creates a new seismic receipt converter.
-    pub const fn new() -> Self {
-        Self
+    /// Creates a new seismic receipt converter with the given chain spec.
+    pub fn new<ChainSpec>(chain_spec: Arc<ChainSpec>) -> Self
+    where
+        ChainSpec: EthChainSpec + 'static,
+    {
+        Self { chain_spec }
     }
 }
 
@@ -84,14 +103,23 @@ impl ReceiptConverter<SeismicPrimitives> for SeismicReceiptConverter {
         &self,
         inputs: Vec<ConvertReceiptInput<'_, SeismicPrimitives>>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
-        inputs
-            .into_iter()
-            .map(|input| {
-                SeismicReceiptBuilder::new(input)
-                    .map_err(SeismicEthApiError::Eth)
-                    .map(|builder| builder.build())
-            })
-            .collect()
+        let mut receipts = Vec::with_capacity(inputs.len());
+
+        for input in inputs {
+            let timestamp_seconds = if cfg!(feature = "timestamp-in-seconds") {
+                input.meta.timestamp
+            } else {
+                input.meta.timestamp / 1000
+            };
+            let blob_params = self.chain_spec.blob_params_at_timestamp(timestamp_seconds);
+            receipts.push(
+                SeismicReceiptBuilder::new(input, blob_params)
+                    .map_err(SeismicEthApiError::Eth)?
+                    .build(),
+            );
+        }
+
+        Ok(receipts)
     }
 }
 
@@ -100,10 +128,14 @@ mod tests {
     use super::*;
     use alloy_consensus::{
         transaction::{Recovered, TransactionMeta},
-        Eip658Value, Receipt,
+        Eip658Value, Receipt, TxEip4844,
     };
-    use alloy_primitives::{Address, B256};
+    use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
+    use alloy_primitives::{Address, Signature, B256, U256};
+    use reth_seismic_chainspec::SEISMIC_MAINNET;
+    use reth_seismic_primitives::SeismicTransactionSigned;
     use reth_seismic_test_utils::get_signed_seismic_tx;
+    use seismic_alloy_consensus::SeismicTypedTransaction;
     use std::borrow::Cow;
 
     #[test]
@@ -122,6 +154,72 @@ mod tests {
             next_log_index: 0,
             meta: TransactionMeta::default(),
         };
-        assert!(SeismicReceiptBuilder::new(input).is_err());
+        assert!(SeismicReceiptBuilder::new(input, None).is_err());
+    }
+
+    #[test]
+    fn eip4844_receipt_includes_blob_gas_price() {
+        const EXCESS_BLOB_GAS: u64 = 10_000_000;
+
+        let mut versioned_hash = [0u8; 32];
+        versioned_hash[0] = VERSIONED_HASH_VERSION_KZG;
+        let tx = SeismicTransactionSigned::new_unhashed(
+            SeismicTypedTransaction::Eip4844(TxEip4844 {
+                blob_versioned_hashes: vec![B256::from(versioned_hash)],
+                ..Default::default()
+            }),
+            Signature::new(U256::from(1), U256::from(1), false),
+        );
+        let receipt = SeismicReceipt::Eip4844(Receipt {
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+            logs: Vec::new(),
+        });
+        let input = ConvertReceiptInput {
+            receipt: Cow::Owned(receipt),
+            tx: Recovered::new_unchecked(&tx, Address::ZERO),
+            gas_used: 0,
+            next_log_index: 0,
+            meta: TransactionMeta { excess_blob_gas: Some(EXCESS_BLOB_GAS), ..Default::default() },
+        };
+
+        let rpc_receipt = SeismicReceiptConverter::new(SEISMIC_MAINNET.clone())
+            .convert_receipts(vec![input])
+            .unwrap()
+            .pop()
+            .unwrap();
+        let expected_blob_gas_price =
+            EthChainSpec::blob_params_at_timestamp(SEISMIC_MAINNET.as_ref(), 0)
+                .unwrap()
+                .calc_blob_fee(EXCESS_BLOB_GAS);
+
+        assert_eq!(rpc_receipt.blob_gas_price, Some(expected_blob_gas_price));
+        assert_eq!(rpc_receipt.blob_gas_used, Some(DATA_GAS_PER_BLOB));
+    }
+
+    #[test]
+    fn non_blob_receipt_omits_blob_gas_fields() {
+        let tx = get_signed_seismic_tx(B256::ZERO);
+        let receipt = SeismicReceipt::Seismic(Receipt {
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+            logs: Vec::new(),
+        });
+        let input = ConvertReceiptInput {
+            receipt: Cow::Owned(receipt),
+            tx: Recovered::new_unchecked(&tx, Address::ZERO),
+            gas_used: 0,
+            next_log_index: 0,
+            meta: TransactionMeta { excess_blob_gas: Some(10_000_000), ..Default::default() },
+        };
+
+        let rpc_receipt = SeismicReceiptConverter::new(SEISMIC_MAINNET.clone())
+            .convert_receipts(vec![input])
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(rpc_receipt.blob_gas_price, None);
+        assert_eq!(rpc_receipt.blob_gas_used, None);
     }
 }


### PR DESCRIPTION
## Summary

- give the Seismic receipt converter access to the node's configured chain spec
- select the active EIP-4844 blob parameters at the receipt block timestamp
- populate `blobGasPrice` for blob-transaction receipts while preserving non-blob behavior

## Impact

`eth_getTransactionReceipt` returned `blobGasUsed` for EIP-4844 transactions but omitted `blobGasPrice`. This made Seismic's receipt response incomplete for wallets, indexers, and fee-accounting clients that need the actual blob fee paid.

The [Ethereum Execution API receipt schema](https://github.com/ethereum/execution-apis/blob/main/src/schemas/receipt.yaml) specifies `blobGasPrice` for EIP-4844 transactions.

## Root cause

`SeismicReceiptBuilder` always called the shared `build_receipt` helper with `None` for blob parameters. The helper therefore could not calculate a price from the block's `excessBlobGas`, even when the transaction was an EIP-4844 blob transaction.

This change mirrors the fork-aware Ethereum receipt converter: it normalizes the receipt timestamp, resolves the active `BlobParams` from the configured chain spec, and passes them to `build_receipt`.

## Reproduction

On base commit `39d04d158da383324b12c2e3397b0b28f3c3ee36`:

1. Build a `ConvertReceiptInput` containing an EIP-4844 transaction with one KZG-versioned blob hash.
2. Set `TransactionMeta::excess_blob_gas` to `Some(10_000_000)` and use the Seismic mainnet chain spec, where Cancun/Prague are active at genesis.
3. Convert the receipt and inspect its RPC blob fields.

Before the fix, `blob_gas_used` is present but `blob_gas_price` is `None`. The regression test added by this PR was first run against that base and failed with:

```text
assertion failed: rpc_receipt.blob_gas_price.is_some()
```

The focused reproduction now passes:

```bash
cargo test -p reth-seismic-rpc eth::receipt::tests::eip4844_receipt_includes_blob_gas_price -- --exact --nocapture
```

The test asserts both the exact fork-calculated blob gas price and one blob's `DATA_GAS_PER_BLOB` usage. A companion test verifies that non-blob receipts still omit both blob fields.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo test -p reth-seismic-rpc`
- `cargo test -p reth-seismic-rpc --features timestamp-in-seconds eth::receipt::tests -- --nocapture`
- `cargo check --workspace`
- `RUSTFLAGS="-D warnings" cargo check`
- Seismic CI's strict clippy command for `reth-seismic*` and `seismic-reth*` packages

## Scope

This is independent of #469 (Engine payload blob fee environment) and #486 (txpool blob sidecar retention). It only changes RPC receipt conversion and does not modify txpool, payload building, or consensus behavior.
