### PR TITLE
disable eth_getProof

### DIFF
--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -441,10 +441,7 @@ where
                 // carry no encryption key).
                 modules.remove_method_from_configured("eth_callBundle");
 
-                // `eth_getProof` returns Merkle proofs whose leaves are the raw account and
-                // storage values — i.e. plaintext shielded storage, with no signed-read path to
-                // encrypt them. The proof *is* the answer, so there is nothing to sanitize; drop
-                // the method on every transport, including the JWT-protected engine port's copy.
+                // `eth_getProof` is disabled because of a security audits revealing that valid merkle proofs of public slots could make it easier to brute force the values of private slots in the same contract
                 modules.remove_method_from_configured("eth_getProof");
                 auth_module.remove_auth_method("eth_getProof");
 

--- a/crates/seismic/node/src/node.rs
+++ b/crates/seismic/node/src/node.rs
@@ -387,7 +387,7 @@ where
 
         self.inner
             .launch_add_ons_with(ctx, move |container| {
-                let RpcModuleContainer { modules, registry, .. } = container;
+                let RpcModuleContainer { modules, registry, auth_module, .. } = container;
                 modules.merge_if_module_configured(
                     RethRpcModule::Flashbots,
                     validation_api.into_rpc(),
@@ -440,6 +440,13 @@ where
                 // and its per-tx output cannot be uniformly encrypted (plain, non-seismic bundle txs
                 // carry no encryption key).
                 modules.remove_method_from_configured("eth_callBundle");
+
+                // `eth_getProof` returns Merkle proofs whose leaves are the raw account and
+                // storage values — i.e. plaintext shielded storage, with no signed-read path to
+                // encrypt them. The proof *is* the answer, so there is nothing to sanitize; drop
+                // the method on every transport, including the JWT-protected engine port's copy.
+                modules.remove_method_from_configured("eth_getProof");
+                auth_module.remove_auth_method("eth_getProof");
 
                 Ok(())
             })

--- a/crates/seismic/node/tests/e2e/integration.rs
+++ b/crates/seismic/node/tests/e2e/integration.rs
@@ -2274,6 +2274,34 @@ async fn test_call_bundle_disabled() -> eyre::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_proof_disabled() -> eyre::Result<()> {
+    let (_node, client, _chain_id, _wallet, _tasks) = setup_test_node().await?;
+
+    let result = client
+        .request::<serde_json::Value, _>(
+            "eth_getProof",
+            rpc_params![Address::ZERO, Vec::<B256>::new(), "latest"],
+        )
+        .await;
+    match result {
+        Err(jsonrpsee::core::client::Error::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                jsonrpsee::types::error::ErrorCode::MethodNotFound.code(),
+                "eth_getProof must be unregistered, got error: {err}"
+            );
+        }
+        other => panic!("eth_getProof must return method-not-found, got: {other:?}"),
+    }
+
+    // Control: a sibling Eth method we do not remove is still served.
+    let block_number: String = client.request("eth_blockNumber", rpc_params![]).await?;
+    assert!(block_number.starts_with("0x"), "unexpected eth_blockNumber response: {block_number}");
+
+    Ok(())
+}
+
 /// Get the latest block number via `eth_blockNumber`.
 async fn get_block_number(client: &jsonrpsee::http_client::HttpClient) -> u64 {
     let result: serde_json::Value =


### PR DESCRIPTION
Based on the audits and the potential that eth_getProof could make it so some private state could be brute forced this PR disables it to possibly be revisited at a later date