### PR TITLE
feat(seismic): report signed_read via the 0x6A tx-context precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=db9fa992e33988d418ab036e4c5fd904183c9b52#db9fa992e33988d418ab036e4c5fd904183c9b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "alloy-seismic-evm"
 version = "0.20.1"
-source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=cfd769955988712649d96a749a5d82f65c540778#cfd769955988712649d96a749a5d82f65c540778"
+source = "git+https://github.com/SeismicSystems/seismic-evm.git?rev=db9fa992e33988d418ab036e4c5fd904183c9b52#db9fa992e33988d418ab036e4c5fd904183c9b52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2251,7 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2972,7 +2972,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4110,7 +4110,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4539,7 +4539,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5579,7 +5579,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6616,7 +6616,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "auto_impl",
  "either",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "auto_impl",
  "either",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10875,7 +10875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11327,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=4c29c001ca356a3ab32ce0e5da9e299199b3f2e6#4c29c001ca356a3ab32ce0e5da9e299199b3f2e6"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -11937,7 +11937,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4110,7 +4110,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4539,7 +4539,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5579,7 +5579,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6616,7 +6616,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10428,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "auto_impl",
  "either",
@@ -10513,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "auto_impl",
  "either",
@@ -10573,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",
@@ -10875,7 +10875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11327,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=6b1c2b447b8a356e9af1d8e5ed17797dd47784d2#6b1c2b447b8a356e9af1d8e5ed17797dd47784d2"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=f42b95084fb914fb68087f450a4e4ad7ef20d248#f42b95084fb914fb68087f450a4e4ad7ef20d248"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -11937,7 +11937,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,18 +769,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "f42b95084fb914fb68087f450a4e4ad7ef20d248" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,18 +769,18 @@ alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.gi
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "4c29c001ca356a3ab32ce0e5da9e299199b3f2e6" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-bytecode = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-database = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-state = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-primitives = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-interpreter = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-inspector = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-context = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-context-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+revm-database-interface = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+op-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "6b1c2b447b8a356e9af1d8e5ed17797dd47784d2" }
 
 revm-inspectors = { git = "https://github.com/SeismicSystems/seismic-revm-inspectors.git", rev = "31ce52dd54e30987cf558f2f6a246a02d8d63319" }
 
@@ -792,5 +792,5 @@ seismic-alloy-provider = { git = "https://github.com/SeismicSystems/seismic-allo
 seismic-alloy-genesis = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "b9d4260621a586a2292abf6d60e79cc9cc49e581" }
 
 # evm
-alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }
-alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "cfd769955988712649d96a749a5d82f65c540778" }
+alloy-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "db9fa992e33988d418ab036e4c5fd904183c9b52" }
+alloy-seismic-evm = { git = "https://github.com/SeismicSystems/seismic-evm.git", rev = "db9fa992e33988d418ab036e4c5fd904183c9b52" }

--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -987,6 +987,7 @@ mod tests {
             },
             tx_hash: Default::default(),
             decryption_failed: false,
+            signed_read: false,
         }
     }
 

--- a/crates/seismic/fuzz/src/tx_gen.rs
+++ b/crates/seismic/fuzz/src/tx_gen.rs
@@ -95,6 +95,7 @@ impl FuzzSeismicTx {
             },
             tx_hash: Default::default(),
             decryption_failed: false,
+            signed_read: false,
         }
     }
 

--- a/crates/seismic/fuzz/tests/flagged_storage.rs
+++ b/crates/seismic/fuzz/tests/flagged_storage.rs
@@ -41,6 +41,7 @@ fn call_tx(caller: Address, contract_addr: Address, gas_limit: u32) -> SeismicTr
         },
         tx_hash: Default::default(),
         decryption_failed: false,
+        signed_read: false,
     }
 }
 

--- a/crates/seismic/node/src/utils.rs
+++ b/crates/seismic/node/src/utils.rs
@@ -113,8 +113,9 @@ pub mod test_utils {
     pub use reth_seismic_primitives::test_utils::{
         client_decrypt, client_encrypt, get_ciphertext, get_client_io_sk, get_encryption_nonce,
         get_network_public_key, get_plaintext, get_seismic_elements, get_seismic_metadata,
-        get_seismic_tx, get_signed_seismic_tx, get_signed_seismic_tx_bytes,
-        get_signed_seismic_tx_encoding, get_signed_seismic_tx_typed_data, get_signing_private_key,
+        get_seismic_tx, get_signed_seismic_call_typed_data, get_signed_seismic_tx,
+        get_signed_seismic_tx_bytes, get_signed_seismic_tx_encoding,
+        get_signed_seismic_tx_typed_data, get_signing_private_key,
         get_unsigned_seismic_tx_request, get_unsigned_seismic_tx_typed_data, get_wrong_private_key,
         sign_seismic_tx, sign_tx,
     };

--- a/crates/seismic/node/tests/e2e/fixtures/README.md
+++ b/crates/seismic/node/tests/e2e/fixtures/README.md
@@ -2,8 +2,10 @@
 
 `TxTypeProbe.sol` is the source for the `TXTYPE_PROBE_DEPLOY` creation bytecode
 embedded in [`../txtype.rs`](../txtype.rs). It is stock Solidity: it reads the
-current transaction's EIP-2718 type byte from the `0x6A` tx-type precompile via
-`staticcall` — there is no compiler builtin and no `ssolc` change.
+current transaction's EIP-2718 type byte and its signed-read flag from the `0x6A`
+tx-context precompile via `staticcall` — there is no compiler builtin and no
+`ssolc` change. Empty input selects the tx type; a single `0x01` byte selects the
+signed-read flag.
 
 ## Reproducing the committed bytecode
 

--- a/crates/seismic/node/tests/e2e/fixtures/TxTypeProbe.sol
+++ b/crates/seismic/node/tests/e2e/fixtures/TxTypeProbe.sol
@@ -2,16 +2,26 @@
 pragma solidity ^0.8.0;
 
 // Source for the `TXTYPE_PROBE_DEPLOY` bytecode used by the e2e tests in
-// `../txtype.rs`. Stock Solidity — reads the EIP-2718 tx type from the 0x6A
-// tx-type precompile via `staticcall`, no compiler builtin. See `README.md`
-// for the exact compile command that reproduces the committed bytecode.
+// `../txtype.rs`. Stock Solidity — reads the EIP-2718 tx type and the
+// signed-read flag from the 0x6A tx-context precompile via `staticcall`, no
+// compiler builtin. See `README.md` for the exact compile command that
+// reproduces the committed bytecode.
 contract TxTypeProbe {
-    address constant TX_TYPE = address(0x6A);
+    address constant TX_CONTEXT = address(0x6A);
 
-    function _txType() private view returns (uint256 t) {
-        (bool ok, bytes memory ret) = TX_TYPE.staticcall("");
-        require(ok && ret.length == 32, "TX_INFO");
-        t = abi.decode(ret, (uint256));
+    // Empty input selects the tx type; a single 0x01 byte selects the signed-read flag.
+    function _read(bytes memory selector) private view returns (uint256 v) {
+        (bool ok, bytes memory ret) = TX_CONTEXT.staticcall(selector);
+        require(ok && ret.length == 32, "TX_CONTEXT");
+        v = abi.decode(ret, (uint256));
+    }
+
+    function _txType() private view returns (uint256) {
+        return _read("");
+    }
+
+    function _signedRead() private view returns (uint256) {
+        return _read(hex"01");
     }
 
     // isSeismic() [selector 02ce8088]: txType() == 0x4A as an abi bool.
@@ -22,5 +32,20 @@ contract TxTypeProbe {
     // requireSeismic() [selector c6d819f6]: reverts unless txType() == 0x4A.
     function requireSeismic() external view {
         require(_txType() == 0x4A);
+    }
+
+    // isSignedRead() [selector 28782220]: the signed-read flag as an abi bool.
+    function isSignedRead() external view returns (bool) {
+        return _signedRead() == 1;
+    }
+
+    // requireSignedRead() [selector 6cac1460]: reverts unless the signed-read flag is 1.
+    function requireSignedRead() external view {
+        require(_signedRead() == 1);
+    }
+
+    // requireNotSignedRead() [selector 2dfeb92e]: reverts unless the signed-read flag is 0.
+    function requireNotSignedRead() external view {
+        require(_signedRead() == 0);
     }
 }

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -1,10 +1,11 @@
 //! End-to-end coverage for tx-type RPC classification on the seismic node (precompile variant).
 //!
 //! The node must run an authenticated signed read as a Seismic tx (type 74) and a plain `eth_call`
-//! as standard. The probe reads the type via `staticcall` to the 0x6A tx-info precompile; its
-//! `requireSeismic()` reverts unless the type is 74, so success-vs-revert is a **74-specific**
-//! signal (no other type passes) that needs no response decryption and exercises the `eth_call`
-//! and `estimateGas` handlers directly (reth tags those two handlers independently).
+//! as standard, and must additionally report `signed_read` only for the former. The probe reads
+//! both fields via `staticcall` to the 0x6A tx-context precompile; its `require*()` entry points
+//! revert unless the field holds the expected value, so success-vs-revert is a **field-specific**
+//! signal that needs no response decryption and exercises the `eth_call` and `estimateGas`
+//! handlers directly (reth tags those two handlers independently).
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // Test file.
 
 use alloy_eips::eip2718::Encodable2718;
@@ -19,11 +20,14 @@ use reth_seismic_primitives::test_utils::sign_tx;
 use reth_seismic_rpc::ext::EthApiOverrideClient;
 use seismic_alloy_rpc_types::{SeismicCallRequest, SeismicTransactionRequest};
 
-// TxTypeProbe (stock solc): isSeismic() [02ce8088] / requireSeismic() [c6d819f6] read the tx type
-// by staticcall to the 0x6A tx-type precompile. Source + reproduce command: fixtures/TxTypeProbe.sol.
-const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b506103058061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c806302ce808814610038578063c6d819f614610056575b5f5ffd5b610040610060565b60405161004d9190610171565b60405180910390f35b61005e610071565b005b5f604a61006b610086565b14905090565b604a61007b610086565b14610084575f5ffd5b565b5f5f5f606a73ffffffffffffffffffffffffffffffffffffffff166040516100ad906101b7565b5f60405180830381855afa9150503d805f81146100e5576040519150601f19603f3d011682016040523d82523d5f602084013e6100ea565b606091505b50915091508180156100fd575060208151145b61013c576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040161013390610225565b60405180910390fd5b80806020019051810190610150919061027a565b9250505090565b5f8115159050919050565b61016b81610157565b82525050565b5f6020820190506101845f830184610162565b92915050565b5f81905092915050565b50565b5f6101a25f8361018a565b91506101ad82610194565b5f82019050919050565b5f6101c182610197565b9150819050919050565b5f82825260208201905092915050565b7f54585f494e464f000000000000000000000000000000000000000000000000005f82015250565b5f61020f6007836101cb565b915061021a826101db565b602082019050919050565b5f6020820190508181035f83015261023c81610203565b9050919050565b5f5ffd5b5f819050919050565b61025981610247565b8114610263575f5ffd5b50565b5f8151905061027481610250565b92915050565b5f6020828403121561028f5761028e610243565b5b5f61029c84828501610266565b9150509291505056fea26469706673582212204924f4189084c792361d86e18baf71dcadcfd5b6f8088b4caf833e2180d75aff64736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
+// TxTypeProbe (stock solc): reads the 0x6A tx-context precompile by staticcall — empty input for
+// the tx type (requireSeismic), a single 0x01 byte for the signed-read flag (requireSignedRead /
+// requireNotSignedRead). Source + reproduce command: fixtures/TxTypeProbe.sol.
+const TXTYPE_PROBE_DEPLOY: &str = "6080604052348015600e575f5ffd5b5061041e8061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610055575f3560e01c806302ce80881461005957806328782220146100775780632dfeb92e146100955780636cac14601461009f578063c6d819f6146100a9575b5f5ffd5b6100616100b3565b60405161006e9190610263565b60405180910390f35b61007f6100c4565b60405161008c9190610263565b60405180910390f35b61009d6100d5565b005b6100a76100e9565b005b6100b16100fe565b005b5f604a6100be610113565b14905090565b5f60016100cf610130565b14905090565b5f6100de610130565b146100e7575f5ffd5b565b60016100f3610130565b146100fc575f5ffd5b565b604a610108610113565b14610111575f5ffd5b565b5f61012b60405180602001604052805f815250610174565b905090565b5f61016f6040518060400160405280600181526020017f0100000000000000000000000000000000000000000000000000000000000000815250610174565b905090565b5f5f5f606a73ffffffffffffffffffffffffffffffffffffffff168460405161019d91906102ce565b5f60405180830381855afa9150503d805f81146101d5576040519150601f19603f3d011682016040523d82523d5f602084013e6101da565b606091505b50915091508180156101ed575060208151145b61022c576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016102239061033e565b60405180910390fd5b808060200190518101906102409190610393565b92505050919050565b5f8115159050919050565b61025d81610249565b82525050565b5f6020820190506102765f830184610254565b92915050565b5f81519050919050565b5f81905092915050565b8281835e5f83830152505050565b5f6102a88261027c565b6102b28185610286565b93506102c2818560208601610290565b80840191505092915050565b5f6102d9828461029e565b915081905092915050565b5f82825260208201905092915050565b7f54585f434f4e54455854000000000000000000000000000000000000000000005f82015250565b5f610328600a836102e4565b9150610333826102f4565b602082019050919050565b5f6020820190508181035f8301526103558161031c565b9050919050565b5f5ffd5b5f819050919050565b61037281610360565b811461037c575f5ffd5b50565b5f8151905061038d81610369565b92915050565b5f602082840312156103a8576103a761035c565b5b5f6103b58482850161037f565b9150509291505056fea2646970667358221220e56727fc82b547363957084e7329dccb37dde4880bce06d778cd62d7596e36d064736f6c63782c302e382e33312d646576656c6f702e323032362e372e32302b636f6d6d69742e66643566333839632e6d6f64005d";
 
 const REQUIRE_SEISMIC_SELECTOR: &str = "c6d819f6";
+const REQUIRE_SIGNED_READ_SELECTOR: &str = "6cac1460";
+const REQUIRE_NOT_SIGNED_READ_SELECTOR: &str = "2dfeb92e";
 
 /// Plain standard `SeismicTransactionRequest` (no signature, no seismic elements) to `contract`.
 fn plain_call(contract: alloy_primitives::Address, calldata: Bytes) -> SeismicTransactionRequest {
@@ -143,6 +147,130 @@ async fn test_txtype_estimate_gas_classifies_signed_read() {
         plain_res.is_err(),
         "plain estimateGas of requireSeismic() should revert (txtype()!=74), but it succeeded"
     );
+}
+
+/// `signed_read` must be set exactly on the authenticated read path, not merely on anything typed
+/// 74: `requireSignedRead()` succeeds for a signed `eth_call` and reverts for a plain one, and
+/// `requireNotSignedRead()` does the reverse. Both directions are asserted so the test fails if the
+/// flag is hardwired either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signed_read_flag_eth_call() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+
+    for (selector, signed_should_pass) in
+        [(REQUIRE_SIGNED_READ_SELECTOR, true), (REQUIRE_NOT_SIGNED_READ_SELECTOR, false)]
+    {
+        let recent = node.advance_block().await.unwrap().block().hash();
+        let calldata = Bytes::from_hex(selector).unwrap();
+
+        let signed = get_signed_seismic_tx_typed_data(
+            &signer,
+            1,
+            TxKind::Call(contract),
+            chain_id,
+            calldata.clone(),
+            recent,
+        )
+        .await;
+        let signed_res = EthApiOverrideClient::<Block>::call(
+            &client,
+            SeismicCallRequest::TypedData(signed),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            signed_res.is_ok(),
+            signed_should_pass,
+            "signed eth_call to {selector}: expected pass={signed_should_pass}, got {signed_res:?}"
+        );
+
+        let plain_res = EthApiOverrideClient::<Block>::call(
+            &client,
+            SeismicCallRequest::TransactionRequest(plain_call(contract, calldata)),
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            plain_res.is_ok(),
+            !signed_should_pass,
+            "plain eth_call to {selector}: expected pass={}, got {plain_res:?}",
+            !signed_should_pass
+        );
+    }
+}
+
+/// The `estimateGas` handler sets `signed_read` independently of `eth_call` (reth tags the two
+/// handlers separately), so it gets its own assertion in both directions.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_signed_read_flag_estimate_gas() {
+    reth_tracing::init_test_tracing();
+    ensure_mock_purpose_keys();
+
+    let (mut nodes, _tasks, wallet) = setup(1).await.unwrap();
+    let mut node = nodes.pop().unwrap();
+    let client = HttpClientBuilder::default().build(node.rpc_url()).unwrap();
+    let signer = wallet.inner.clone();
+    let from = signer.address();
+    let chain_id = wallet.chain_id;
+
+    let contract = deploy_probe(&client, &mut node, &signer, from, chain_id).await;
+
+    for (selector, signed_should_pass) in
+        [(REQUIRE_SIGNED_READ_SELECTOR, true), (REQUIRE_NOT_SIGNED_READ_SELECTOR, false)]
+    {
+        let recent = node.advance_block().await.unwrap().block().hash();
+        let calldata = Bytes::from_hex(selector).unwrap();
+
+        let signed = get_signed_seismic_tx_typed_data(
+            &signer,
+            1,
+            TxKind::Call(contract),
+            chain_id,
+            calldata.clone(),
+            recent,
+        )
+        .await;
+        let signed_res = EthApiOverrideClient::<Block>::estimate_gas(
+            &client,
+            SeismicCallRequest::TypedData(signed),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            signed_res.is_ok(),
+            signed_should_pass,
+            "signed estimateGas of {selector}: expected pass={signed_should_pass}, got {signed_res:?}"
+        );
+
+        let plain_res = EthApiOverrideClient::<Block>::estimate_gas(
+            &client,
+            SeismicCallRequest::TransactionRequest(plain_call(contract, calldata)),
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(
+            plain_res.is_ok(),
+            !signed_should_pass,
+            "plain estimateGas of {selector}: expected pass={}, got {plain_res:?}",
+            !signed_should_pass
+        );
+    }
 }
 
 /// Deploy the probe as a standard tx via the signer's account (nonce 0) and return its address.

--- a/crates/seismic/node/tests/e2e/txtype.rs
+++ b/crates/seismic/node/tests/e2e/txtype.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types::{Block, TransactionInput, TransactionRequest};
 use jsonrpsee::http_client::HttpClientBuilder;
 use reth_seismic_node::utils::{
     e2e::{ensure_mock_purpose_keys, setup},
-    test_utils::get_signed_seismic_tx_typed_data,
+    test_utils::get_signed_seismic_call_typed_data,
 };
 use reth_seismic_primitives::test_utils::sign_tx;
 use reth_seismic_rpc::ext::EthApiOverrideClient;
@@ -60,7 +60,7 @@ async fn test_txtype_eth_call_classifies_signed_read() {
     let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
 
     // Signed read -> txtype()==74 -> requireSeismic() succeeds.
-    let signed = get_signed_seismic_tx_typed_data(
+    let signed = get_signed_seismic_call_typed_data(
         &signer,
         1,
         TxKind::Call(contract),
@@ -115,7 +115,7 @@ async fn test_txtype_estimate_gas_classifies_signed_read() {
     let recent = node.advance_block().await.unwrap().block().hash();
     let selector = Bytes::from_hex(REQUIRE_SEISMIC_SELECTOR).unwrap();
 
-    let signed = get_signed_seismic_tx_typed_data(
+    let signed = get_signed_seismic_call_typed_data(
         &signer,
         1,
         TxKind::Call(contract),
@@ -173,7 +173,7 @@ async fn test_signed_read_flag_eth_call() {
         let recent = node.advance_block().await.unwrap().block().hash();
         let calldata = Bytes::from_hex(selector).unwrap();
 
-        let signed = get_signed_seismic_tx_typed_data(
+        let signed = get_signed_seismic_call_typed_data(
             &signer,
             1,
             TxKind::Call(contract),
@@ -235,7 +235,7 @@ async fn test_signed_read_flag_estimate_gas() {
         let recent = node.advance_block().await.unwrap().block().hash();
         let calldata = Bytes::from_hex(selector).unwrap();
 
-        let signed = get_signed_seismic_tx_typed_data(
+        let signed = get_signed_seismic_call_typed_data(
             &signer,
             1,
             TxKind::Call(contract),

--- a/crates/seismic/primitives/src/test_utils.rs
+++ b/crates/seismic/primitives/src/test_utils.rs
@@ -340,3 +340,34 @@ pub async fn get_signed_seismic_tx_typed_data(
         _ => panic!("Signed transaction is not a seismic transaction"),
     }
 }
+
+/// Like [`get_signed_seismic_tx_typed_data`] but marks the payload as an authenticated signed read
+/// (wire `signed_read = true`), as an `eth_call`/`estimateGas` signed read must carry. The flag is
+/// set in the metadata before encryption so the ciphertext's AAD matches.
+#[allow(clippy::panic)] // Test util function - panic on failure is acceptable
+pub async fn get_signed_seismic_call_typed_data(
+    sk_wallet: &PrivateKeySigner,
+    nonce: u64,
+    to: TxKind,
+    chain_id: u64,
+    plaintext: Bytes,
+    recent_block_hash: B256,
+) -> TypedDataRequest {
+    let mut plaintext_req = get_plaintext_tx_request(sk_wallet, nonce, to, chain_id, &plaintext);
+    let mut metadata = get_metadata(&plaintext_req, recent_block_hash);
+    metadata.seismic_elements.signed_read = true;
+    let ciphertext = metadata
+        .client_encrypt(&plaintext, &get_network_public_key(), &get_client_io_sk())
+        .unwrap();
+    plaintext_req.input = TransactionInput { input: Some(ciphertext), data: None };
+    let tx = SeismicTransactionRequest {
+        inner: plaintext_req,
+        seismic_elements: Some(metadata.seismic_elements),
+    };
+    let signed = sign_tx(sk_wallet.clone(), tx).await;
+
+    match signed {
+        SeismicTxEnvelope::Seismic(tx) => tx.into(),
+        _ => panic!("Signed transaction is not a seismic transaction"),
+    }
+}

--- a/crates/seismic/primitives/src/transaction/signed.rs
+++ b/crates/seismic/primitives/src/transaction/signed.rs
@@ -200,7 +200,7 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
             SeismicTypedTransaction::Eip7702(tx) => TxEnv::from_recovered_tx(tx, sender),
             SeismicTypedTransaction::Seismic(tx) => TxEnv::from_recovered_tx(tx, sender),
         };
-        let tx = Self { base, tx_hash, decryption_failed: false };
+        let tx = Self { base, tx_hash, decryption_failed: false, signed_read: false };
         tracing::debug!("from_recovered_tx: tx: {:?}", tx);
         tx
     }
@@ -209,7 +209,12 @@ impl FromRecoveredTx<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
 impl FromTxWithEncoded<SeismicTransactionSigned> for SeismicTransaction<TxEnv> {
     fn from_encoded_tx(tx: &SeismicTransactionSigned, sender: Address, _encoded: Bytes) -> Self {
         let tx_env = Self::from_recovered_tx(tx, sender);
-        Self { base: tx_env.base, tx_hash: tx_env.tx_hash, decryption_failed: false }
+        Self {
+            base: tx_env.base,
+            tx_hash: tx_env.tx_hash,
+            decryption_failed: false,
+            signed_read: false,
+        }
     }
 }
 

--- a/crates/seismic/rpc/src/eth/call.rs
+++ b/crates/seismic/rpc/src/eth/call.rs
@@ -222,7 +222,12 @@ where
 
         tracing::debug!("reth-seismic-rpc::eth create_txn_env {:?}", env);
 
-        Ok(SeismicTransaction { base: env, tx_hash: Default::default(), decryption_failed: false }
-            .into())
+        Ok(SeismicTransaction {
+            base: env,
+            tx_hash: Default::default(),
+            decryption_failed: false,
+            signed_read: tx_type == SEISMIC_TX_TYPE_ID,
+        }
+        .into())
     }
 }

--- a/crates/seismic/rpc/src/eth/utils.rs
+++ b/crates/seismic/rpc/src/eth/utils.rs
@@ -74,6 +74,7 @@ pub fn convert_seismic_call_to_tx_request(
             // Bound the calldata before the downstream ECDH/AES decrypt — same limit as the bytes
             // path, so the guard can't be bypassed by submitting via TypedData instead of Bytes.
             check_signed_read_input_size(req.inner.input.input().map_or(0, |b| b.len()))?;
+            ensure_wire_signed_read(&req)?;
             Ok((req, true))
         }
 
@@ -81,9 +82,23 @@ pub fn convert_seismic_call_to_tx_request(
             let tx = recover_raw_seismic_call_tx(&bytes)?;
             let mut req: SeismicTransactionRequest = tx.inner().clone().into();
             TransactionBuilder::<SeismicReth>::set_from(&mut req, tx.signer());
+            ensure_wire_signed_read(&req)?;
             Ok((req, true))
         }
     }
+}
+
+/// A signed Seismic call must carry a wire-level `signed_read = true`; a write-intent payload
+/// (`signed_read = false`) must not be classified and executed as a signed read.
+fn ensure_wire_signed_read(request: &SeismicTransactionRequest) -> Result<(), EthApiError> {
+    if !request.seismic_elements.as_ref().is_some_and(|e| e.signed_read) {
+        return Err(EthApiError::Other(Box::new(jsonrpsee_types::ErrorObject::owned(
+            -32602,
+            "signed Seismic call must set signed_read=true",
+            None::<String>,
+        ))));
+    }
+    Ok(())
 }
 
 /// Reject a signed read whose payload exceeds the configured size cap, before any of the unmetered
@@ -387,6 +402,72 @@ mod test {
         .unwrap();
         assert_eq!(signed_sighash, expected_sighash);
         assert_eq!(recovered_sighash, expected_sighash);
+    }
+
+    /// A validly-signed Seismic tx whose wire `signed_read` is false — a write-intent payload.
+    fn signed_write_intent() -> (TxSeismic, Signature) {
+        let r_bytes =
+            hex::decode("e93185920818650416b4b0cc953c48f59fd9a29af4b7e1c4b1ac4824392f9220")
+                .unwrap();
+        let s_bytes =
+            hex::decode("79b76b064a83d423997b7234c575588f60da5d3e1e0561eff9804eb04c23789a")
+                .unwrap();
+        let mut r_padded = [0u8; 32];
+        let mut s_padded = [0u8; 32];
+        r_padded[32 - r_bytes.len()..].copy_from_slice(&r_bytes);
+        s_padded[32 - s_bytes.len()..].copy_from_slice(&s_bytes);
+        let signature =
+            Signature::new(U256::from_be_bytes(r_padded), U256::from_be_bytes(s_padded), false);
+        let tx = TxSeismic {
+            chain_id: 5124,
+            nonce: 48,
+            gas_price: 360000,
+            gas_limit: 169477,
+            to: alloy_primitives::TxKind::Call(
+                Address::from_str("0x3aB946eEC2553114040dE82D2e18798a51cf1e14").unwrap(),
+            ),
+            value: U256::from_str("1000000000000000").unwrap(),
+            input: Bytes::from_str("0x4e69e56c3bb999b8c98772ebb32aebcbd43b33e9e65a46333dfe6636f37f3009e93bad334235aec73bd54d11410e64eb2cab4da8").unwrap(),
+            seismic_elements: TxSeismicElements {
+                encryption_pubkey: PublicKey::from_str("028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0").unwrap(),
+                encryption_nonce: U96::from_str("0x7da3a99bf0f90d56551d99ea").unwrap(),
+                message_version: 2,
+                recent_block_hash: alloy_primitives::B256::from_slice(&hex::decode("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef").unwrap()),
+                expires_at_block: 1000000,
+                signed_read: false,
+            },
+            authorization_list: vec![],
+        };
+        (tx, signature)
+    }
+
+    #[test]
+    fn convert_rejects_typed_data_write_intent() {
+        use crate::utils::convert_seismic_call_to_tx_request;
+        use seismic_alloy_rpc_types::SeismicCallRequest;
+        let (tx, signature) = signed_write_intent();
+        let req = TypedDataRequest { signature, data: tx.eip712_to_type_data() };
+        let err = convert_seismic_call_to_tx_request(SeismicCallRequest::TypedData(req))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("signed_read=true"), "{err}");
+    }
+
+    #[test]
+    fn convert_rejects_raw_bytes_write_intent() {
+        use crate::utils::convert_seismic_call_to_tx_request;
+        use alloy_eips::Encodable2718;
+        use seismic_alloy_rpc_types::SeismicCallRequest;
+        let (tx, signature) = signed_write_intent();
+        let signed = SeismicTransactionSigned::new_unhashed(
+            seismic_alloy_consensus::SeismicTypedTransaction::Seismic(tx),
+            signature,
+        );
+        let bytes = signed.encoded_2718();
+        let err = convert_seismic_call_to_tx_request(SeismicCallRequest::Bytes(bytes.into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("signed_read=true"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
Part of SEI-98, stacked on SEI-67 (`hbai__txtype-precompile`).

Plumbs the `signed_read` flag through the RPC/call path so the `0x6A` precompile reports it: an authenticated signed read returns 1, a plain call and a mined write return 0. Closes SEI-116.