### PR TITLE
fix(seismic-evm): use excess_blob_gas instead of blob_gas_used in evm_env_for_payload

### DIFF
--- a/crates/seismic/evm/src/lib.rs
+++ b/crates/seismic/evm/src/lib.rs
@@ -267,8 +267,10 @@ impl ConfigureEngineEvm<ExecutionData> for SeismicEvmConfig {
 
         let blob_excess_gas_and_price = payload
             .payload
-            .blob_gas_used()
-            .map(|_gas| BlobExcessGasAndPrice::new_with_spec(0, spec_id.into_eth_spec()));
+            .excess_blob_gas()
+            .map(|excess_blob_gas| {
+                BlobExcessGasAndPrice::new_with_spec(excess_blob_gas, spec_id.into_eth_spec())
+            });
 
         let block_env = BlockEnv {
             number: U256::from(payload.payload.block_number()),


### PR DESCRIPTION
## Summary

`evm_env_for_payload` contained two compounding mistakes when building `blob_excess_gas_and_price`:

1. Called `.blob_gas_used()` instead of `.excess_blob_gas()` these are different fields: `blob_gas_used` is the per-block blob gas consumption; `excess_blob_gas` is the EIP-4844 running total that determines the next blob base fee.
2. The retrieved value was immediately discarded (`|_gas|`) and `0` was hardcoded, collapsing blob pricing to the minimum (1 wei) regardless of chain congestion.

The correct pattern was already used in `evm_env` one call-site away in the same file.

## Impact

Currently **dormant** Seismic does not yet process EIP-4844 blob transactions. However `evm_env_for_payload` is called during `engine_newPayload` re-execution, so this would silently miscompute blob base fees as soon as blob transactions are enabled.

## Changes

- `crates/seismic/evm/src/lib.rs`: replace `blob_gas_used()` + hardcoded `0` with `excess_blob_gas()` + actual value

Closes SeismicSystems/seismic-reth#496