### PR TITLE
fix(seismic/evm): preserve EIP-7702 authorizations in block execution

### DIFF
--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -198,7 +198,12 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
             SeismicTypedTransaction::Eip1559(tx) => TxEnv::from_recovered_tx(tx, sender),
             SeismicTypedTransaction::Eip4844(tx) => TxEnv::from_recovered_tx(tx, sender),
             SeismicTypedTransaction::Eip7702(tx) => TxEnv::from_recovered_tx(tx, sender),
-            SeismicTypedTransaction::Seismic(tx) => TxEnv::from_recovered_tx(tx, sender),
+            SeismicTypedTransaction::Seismic(tx) => {
+                let mut tx_env = TxEnv::from_recovered_tx(tx, sender);
+                // The base `TxSeismic` conversion omits its EIP-7702 authorization list.
+                tx_env.set_signed_authorization(tx.authorization_list.clone());
+                tx_env
+            }
         };
         let tx = Self { base, tx_hash, decryption_failed: false };
         tracing::debug!("from_recovered_tx: tx: {:?}", tx);
@@ -724,13 +729,15 @@ pub mod serde_bincode_compat {
 mod tests {
     use core::str::FromStr;
 
-    use reth_seismic_test_utils::{get_signed_seismic_tx, get_signing_private_key};
+    use reth_seismic_test_utils::{get_seismic_tx, get_signed_seismic_tx, get_signing_private_key};
 
     use super::*;
+    use alloy_eips::eip7702::Authorization;
     use alloy_primitives::{aliases::U96, hex, U256};
     use proptest::proptest;
     use proptest_arbitrary_interop::arb;
     use reth_codecs::Compact;
+    use revm_context::either::Either;
     use secp256k1::PublicKey;
     use seismic_alloy_consensus::SeismicTxType;
     use seismic_revm::transaction::abstraction::SeismicTxTr;
@@ -743,6 +750,27 @@ mod tests {
         let expected_signer = Address::from_private_key(&get_signing_private_key());
 
         assert_eq!(recovered_signer, expected_signer);
+    }
+
+    #[test]
+    fn seismic_tx_env_preserves_authorization_list() {
+        let sender = Address::with_last_byte(1);
+        let authorization = Authorization {
+            chain_id: U256::from(5123),
+            address: Address::with_last_byte(2),
+            nonce: 3,
+        }
+        .into_signed(Signature::new(U256::from(1), U256::from(1), false));
+        let mut tx = get_seismic_tx(sender, B256::ZERO);
+        tx.authorization_list.push(authorization.clone());
+        let signed = SeismicTransactionSigned::new_unhashed(
+            SeismicTypedTransaction::Seismic(tx),
+            Signature::new(U256::from(2), U256::from(2), false),
+        );
+
+        let recovered = SeismicTransaction::<TxEnv>::from_recovered_tx(&signed, sender);
+
+        assert_eq!(recovered.base.authorization_list, vec![Either::Left(authorization)]);
     }
 
     /// Build the EIP-2718 bytes of a signed seismic tx with the given `signed_read`/`to`.


### PR DESCRIPTION
## Problem

`TxSeismic` carries signed EIP-7702 authorizations, but its production conversion from `SeismicTransactionSigned` to `SeismicTransaction<TxEnv>` loses them. The delegated `TxSeismic` conversion initializes omitted fields from `TxEnv::default()`, leaving `authorization_list` empty.

This differs from the RPC simulation path, which copies the same list into `TxEnv`.

### Reproduction

1. Build a `TxSeismic` with one `SignedAuthorization`.
2. Wrap it in `SeismicTransactionSigned` and call the production `FromRecoveredTx` conversion.
3. Inspect `recovered.base.authorization_list`.

On base commit `39d04d158da383324b12c2e3397b0b28f3c3ee36`, the regression fails because the converted list is empty:

```text
left: []
right: [Left(SignedAuthorization { ... })]
```

## Why it matters

Payload construction and block import execute the converted environment. With an empty list, EIP-7702 pre-execution returns early, the signed delegations are not applied, and intrinsic authorization gas is calculated from zero entries. A transaction can therefore simulate with delegation semantics but execute in a block without them.

## Fix

Populate the converted Seismic `TxEnv` with the transaction's signed authorization list using `set_signed_authorization`. Other transaction variants are unchanged.

The regression asserts that the complete signed authorization survives the production conversion, including its signed representation.

## Tests

- `cargo test -p reth-seismic-primitives --features arbitrary,reth-codec seismic_tx_env_preserves_authorization_list --locked -- --nocapture`
- `cargo test -p reth-seismic-primitives --features arbitrary,reth-codec --locked`
- `cargo check -p reth-seismic-node --locked`
- `cargo check --workspace`
- `RUSTFLAGS="-D warnings" cargo check`
- `cargo clippy -p 'reth-seismic*' -p 'seismic-reth*' --lib --tests --no-deps -- -D warnings -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic -W clippy::unreachable -W clippy::todo`
- `cargo +nightly fmt --all --check`

The MSRV 1.88 build, pinned workspace clippy 1.91.1, `dprint`, `zepter`, and workspace `nextest` lanes were not run locally because those toolchains/binaries are not installed; GitHub CI will run them. This change does not touch Cargo metadata, TOML, dependencies, or genesis files.

## Risk

The change is limited to the Seismic transaction-to-EVM boundary and does not alter wire encoding, signatures, storage, or other transaction types. Keeping authorizations signed matches the existing RPC path; revm recovers them during EIP-7702 pre-execution.
