### PR TITLE
fix(ci): gate rolling nightly tag on release success

### DIFF
--- a/.github/scripts/create-tag.js
+++ b/.github/scripts/create-tag.js
@@ -1,3 +1,7 @@
+function isReferenceAlreadyExistsError(err) {
+    return err.status === 422 && /Reference already exists/i.test(err.message);
+}
+
 module.exports = async ({ github, context }, tagName) => {
     try {
         await github.rest.git.createRef({
@@ -5,10 +9,24 @@ module.exports = async ({ github, context }, tagName) => {
             repo: context.repo.repo,
             ref: `refs/tags/${tagName}`,
             sha: context.sha,
-            force: true,
         });
     } catch (err) {
-        console.error(`Failed to create tag: ${tagName}`);
-        console.error(err);
+        if (!isReferenceAlreadyExistsError(err)) {
+            console.error(`Failed to create tag: ${tagName}`);
+            throw err;
+        }
+
+        const existingRef = await github.rest.git.getRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: `tags/${tagName}`,
+        });
+        const existingSha = existingRef.data.object.sha;
+
+        if (existingSha !== context.sha) {
+            throw new Error(
+                `Tag ${tagName} already exists at ${existingSha}, expected ${context.sha}`
+            );
+        }
     }
 };

--- a/.github/scripts/create-tag.test.js
+++ b/.github/scripts/create-tag.test.js
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const createTag = require('./create-tag.js');
+
+const context = {
+    repo: {
+        owner: 'SeismicSystems',
+        repo: 'seismic-reth',
+    },
+    sha: 'abc123',
+};
+
+function githubWithGit(overrides) {
+    return {
+        rest: {
+            git: {
+                createRef: async () => undefined,
+                getRef: async () => ({ data: { object: { sha: context.sha } } }),
+                ...overrides,
+            },
+        },
+    };
+}
+
+test('createTag creates a new ref for the requested tag', async () => {
+    const calls = [];
+    const github = githubWithGit({
+        createRef: async args => {
+            calls.push(args);
+        },
+    });
+
+    await createTag({ github, context }, 'nightly-abc123');
+
+    assert.deepEqual(calls, [
+        {
+            owner: 'SeismicSystems',
+            repo: 'seismic-reth',
+            ref: 'refs/tags/nightly-abc123',
+            sha: 'abc123',
+        },
+    ]);
+});
+
+test('createTag treats an existing same-SHA tag as idempotent', async () => {
+    let checkedRef;
+    const github = githubWithGit({
+        createRef: async () => {
+            const err = new Error('Reference already exists');
+            err.status = 422;
+            throw err;
+        },
+        getRef: async args => {
+            checkedRef = args.ref;
+            return { data: { object: { sha: context.sha } } };
+        },
+    });
+
+    await createTag({ github, context }, 'nightly-abc123');
+
+    assert.equal(checkedRef, 'tags/nightly-abc123');
+});
+
+test('createTag rejects an existing tag that points at another SHA', async () => {
+    const github = githubWithGit({
+        createRef: async () => {
+            const err = new Error('Reference already exists');
+            err.status = 422;
+            throw err;
+        },
+        getRef: async () => ({ data: { object: { sha: 'def456' } } }),
+    });
+
+    await assert.rejects(
+        createTag({ github, context }, 'nightly-abc123'),
+        /already exists at def456, expected abc123/
+    );
+});
+
+test('createTag propagates non-idempotent create failures', async () => {
+    const github = githubWithGit({
+        createRef: async () => {
+            const err = new Error('GitHub API unavailable');
+            err.status = 500;
+            throw err;
+        },
+    });
+
+    await assert.rejects(
+        createTag({ github, context }, 'nightly-abc123'),
+        /GitHub API unavailable/
+    );
+});
+
+test('createTag propagates non-existing-reference validation failures', async () => {
+    const github = githubWithGit({
+        createRef: async () => {
+            const err = new Error('Invalid sha');
+            err.status = 422;
+            throw err;
+        },
+    });
+
+    await assert.rejects(
+        createTag({ github, context }, 'nightly-abc123'),
+        /Invalid sha/
+    );
+});

--- a/.github/scripts/move-tag.js
+++ b/.github/scripts/move-tag.js
@@ -1,15 +1,9 @@
 module.exports = async ({ github, context }, tagName) => {
-    try {
-        await github.rest.git.updateRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: `tags/${tagName}`,
-            sha: context.sha,
-            force: true,
-        });
-    } catch (err) {
-        console.error(`Failed to move nightly tag.`);
-        console.error(`This should only happen the first time.`);
-        console.error(err);
-    }
+    await github.rest.git.updateRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: `tags/${tagName}`,
+        sha: context.sha,
+        force: true,
+    });
 };

--- a/.github/scripts/move-tag.test.js
+++ b/.github/scripts/move-tag.test.js
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const moveTag = require('./move-tag.js');
+
+const context = {
+    repo: {
+        owner: 'SeismicSystems',
+        repo: 'seismic-reth',
+    },
+    sha: 'abc123',
+};
+
+test('moveTag updates the requested tag to the workflow SHA', async () => {
+    const calls = [];
+    const github = {
+        rest: {
+            git: {
+                updateRef: async args => {
+                    calls.push(args);
+                },
+            },
+        },
+    };
+
+    await moveTag({ github, context }, 'nightly');
+
+    assert.deepEqual(calls, [
+        {
+            owner: 'SeismicSystems',
+            repo: 'seismic-reth',
+            ref: 'tags/nightly',
+            sha: 'abc123',
+            force: true,
+        },
+    ]);
+});
+
+test('moveTag propagates update failures', async () => {
+    const github = {
+        rest: {
+            git: {
+                updateRef: async () => {
+                    throw new Error('GitHub API unavailable');
+                },
+            },
+        },
+    };
+
+    await assert.rejects(
+        moveTag({ github, context }, 'nightly'),
+        /GitHub API unavailable/
+    );
+});

--- a/.github/scripts/seismic-release-workflow.test.js
+++ b/.github/scripts/seismic-release-workflow.test.js
@@ -1,0 +1,14 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const test = require('node:test');
+
+test('nightly tag move is gated on a successful release job', () => {
+    const workflowPath = resolve(__dirname, '../workflows/seismic-release.yml');
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    assert.match(
+        workflow,
+        /- name: Move nightly tag\n\s+if: \$\{\{ env\.IS_NIGHTLY == 'true' && needs\.release\.result == 'success' \}\}/
+    );
+});

--- a/.github/workflows/seismic-release.yml
+++ b/.github/workflows/seismic-release.yml
@@ -229,7 +229,7 @@ jobs:
 
       # Moves the `nightly` tag to `HEAD`
       - name: Move nightly tag
-        if: ${{ env.IS_NIGHTLY == 'true' }}
+        if: ${{ env.IS_NIGHTLY == 'true' && needs.release.result == 'success' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Fixes #490

This PR makes the rolling nightly tag reflect only successfully published nightly assets.

Previously, the cleanup job always ran after the release matrix, so `move-tag.js` could advance nightly even when the release job failed. The tag helper scripts also caught broad API failures without rethrowing, which could leave the workflow green while the tag stayed stale or inconsistent.

---

## Changes

- Gate the Move nightly tag step on `needs.release.result == 'success'`
- Keep repeated `nightly-<sha>` tag creation idempotent when the existing tag already points to the current workflow SHA
- Reject an existing `nightly-<sha>` tag if it points at a different SHA
- Propagate `createRef` / `updateRef` API failures instead of swallowing them
- Add `node:test` coverage for:
  - successful tag creation
  - same-SHA idempotency
  - mismatched existing tags
  - GitHub API failure propagation
  - rolling nightly workflow gating

---

## How to Test

```bash
node --test .github/scripts/create-tag.test.js .github/scripts/move-tag.test.js .github/scripts/seismic-release-workflow.test.js
node --check .github/scripts/create-tag.js
node --check .github/scripts/move-tag.js
node --check .github/scripts/create-tag.test.js
node --check .github/scripts/move-tag.test.js
node --check .github/scripts/seismic-release-workflow.test.js
```

**Not run:**
- `dprint check .github/workflows/seismic-release.yml` — dprint is not installed locally
- `actionlint .github/workflows/seismic-release.yml` — actionlint is not installed locally

---

## Checklist

- [x] Tests pass — full coverage for tag creation, idempotency, mismatch rejection, and failure propagation
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The gating condition only prevents the nightly tag from advancing on a failed release — it does not change behavior on success. Idempotency and mismatch-rejection logic are additive safety checks around existing tag operations. `dprint`/`actionlint` checks were not run locally due to tooling availability but the workflow YAML change is a single conditional gate.

**Type:** 🐛 Bug fix
**Fixes:** #490