### PR TITLE
fix(seismic/cli): preserve hardforks for genesis files

### DIFF
--- a/crates/seismic/chainspec/src/lib.rs
+++ b/crates/seismic/chainspec/src/lib.rs
@@ -33,6 +33,24 @@ const fn normalize_genesis(mut genesis: Genesis) -> Genesis {
     genesis
 }
 
+/// Builds a [`ChainSpec`] for a custom Seismic [`Genesis`].
+///
+/// Genesis-configured fields are retained, while the hardfork schedule and merge metadata use the
+/// canonical settings shared by all Seismic networks.
+pub fn seismic_chain_spec_from_genesis(genesis: Genesis) -> ChainSpec {
+    // All Seismic networks currently share the same canonical hardfork schedule.
+    let hardforks = SEISMIC_DEV_HARDFORKS.clone();
+    let genesis_hash = make_genesis_header(&genesis, &hardforks).hash_slow();
+    let genesis = normalize_genesis(genesis);
+    let mut chain_spec: ChainSpec = genesis.into();
+
+    chain_spec.genesis_header =
+        SealedHeader::new(make_genesis_header(&chain_spec.genesis, &hardforks), genesis_hash);
+    chain_spec.paris_block_and_final_difficulty = Some((0, U256::ZERO));
+    chain_spec.hardforks = hardforks;
+    chain_spec
+}
+
 /// Genesis hash for the Seismic mainnet
 /// Calculated by rlp encoding the genesis header and hashing it.
 ///
@@ -164,6 +182,8 @@ pub static SEISMIC_MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
 mod tests {
     use crate::*;
     use alloy_consensus::constants::MAINNET_GENESIS_HASH;
+    use alloy_eips::eip7840::BlobParams;
+    use alloy_genesis::GenesisAccount;
     use alloy_primitives::address;
     use reth_chainspec::MAINNET;
     use reth_ethereum_forks::EthereumHardfork;
@@ -251,6 +271,33 @@ mod tests {
             SEISMIC_TESTNET.genesis.alloc.contains_key(&aes_lib),
             "running testnet genesis must remain immutable"
         );
+    }
+
+    #[test]
+    fn custom_genesis_preserves_config_derived_fields() {
+        let account = address!("0000000000000000000000000000000000000042");
+        let deposit_contract = address!("0000000000000000000000000000000000000043");
+        let mut genesis = Genesis::default();
+        genesis.config.chain_id = 12_345;
+        genesis
+            .alloc
+            .insert(account, GenesisAccount { balance: U256::from(42), ..Default::default() });
+        genesis.config.deposit_contract_address = Some(deposit_contract);
+        genesis.config.blob_schedule.insert("cancun".into(), BlobParams::prague());
+        let expected_blob_params = genesis.config.blob_schedule_blob_params();
+
+        let chain_spec = seismic_chain_spec_from_genesis(genesis);
+
+        assert_eq!(chain_spec.chain, Chain::from_id(12_345));
+        assert_eq!(chain_spec.genesis.alloc[&account].balance, U256::from(42));
+        assert_eq!(chain_spec.genesis.config.deposit_contract_address, Some(deposit_contract));
+        assert_eq!(
+            chain_spec.deposit_contract.map(|contract| contract.address),
+            Some(deposit_contract)
+        );
+        assert_eq!(chain_spec.blob_params, expected_blob_params);
+        assert!(chain_spec.hardforks.get(SeismicHardfork::Mercury).is_some());
+        assert!(chain_spec.hardforks.get(EthereumHardfork::Osaka).is_none());
     }
 
     #[test]

--- a/crates/seismic/cli/src/chainspec.rs
+++ b/crates/seismic/cli/src/chainspec.rs
@@ -1,6 +1,8 @@
 use reth_chainspec::ChainSpec;
 use reth_cli::chainspec::{parse_genesis, ChainSpecParser};
-use reth_seismic_chainspec::{SEISMIC_DEV, SEISMIC_MAINNET, SEISMIC_TESTNET};
+use reth_seismic_chainspec::{
+    seismic_chain_spec_from_genesis, SEISMIC_DEV, SEISMIC_MAINNET, SEISMIC_TESTNET,
+};
 use std::sync::Arc;
 
 /// Seismic chain specification parser.
@@ -27,18 +29,37 @@ pub fn chain_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::Error> 
         "dev" => SEISMIC_DEV.clone(),
         "testnet" => SEISMIC_TESTNET.clone(),
         "mainnet" => SEISMIC_MAINNET.clone(),
-        _ => Arc::new(parse_genesis(s)?.into()),
+        _ => Arc::new(seismic_chain_spec_from_genesis(parse_genesis(s)?)),
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_chainspec::EthereumHardforks;
 
     #[test]
     fn parse_known_chain_spec() {
         for &chain in SeismicChainSpecParser::SUPPORTED_CHAINS {
             assert!(<SeismicChainSpecParser as ChainSpecParser>::parse(chain).is_ok());
         }
+    }
+
+    #[test]
+    fn genesis_file_uses_canonical_seismic_spec() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../chainspec/res/genesis/dev.json");
+        let parsed = chain_value_parser(path).unwrap();
+
+        assert!(!SEISMIC_DEV.is_osaka_active_at_timestamp(0));
+        assert!(!parsed.is_osaka_active_at_timestamp(0));
+        assert_eq!(parsed.hardforks, SEISMIC_DEV.hardforks);
+        assert_eq!(parsed.genesis_hash(), SEISMIC_DEV.genesis_hash());
+        assert_eq!(parsed.genesis_timestamp(), SEISMIC_DEV.genesis_timestamp());
+        assert_eq!(
+            parsed.paris_block_and_final_difficulty,
+            SEISMIC_DEV.paris_block_and_final_difficulty
+        );
+        assert_eq!(parsed.chain, SEISMIC_DEV.chain);
+        assert_eq!(&parsed.genesis.alloc, &SEISMIC_DEV.genesis.alloc);
     }
 }

--- a/crates/seismic/cli/src/lib.rs
+++ b/crates/seismic/cli/src/lib.rs
@@ -307,9 +307,8 @@ mod test {
     #[test]
     fn genesis_hash_from_genesis_file() -> Result<(), clap::Error> {
         // Deploy passes a genesis *file* (`--chain reth-genesis.json`), while devs
-        // use the built-in `--chain dev`; both must agree on the hash. File parsing
-        // derives hardforks from the JSON config rather than SEISMIC_DEV_HARDFORKS,
-        // so this also fails if the two chain definitions drift apart.
+        // use the built-in `--chain dev`; both must agree on the hash and canonical
+        // Seismic hardfork schedule.
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../chainspec/res/genesis/dev.json");
         let cli = Cli::<SeismicChainSpecParser, NoArgs>::try_parse_from([
             "seismic-reth",


### PR DESCRIPTION
## Summary

- build file and inline genesis inputs with the canonical Seismic hardfork schedule
- preserve custom chain data and config-derived blob/deposit settings
- keep the raw genesis hash while normalizing the in-memory timestamp like the built-in specs

## Impact

Seismic's built-in specs stop at Prague and add Mercury, but the supported `--chain <genesis-file>` path previously converted the JSON with Ethereum's generic `ChainSpec::from(Genesis)`. The shipped and deploy-generated genesis files contain `osakaTime: 0`, so file-configured nodes activated Osaka while Seismic execution remained on Mercury.

The production txpool follows the parsed chain spec. As a result, it applied Osaka's per-transaction gas cap of `2^24` and rejected otherwise valid Mercury transactions between `16,777,217` gas and the configured 30,000,000 block gas limit. Deploy tooling uses this exact file-based `--chain` path.

## Root cause

`crates/seismic/cli/src/chainspec.rs` passed custom genesis inputs directly through the generic Ethereum conversion. That conversion correctly honors `osakaTime`, but it does not know about Seismic's authoritative hardfork schedule or Mercury.

## Reproduction

On base commit `39d04d158da383324b12c2e3397b0b28f3c3ee36`:

1. Parse `crates/seismic/chainspec/res/genesis/dev.json` through `chain_value_parser`.
2. Compare the result with `SEISMIC_DEV` at timestamp zero:
   - `SEISMIC_DEV.is_osaka_active_at_timestamp(0)` is `false`.
   - the file-parsed spec returns `true`.
3. Validate a funded legacy transaction with `gas_limit = MAX_TX_GAS_LIMIT_OSAKA + 1`:
   - the pre-Osaka validator accepts it;
   - the Osaka validator rejects it with `InvalidTransactionError::GasLimitTooHigh`.

The parser regression added here fails on the old conversion because the file spec activates Osaka and has a different hardfork schedule. It now verifies that the file and built-in forms agree on the schedule, genesis hash, normalized timestamp, Paris metadata, chain ID, and allocation.

## Fix

The new Seismic-local genesis constructor first derives the existing config-dependent fields, then installs the canonical Seismic schedule and Paris metadata and rebuilds the genesis header. It computes the sealed hash from the raw genesis before timestamp normalization, matching the built-in chain identity behavior.

This does not modify the genesis JSON files, enable Osaka, change Mercury execution, or alter upstream Ethereum genesis parsing.

## Validation

- `cargo test -p reth-seismic-chainspec`
- `cargo test -p reth-seismic-cli`
- `cargo test -p reth-seismic-chainspec --all-features`
- `cargo +nightly fmt --all -- --check`
- Seismic CI clippy command from `.github/workflows/seismic.yml`
- `git diff --check`
